### PR TITLE
Issue #183/Fixed

### DIFF
--- a/js/src/plugin.js
+++ b/js/src/plugin.js
@@ -31,7 +31,7 @@ export default function plugin(pluginName, className, shortHand = false) {
             let data = $this.data(dataName);
             let options = $.extend({}, className.DEFAULTS, $this.data(), typeof option === 'object' && option);
 
-            if (!data) {
+            if (!data || $.isEmptyObject(data)) {
                 $this.data(dataName, (data = new className(this, options)));
             }
 

--- a/src/View.php
+++ b/src/View.php
@@ -958,12 +958,15 @@ class View implements jsExpressionable
 
         if (!$force_echo && $this->app && method_exists($this->app, 'jsReady')) {
             $this->app->jsReady($actions);
-
             return '';
         }
 
-        $ready = new jsFunction($actions);
+        // delegate $action rendering in hosting app if exist.
+        if ($this->app && method_exists($this->app, 'getViewJs')) {
+        	return $this->app->getViewJs($actions);
+        }
 
+	    $ready = new jsFunction($actions);
         return "<script>\n".
             (new jQuery($ready))->jsRender().
             '</script>';


### PR DESCRIPTION
When user press cancel on confirm dialog after clicking a table delete
button, the ajaxec plugin is returning an initialized but empty data
object. Therefore, simply testing for an initialized object will
prevent calling ajaxec . We now also check that condition in order to
be able to call ajaxec plugin on an empty object as well.