### PR TITLE
Make reload atomic

### DIFF
--- a/js/src/plugins/reloadView.js
+++ b/js/src/plugins/reloadView.js
@@ -4,6 +4,13 @@ export default class reloadView {
     constructor(element, options) {
         const $element = $(element);
 
+        $element.spinner({
+            'loaderText': '',
+            'active': true,
+            'inline': true,
+            'centered': true,
+            'replace': true});
+
         if(options.uri) {
             $.get(options.uri, options.uri_options, (data) => {
                 $element.replaceWith(data);

--- a/src/jsReload.php
+++ b/src/jsReload.php
@@ -32,13 +32,6 @@ class jsReload implements jsExpressionable
     public function jsRender()
     {
         $final = (new jQuery($this->view))
-          ->spinner([
-            'loaderText' => '',
-            'active'     => true,
-            'inline'     => true,
-            'centered'   => true,
-            'replace'    => true,
-          ])
           ->reloadView(
           [
               'uri'         => $this->cb->getURL(),


### PR DESCRIPTION
Currently jsReload() contains 2 actions - replace content with spinner, then load new content and replace. This PR combines them into a single method call. This way if we pass some expression based on the content that is about to be reloaded, we won't loose it due to spinner.

``` php
$grid = $page->add('Grid');
$grid->menu->addItem('Complete Selected', new \atk4\ui\jsReload($grid->table, [
    'delete'=>$grid->addSelection()->jsChecked()
]));
var_dump($_GET);
```

jsChecked is cleared by spinner and passed as empty string into reloadView.
