### PR TITLE
Implement nice validation error display

### DIFF
--- a/demos/button2.php
+++ b/demos/button2.php
@@ -42,3 +42,8 @@ $b = $layout->add(new Button('success'));
 $b->on('click', function ($b) {
     return 'success';
 });
+
+$b = $layout->add(new Button('failure'));
+$b->on('click', function ($b) {
+    throw new \atk4\data\ValidationException(['Everything is bad']);
+});

--- a/demos/init.php
+++ b/demos/init.php
@@ -4,10 +4,9 @@ date_default_timezone_set('UTC');
 
 require '../vendor/autoload.php';
 
-$app = new \atk4\ui\App([
-    'Agile UI v1.1 - Demo Suite',
-    'icon'=> 'user',
-]);
+$app = new \atk4\ui\App();
+
+$app->title = 'Agile UI - Demo Suite';
 
 if (file_exists('../public/atk4JS.min.js')) {
     $app->cdn['atk'] = '../public';

--- a/src/jsCallback.php
+++ b/src/jsCallback.php
@@ -95,7 +95,7 @@ class jsCallback extends Callback implements jsExpressionable
             } catch (\atk4\data\ValidationException $e) {
                 // Validation exceptions will be presented to user in a friendly way
 
-                $acitons = [];
+                $actions = [];
                 $actions[] = new jsExpression('alert([])', [$e->getMessage()]);
 
                 $ajaxec = implode(";\n", array_map(function (jsExpressionable $r) {

--- a/src/jsCallback.php
+++ b/src/jsCallback.php
@@ -105,7 +105,7 @@ class jsCallback extends Callback implements jsExpressionable
                 $m = new Message($e->getMessage());
                 $m->addClass('error');
 
-                $this->app->terminate(json_encode(['success'=>false, 'message'=>$m->getHTML(), 'eval'=>$ajaxec]));
+                $this->app->terminate(json_encode(['success'=>false, 'message'=>$m->getHTML()]));
             }
         });
     }

--- a/src/jsCallback.php
+++ b/src/jsCallback.php
@@ -53,44 +53,60 @@ class jsCallback extends Callback implements jsExpressionable
         }
 
         return parent::set(function () use ($callback) {
-            $chain = new jQuery(new jsExpression('this'));
+            try {
+                $chain = new jQuery(new jsExpression('this'));
 
-            $values = [];
-            foreach ($this->args as $key=>$value) {
-                $values[] = isset($_POST[$key]) ? $_POST[$key] : null;
-            }
-
-            $response = call_user_func_array($callback, array_merge([$chain], $values));
-
-            if ($response === $chain) {
-                $response = null;
-            }
-
-            $actions = [];
-
-            if ($chain->_chain) {
-                $actions[] = $chain;
-            }
-
-            $response = $this->flatternArray($response);
-
-            foreach ($response as $r) {
-                if (is_string($r)) {
-                    $actions[] = new jsExpression('alert([])', [$r]);
-                } elseif ($r instanceof jsExpressionable) {
-                    $actions[] = $r;
-                } elseif ($r === null) {
-                    continue;
-                } else {
-                    throw new Exception(['Incorrect callback. Must be string or action.', 'r'=>$r]);
+                $values = [];
+                foreach ($this->args as $key=>$value) {
+                    $values[] = isset($_POST[$key]) ? $_POST[$key] : null;
                 }
+
+                $response = call_user_func_array($callback, array_merge([$chain], $values));
+
+                if ($response === $chain) {
+                    $response = null;
+                }
+
+                $actions = [];
+
+                if ($chain->_chain) {
+                    $actions[] = $chain;
+                }
+
+                $response = $this->flatternArray($response);
+
+                foreach ($response as $r) {
+                    if (is_string($r)) {
+                        $actions[] = new jsExpression('alert([])', [$r]);
+                    } elseif ($r instanceof jsExpressionable) {
+                        $actions[] = $r;
+                    } elseif ($r === null) {
+                        continue;
+                    } else {
+                        throw new Exception(['Incorrect callback. Must be string or action.', 'r'=>$r]);
+                    }
+                }
+
+                $ajaxec = implode(";\n", array_map(function (jsExpressionable $r) {
+                    return $r->jsRender();
+                }, $actions));
+
+                $this->app->terminate(json_encode(['success'=>true, 'message'=>'Success', 'eval'=>$ajaxec]));
+            } catch (\atk4\data\ValidationException $e) {
+                // Validation exceptions will be presented to user in a friendly way
+
+                $acitons = [];
+                $actions[] = new jsExpression('alert([])', [$e->getMessage()]);
+
+                $ajaxec = implode(";\n", array_map(function (jsExpressionable $r) {
+                    return $r->jsRender();
+                }, $actions));
+
+                $m = new Message($e->getMessage());
+                $m->addClass('error');
+
+                $this->app->terminate(json_encode(['success'=>false, 'message'=>$m->getHTML(), 'eval'=>$ajaxec]));
             }
-
-            $ajaxec = implode(";\n", array_map(function (jsExpressionable $r) {
-                return $r->jsRender();
-            }, $actions));
-
-            $this->app->terminate(json_encode(['success'=>true, 'message'=>'Success', 'eval'=>$ajaxec]));
         });
     }
 }


### PR DESCRIPTION
Models now throw "ValidationError" when something is wrong with the data. That's not an applicaiton error, if it's left un-cached then the error should be properly presented to the user.

The form already does that by highlighting appropriate field with the error message, but the standard callback handlers based around jsCallback would show an ugly message.

This PR will display validation errors nicely, if developer didn't bother to take care of them.

Demo now have a [failure] button:

<img width="372" alt="screen shot 2017-07-04 at 12 29 20" src="https://user-images.githubusercontent.com/453929/27828536-902b70f8-60b4-11e7-8a5d-0bc99262ce79.png">

Click it to get this prompt:

<img width="963" alt="screen shot 2017-07-04 at 12 29 26" src="https://user-images.githubusercontent.com/453929/27828550-989915e2-60b4-11e7-9d2e-acb7d19725f8.png">

The responsible code is:

``` php
$b = $layout->add(new Button('failure'));
$b->on('click', function ($b) {
    throw new \atk4\data\ValidationException(['Everything is bad']);
});
```

