### PR TITLE
Fix/tab url

### DIFF
--- a/src/Tabs.php
+++ b/src/Tabs.php
@@ -33,6 +33,7 @@ class Tabs extends View
 
         // add tabs menu item
         $item = $this->add([$item, 'class'=>['item']], 'Menu');
+        $item->setElement('a');
         $item->setAttr('data-tab', $item->name);
 
         // add tabs sub-view


### PR DESCRIPTION
Fix Cursor when hovering on tab.

Tab menu item needs to be define as anchor element instead of div in order for semantic-ui.css to show pointer cursor over tab.