### PR TITLE
Respect 'exit()' in callback

### DIFF
--- a/src/Callback.php
+++ b/src/Callback.php
@@ -70,13 +70,23 @@ class Callback
             if (isset($_POST[$this->name])) {
                 $this->triggered = $_POST[$this->name];
 
-                return call_user_func_array($callback, $args);
+                $t = $this->app->run_called;
+                $this->app->run_called = true;
+                $ret = call_user_func_array($callback, $args);
+                $this->app->run_called = $t;
+
+                return $ret;
             }
         } else {
             if (isset($_GET[$this->name])) {
                 $this->triggered = $_GET[$this->name];
 
-                return call_user_func_array($callback, $args);
+                $t = $this->app->run_called;
+                $this->app->run_called = true;
+                $ret = call_user_func_array($callback, $args);
+                $this->app->run_called = $t;
+
+                return $ret;
             }
         }
     }


### PR DESCRIPTION
The following code outputs the file but then still proceeds to execute $app->run(). If 'exit' is found inside a call-back we should respect that and don't try to output anything extra.

``` php
        $vp = $this->add('Callback');
        $vp->set(function() {
            highlight_file($_SERVER['SCRIPT_FILENAME']);
            exit;
        });
        $this->link($vp->getURL());
```