### PR TITLE
Fix/double spinner

### DIFF
--- a/js/src/plugins/reloadView.js
+++ b/js/src/plugins/reloadView.js
@@ -3,12 +3,12 @@ import atkPlugin from 'plugins/atkPlugin';
 export default class reloadView extends atkPlugin {
 
     main() {
-        const spinner = this.$el.atkSpinner({
-            'loaderText': '',
-            'active': true,
-            'inline': true,
-            'centered': true,
-            'replace': false});
+        // const spinner = this.$el.atkSpinner({
+        //     'loaderText': '',
+        //     'active': true,
+        //     'inline': true,
+        //     'centered': true,
+        //     'replace': false});
 
         if(this.settings.uri) {
             this.$el.api({
@@ -16,10 +16,10 @@ export default class reloadView extends atkPlugin {
                 url: this.settings.uri,
                 data: this.settings.uri_options,
                 method: 'GET',
-                obj: this.$el,
-                onComplete: function(response, content) {
-                    content.atkSpinner('remove');
-                }
+                obj: this.$el
+                // onComplete: function(response, content) {
+                //     content.atkSpinner('remove');
+                // }
             });
         }
     }

--- a/js/src/plugins/reloadView.js
+++ b/js/src/plugins/reloadView.js
@@ -3,12 +3,6 @@ import atkPlugin from 'plugins/atkPlugin';
 export default class reloadView extends atkPlugin {
 
     main() {
-        // const spinner = this.$el.atkSpinner({
-        //     'loaderText': '',
-        //     'active': true,
-        //     'inline': true,
-        //     'centered': true,
-        //     'replace': false});
 
         if(this.settings.uri) {
             this.$el.api({
@@ -17,9 +11,6 @@ export default class reloadView extends atkPlugin {
                 data: this.settings.uri_options,
                 method: 'GET',
                 obj: this.$el
-                // onComplete: function(response, content) {
-                //     content.atkSpinner('remove');
-                // }
             });
         }
     }

--- a/js/src/plugins/spinner.js
+++ b/js/src/plugins/spinner.js
@@ -4,6 +4,7 @@ import atkPlugin from 'plugins/atkPlugin';
 export default class spinner extends atkPlugin {
 
     main() {
+        this.timer;
         const options = this.settings;
         // Remove any existing dimmers/spinners
         this.$el.remove('.dimmer');
@@ -38,14 +39,14 @@ export default class spinner extends atkPlugin {
     }
 
     showSpinner($element, $spinner, replace = false) {
-        this.settings.timer = setTimeout(() => {
+        this.timer = setTimeout(() => {
             if(replace) $element.empty();
             $element.append($spinner);
         }, 500);
     }
 
     remove() {
-        clearTimeout(this.settings.timer);
+        clearTimeout(this.timer);
         this.$el.find('.loader').remove();
     }
 }
@@ -59,6 +60,5 @@ spinner.DEFAULTS = {
     loaderText: 'Loading',
     centered: false,
     baseDimmerMarkup: '<div class="ui dimmer"></div>',
-    baseLoaderMarkup: '<div class="ui loader"></div>',
-    timer: null,
+    baseLoaderMarkup: '<div class="ui loader"></div>'
 };

--- a/js/src/plugins/spinner.js
+++ b/js/src/plugins/spinner.js
@@ -38,13 +38,14 @@ export default class spinner extends atkPlugin {
     }
 
     showSpinner($element, $spinner, replace = false) {
-        if(replace) $element.empty();
-
-        $element
-            .append($spinner);
+        this.settings.timer = setTimeout(() => {
+            if(replace) $element.empty();
+            $element.append($spinner);
+        }, 500);
     }
 
     remove() {
+        clearTimeout(this.settings.timer);
         this.$el.find('.loader').remove();
     }
 }
@@ -59,4 +60,5 @@ spinner.DEFAULTS = {
     centered: false,
     baseDimmerMarkup: '<div class="ui dimmer"></div>',
     baseLoaderMarkup: '<div class="ui loader"></div>',
+    timer: null,
 };

--- a/js/src/services/ApiService.js
+++ b/js/src/services/ApiService.js
@@ -61,7 +61,7 @@ class ApiService {
                 }
                 //noinspection JSAnnotator
                 if (response && response.eval) {
-                    eval(`(function($) {${response.eval.replace(/<\/?script>/g, '')}})(jQuery);`);
+                    eval(response.eval.replace(/<\/?script>/g, ''));
                 }
             } else if (response.isServiceError) {
                 // service can still throw an error

--- a/js/src/services/ApiService.js
+++ b/js/src/services/ApiService.js
@@ -61,7 +61,7 @@ class ApiService {
      * Under certain circumstance, response.eval was run and execute prior to onSuccess eval,
      * thus causing some code to be running twice.
      * To avoid conflict, property name in response was change from eval to atkjs.
-     * Which mean response.atkjs now contains code to be eval. 
+     * Which mean response.atkjs now contains code to be eval.
      *
      * @param response
      * @param element

--- a/js/src/services/ApiService.js
+++ b/js/src/services/ApiService.js
@@ -11,11 +11,27 @@ class ApiService {
         return this.instance;
     }
 
+
     constructor() {
         if (!this.instance) {
             this.instance = this;
         }
         return this.instance;
+    }
+
+    /**
+     * Execute js code.
+     * This function should be call using .call() by
+     * passing proper context for 'this'.
+     * ex: apiService.evalResponse.call(this, code, jQuery)
+     * By passig the jQuery reference, $ var use by code that need to be eval
+     * will work just fine, even if $ is not assign globally.
+     *
+     * @param code //javascript to be eval.
+     * @param $  // reference to jQuery.
+     */
+    evalResponse(code, $) {
+        eval(code);
     }
 
 
@@ -41,10 +57,11 @@ class ApiService {
      * and allow us to properly eval the response.
      * Furthermore, the dom element responsible of the api call is returned if needed.
      *
-     * If need, some data are set in the element, inlude into the api call, prior to the call.
-     * This is the case for modal dialog that need to replace specific element content with html
-     * returned by the server without the proper id being set as usual.
-     * In case of modal, for example, the data 'isModal' is set to true and prior to be pass with the api call is set to true.
+     * Change in response object property from eval to atkjs.
+     * Under certain circumstance, response.eval was run and execute prior to onSuccess eval,
+     * thus causing some code to be running twice.
+     * To avoid conflict, property name in response was change from eval to atkjs.
+     * Which mean response.atkjs now contains code to be eval. 
      *
      * @param response
      * @param element
@@ -59,16 +76,16 @@ class ApiService {
                         throw({message:'Unable to replace element with id: '+ response.id});
                     }
                 }
-                //noinspection JSAnnotator
-                if (response && response.eval) {
-                    eval(response.eval.replace(/<\/?script>/g, ''));
+                if (response && response.atkjs) {
+                    // Call evalResponse with proper context, js code and jQuery as $ var.
+                    apiService.evalResponse.call(this, response.atkjs.replace(/<\/?script>/g, ''), jQuery);
                 }
             } else if (response.isServiceError) {
                 // service can still throw an error
                 throw ({message:response.message});
             }
         } catch (e) {
-            alert('Error in ajax replace or eval:\n' + e.message);
+            alert('Error in ajax replace or atkjs:\n' + e.message);
         }
     }
 
@@ -123,7 +140,6 @@ class ApiService {
         }
 
     }
-
 
     /**
      * Display App error in a semantic-ui modal.

--- a/src/View.php
+++ b/src/View.php
@@ -715,11 +715,11 @@ class View implements jsExpressionable
         try {
             $this->renderAll();
 
-            return json_encode(['success'=> true,
-                                'message'=> 'Success',
+            return json_encode(['success' => true,
+                                'message' => 'Success',
                                 'atkjs'   => $this->getJS($force_echo),
-                                'html'   => $this->template->render(),
-                                'id'     => $this->name, ]);
+                                'html'    => $this->template->render(),
+                                'id'      => $this->name, ]);
         } catch (\Exception $exception) {
             $l = $this->add(new self());
             if ($exception instanceof \atk4\core\Exception) {

--- a/src/View.php
+++ b/src/View.php
@@ -717,7 +717,7 @@ class View implements jsExpressionable
 
             return json_encode(['success'=> true,
                                 'message'=> 'Success',
-                                'eval'   => $this->getJS($force_echo),
+                                'atkjs'   => $this->getJS($force_echo),
                                 'html'   => $this->template->render(),
                                 'id'     => $this->name, ]);
         } catch (\Exception $exception) {

--- a/src/jsCallback.php
+++ b/src/jsCallback.php
@@ -91,7 +91,7 @@ class jsCallback extends Callback implements jsExpressionable
                     return $r->jsRender();
                 }, $actions));
 
-                $this->app->terminate(json_encode(['success'=>true, 'message'=>'Success', 'eval'=>$ajaxec]));
+                $this->app->terminate(json_encode(['success'=>true, 'message'=>'Success', 'atkjs'=>$ajaxec]));
             } catch (\atk4\data\ValidationException $e) {
                 // Validation exceptions will be presented to user in a friendly way
 


### PR DESCRIPTION
# Changes

## Server response property change
  Change response object property that hold javascript from eval to atkjs .
Using eval as property name was conflicting when in Wordpress environment causing the javascript
code to be run twice. Once prior to ApiService::onSucces() method and once in ApiService::onSuccess().

# JS fix

## Deleting CRUD record
Now properly eval code, even in a Wordpress environment.

## Double spinner
Remove spinner from reloadView plugin since, semantic api call already load one.

## Add timeout to spinner
Add a timeout function to spinner plugin.
