### PR TITLE
Table method name cosistancy

### DIFF
--- a/docs/table.rst
+++ b/docs/table.rst
@@ -37,7 +37,7 @@ Adding Additional Columns
 -------------------------
 
 If you feel that you'd like to add several other columns to your table, you need to understand what type
-of columns they would be. 
+of columns they would be.
 
 If your column is designed to carry a value of any type, then it's much better to define it as a Model
 Field. A good example of this scenario is adding "total" column to list of your invoice lines that
@@ -86,7 +86,7 @@ but first we need to look at the generic column and understand it's base capabil
 A class resposnible for cell formatting. This class defines 3 main methods that is used by the Table
 when constructing HTML:
 
-.. php:method:: getHeaderCell(\atk4\data\Field $f)
+.. php:method:: getHeaderCellHTML(\atk4\data\Field $f)
 
 Must respond with HTML for the header cell (`<th>`) and an appropriate caption. If necessary
 will include "sorting" icons or any other controls that go in the header of the table.
@@ -94,15 +94,15 @@ will include "sorting" icons or any other controls that go in the header of the 
 The output of this field will automatically encode any values (such as caption), shorten them
 if necessary and localize them.
 
-.. php:method:: getTotalsCell(\atk4\data\Field $f, $value)
+.. php:method:: getTotalsCellHTML(\atk4\data\Field $f, $value)
 
 Provided with the field and the value, format the cell for the footer "totals" column. Table
 can rely on various strategies for calculating totals. See :php:meth:`Table::addTotals`.
 
-.. php:method:: getCellTemplate(\atk4\data\Field f)
+.. php:method:: getDataCellHTML(\atk4\data\Field f)
 
 Provided with a field, this method will respond with HTML **template**. In order to keep
-performance of Web Application at the maximum, Table will execute getCellTemplate for all the
+performance of Web Application at the maximum, Table will execute getDataCellHTML for all the
 fields once. When iterating, a combined template will be used to display the values.
 
 The template must not incorporate field values (simply because related model will not be
@@ -134,7 +134,7 @@ Advanced Column Denifitions
 .. php:class:: Table
 
 Table defines a method `columnFactory`, which returns Column object which is to be used to
-display values of specific model Field. 
+display values of specific model Field.
 
 .. php:method:: columnFactory(\atk4\data\Field $f)
 
@@ -165,8 +165,8 @@ it will automatically delete the record.
 
 You have probably noticed, that I have omitted the name for this column. If name is not specified
 (null) then the Column object will receive "null" when the call to
-:php:meth:`TableColumn\Generic::getHeaderCell`, :php:meth:`TableColumn\Generic::getTotalsCell` and 
-:php:meth:`TableColumn\Generic::getCellTemplate` will be made. The :php:class:`TableColumn\Generic` will
+:php:meth:`TableColumn\Generic::getHeaderCellHTML`, :php:meth:`TableColumn\Generic::getTotalsCellHTML` and
+:php:meth:`TableColumn\Generic::getDataCellHTML` will be made. The :php:class:`TableColumn\Generic` will
 not be able to cope with this situations, but many other column types are perfectly fine with this.
 
 Some column classes will be able to take some information from a specified column, but will work
@@ -211,7 +211,7 @@ your convenience there is a way to add multiple columns efficiently.
 As a final note in this section - you can re-use column objects multiple times::
 
     $c_gap = new \atk4\ui\TableColumn\Template('<td> ... <td>');
-    
+
     $table->addColumn($c_gap);
     $table->setModel(new Order($db), ['name', 'price', 'amount']);
     $table->addColumn($c_gap);
@@ -229,7 +229,7 @@ The tag will override model value. Here is example usage of :php:meth:`TableColu
 
 
     class ExpiredColumn extends \atk4\ui\TableColumn\Generic
-        public function getCellTemplate()
+        public function getDataCellHTML()
         {
             return '{$_expired}';
         }
@@ -276,7 +276,7 @@ virtually any API, Database or SQL resource and it will always take care of form
 as handle field types.
 
 I must also note that by simply adding 'Delete' column (as in example above) will allow your app users
-to delete files from dropbox or issues from GitHub. 
+to delete files from dropbox or issues from GitHub.
 
 Table follows a "universal data design" principles established by Agile UI to make it compatible with
 all the different data persitences. (see :php:ref:`universal_data_access`)
@@ -326,7 +326,7 @@ By default Table will include ID for each row: `<tr data-id="123">`. The followi
 demonstrates how various standard column types are relying on this property::
 
     $table->on('click', 'td', new jsExpression(
-        'document.location=page.php?id=[]', 
+        'document.location=page.php?id=[]',
         [(new jQuery())->closest('tr')->data('id')]
     ));
 
@@ -368,8 +368,8 @@ For setting an attribute you can use setAttr() method::
 
 Setting a new value to the attribute will override previous value.
 
-Please note that if you are redefining :php:meth:`TableColumn\Generic::getHeaderCell`, 
-:php:meth:`TableColumn\Generic::getTotalsCell` or :php:meth:`TableColumn\Generic::getCellTemplate`
+Please note that if you are redefining :php:meth:`TableColumn\Generic::getHeaderCellHTML`,
+:php:meth:`TableColumn\Generic::getTotalsCellHTML` or :php:meth:`TableColumn\Generic::getDataCellHTML`
 and you wish to preserve functionality of setting custom attributes and
 classes, you should generate your TD/TH tag through getTag method.
 
@@ -389,7 +389,7 @@ You can add column to a table that does not link with field::
 Using dynamic values
 --------------------
 
-Body attributes will be embedded into the template by the default :php:meth:`TableColumn\Generic::getCellTemplate`,
+Body attributes will be embedded into the template by the default :php:meth:`TableColumn\Generic::getDataCellHTML`,
 but if you specify attribute (or class) value as a tag, then it will be auto-filled
 with row value or injected HTML.
 
@@ -431,7 +431,7 @@ Status
 .. php:class:: TableColumn\Status
 
 Allow you to set highlight class and icon based on column value. This is most suitable for columns that
-contain pre-defined values. 
+contain pre-defined values.
 
 If your column "status" can be one of the following "pending", "declined", "archived" and "paid" and you would like
 to use different icons and colors to emphasise status::

--- a/src/Table.php
+++ b/src/Table.php
@@ -356,9 +356,9 @@ class Table extends Lister
             if (!is_int($name)) {
                 $field = $this->model->getElement($name);
 
-                $output[] = $column->getHeaderCell($field);
+                $output[] = $column->getHeaderCellHTML($field);
             } else {
-                $output[] = $column->getHeaderCell();
+                $output[] = $column->getHeaderCellHTML();
             }
         }
 
@@ -385,7 +385,7 @@ class Table extends Lister
             if (is_array($this->totals_plan[$name])) {
                 // todo - format
                 $field = $this->model->getElement($name);
-                $output[] = $column->getTotalsCell($field, $this->totals[$name]);
+                $output[] = $column->getTotalsCellHTML($field, $this->totals[$name]);
                 continue;
             }
 
@@ -414,9 +414,9 @@ class Table extends Lister
             if (!is_int($name)) {
                 $field = $this->model->getElement($name);
 
-                $output[] = $column->getCellTemplate($field);
+                $output[] = $column->getDataCellHTML($field);
             } else {
-                $output[] = $column->getCellTemplate();
+                $output[] = $column->getDataCellHTML();
             }
         }
 

--- a/src/Table.php
+++ b/src/Table.php
@@ -256,12 +256,12 @@ class Table extends Lister
 
         // Generate Header Row
         if ($this->header) {
-            $this->t_head->setHTML('cells', $this->renderHeaderCells());
+            $this->t_head->setHTML('cells', $this->getHeaderRowHTML());
             $this->template->setHTML('Head', $this->t_head->render());
         }
 
         // Generate template for data row
-        $this->t_row_master->setHTML('cells', $this->getRowTemplate());
+        $this->t_row_master->setHTML('cells', $this->getDataRowHTML());
         $this->t_row_master['_id'] = '{$_id}';
         $this->t_row = new Template($this->t_row_master->render());
         $this->t_row->app = $this->app;
@@ -311,7 +311,7 @@ class Table extends Lister
         if (!$rows) {
             $this->template->appendHTML('Body', $this->t_empty->render());
         } elseif ($this->totals_plan) {
-            $this->t_totals->setHTML('cells', $this->renderTotalsCells());
+            $this->t_totals->setHTML('cells', $this->getTotalsRowHTML());
             $this->template->appendHTML('Foot', $this->t_totals->render());
         } else {
         }
@@ -343,7 +343,7 @@ class Table extends Lister
      *
      * @return string
      */
-    public function renderHeaderCells()
+    public function getHeaderRowHTML()
     {
         $output = [];
         foreach ($this->columns as $name => $column) {
@@ -371,7 +371,7 @@ class Table extends Lister
      *
      * @return string
      */
-    public function renderTotalsCells()
+    public function getTotalsRowHTML()
     {
         $output = [];
         foreach ($this->columns as $name => $column) {
@@ -401,7 +401,7 @@ class Table extends Lister
      *
      * @return string
      */
-    public function getRowTemplate()
+    public function getDataRowHTML()
     {
         $output = [];
         foreach ($this->columns as $name => $column) {

--- a/src/TableColumn/Actions.php
+++ b/src/TableColumn/Actions.php
@@ -24,7 +24,7 @@ class Actions extends Generic
         $this->table->on('click', '.b_'.$name, $callback);
     }
 
-    public function getCellTemplate(\atk4\data\Field $f = null)
+    public function getDataCellHTML(\atk4\data\Field $f = null)
     {
         $output = '';
 

--- a/src/TableColumn/Checkbox.php
+++ b/src/TableColumn/Checkbox.php
@@ -28,17 +28,17 @@ class Checkbox extends Generic
         }
     }
 
-    public function getHeaderCell(\atk4\data\Field $f = null)
+    public function getHeaderCellHTML(\atk4\data\Field $f = null)
     {
         if (isset($f)) {
             throw new Exception(['Checkbox must be placed in an empty column. Don\'t specify any field.', 'field'=>$f]);
         }
         $this->table->js(true)->find('.'.$this->class)->checkbox();
 
-        return parent::getHeaderCell($f);
+        return parent::getHeaderCellHTML($f);
     }
 
-    public function getCellTemplate(\atk4\data\Field $f = null)
+    public function getDataCellHTML(\atk4\data\Field $f = null)
     {
         return $this->getTag('td', 'body', ['div', 'class'=>'ui checkbox '.$this->class, ['input', 'type'=>'checkbox']]);
     }

--- a/src/TableColumn/Generic.php
+++ b/src/TableColumn/Generic.php
@@ -103,7 +103,7 @@ class Generic
      *
      * @return string
      */
-    public function getHeaderCell(\atk4\data\Field $f = null)
+    public function getHeaderCellHTML(\atk4\data\Field $f = null)
     {
         if ($f === null) {
             return $this->getTag('th', 'head', '');
@@ -120,7 +120,7 @@ class Generic
      *
      * @return string
      */
-    public function getTotalsCell(\atk4\data\Field $f, $value)
+    public function getTotalsCellHTML(\atk4\data\Field $f, $value)
     {
         return $this->getTag('th', 'foot', $this->app->ui_persistence->typecastSaveField($f, $value));
     }
@@ -141,7 +141,7 @@ class Generic
      *
      * @return string
      */
-    public function getCellTemplate(\atk4\data\Field $f = null)
+    public function getDataCellHTML(\atk4\data\Field $f = null)
     {
         if ($f === null) {
             return $this->getTag('td', 'body', '{$c_'.$this->short_name.'}');

--- a/src/TableColumn/Link.php
+++ b/src/TableColumn/Link.php
@@ -31,7 +31,7 @@ class Link extends Generic
     /**
      * kill me now for this code :!!
      */
-    public function getCellTemplate(\atk4\data\Field $f = null)
+    public function getDataCellHTML(\atk4\data\Field $f = null)
     {
         if (is_null($f)) {
             $f = $this;

--- a/src/TableColumn/Money.php
+++ b/src/TableColumn/Money.php
@@ -11,7 +11,7 @@ class Money extends Generic
 
     public $attr = ['all'=>['class'=>['right aligned single line']]];
 
-    public function getCellTemplate(\atk4\data\Field $f = null)
+    public function getDataCellHTML(\atk4\data\Field $f = null)
     {
         if (!isset($f)) {
             throw new Exception(['Money column requires a field']);

--- a/src/TableColumn/Status.php
+++ b/src/TableColumn/Status.php
@@ -26,7 +26,7 @@ class Status extends Generic
         $this->states = $states;
     }
 
-    public function getCellTemplate(\atk4\data\Field $f = null)
+    public function getDataCellHTML(\atk4\data\Field $f = null)
     {
         if ($f === null) {
             throw new Exception(['Status can be used only with model field']);

--- a/src/TableColumn/Template.php
+++ b/src/TableColumn/Template.php
@@ -24,7 +24,7 @@ class Template extends Generic
         $this->template = $template;
     }
 
-    public function getCellTemplate(\atk4\data\Field $f = null)
+    public function getDataCellHTML(\atk4\data\Field $f = null)
     {
         return $this->getTag('td', 'body', $this->template);
     }

--- a/template/semantic-ui/html.html
+++ b/template/semantic-ui/html.html
@@ -7,7 +7,8 @@
     <script src="https://code.jquery.com/jquery-3.1.1.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-serialize-object/2.5.0/jquery.serialize-object.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.10/semantic.min.js"></script>
-    <script src="../js/lib/atk4JS.js"></script>
+    <!--<script src="../js/lib/atk4JS.js"></script>-->
+    <script src="http://ui.agiletoolkit.org/js/lib/atk4JS.js"></script>
     <script>
       $.fn.api.settings.successTest = function(response) {
         if(response && response.eval) {
@@ -19,7 +20,7 @@
         }
         return true;
       }
-      
+
       $.fn.api.settings.onFailure = function(response) {
           w=window.open(null,'Error in JSON response','height=1000,width=1100,location=no,menubar=no,scrollbars=yes,status=no,titlebar=no,toolbar=no');
           if(w){


### PR DESCRIPTION
stick with `get + <modifier> <object> <format>` naming

fixes #83 
```
[X] getHeaderCell -> getHeaderCellHTML
[X] getTotalsCell -> getTotalsCellHTML
[X] getCellTemplate -> getDataCellHTML
```

fixes #84 
```
[X] renderHeaderCells -> getHeaderRowHTML
[X] renderTotalsCells -> getTotalsRowHTML
[X] getRowTemplate -> getDataRowHTML
```
