### PR TITLE
Feature/js notify

### DIFF
--- a/demos/notify.php
+++ b/demos/notify.php
@@ -83,10 +83,10 @@ $modal_form->set(function ($page) use ($modal_form) {
             $js_actions[0] = $modal_form->hide();
             $js_actions[1] = new \atk4\ui\jsNotify([
                 'position'       => 'topCenter',
-                'content'        => 'Thank you '.$f->model['name'],
+                'content'        => 'Thank you ' . $f->model['name'],
                 'openTransition' => 'jiggle',
             ]);
-            
+
             return $js_actions;
         }
     });

--- a/demos/notify.php
+++ b/demos/notify.php
@@ -83,7 +83,7 @@ $modal_form->set(function ($page) use ($modal_form) {
             $js_actions[0] = $modal_form->hide();
             $js_actions[1] = new \atk4\ui\jsNotify([
                 'position'       => 'topCenter',
-                'content'        => 'Thank you ' . $f->model['name'],
+                'content'        => 'Thank you '.$f->model['name'],
                 'openTransition' => 'jiggle',
             ]);
 

--- a/demos/notify.php
+++ b/demos/notify.php
@@ -48,7 +48,6 @@ $f_p2->addField('position', ['width'=>'four']);
 $f_p2->addField('attach', ['width'=>'four']);
 
 $form->onSubmit(function ($f) {
-
     $notifier = new \atk4\ui\jsNotify();
     $notifier->setColor($f->model['color'])
              ->setPosition($f->model['position'])
@@ -60,5 +59,6 @@ $form->onSubmit(function ($f) {
     if ($f->model['attach'] !== 'Body') {
         $notifier->attachTo($f);
     }
+
     return $notifier;
 });

--- a/demos/notify.php
+++ b/demos/notify.php
@@ -15,13 +15,13 @@ class Notifier extends \atk4\data\Model
 
         $this->addField('icon', ['default' => 'warning sign', 'caption' => 'Use semantic-ui icon name']);
 
-        $this->addField('type', ['enum' => ['green', 'red', 'orange', 'yellow', 'teal', 'blue','violet', 'purple', 'pink', 'brown'], 'default' => 'green', 'caption' => 'Select type:']);
+        $this->addField('color', ['enum' => ['green', 'red', 'orange', 'yellow', 'teal', 'blue','violet', 'purple', 'pink', 'brown'], 'default' => 'green', 'caption' => 'Select color:']);
 
-        $this->addField('transition', ['enum' => ['scale', 'fade', 'jiggle', 'flash'], 'default' => 'scale', 'caption' => 'Select transition:']);
+        $this->addField('transition', ['enum' => ['scale', 'fade', 'jiggle', 'flash'], 'default' => 'jiggle', 'caption' => 'Select transition:']);
 
-        $this->addField('width', ['enum' => ['25%', '50%', '75%', '100%'], 'default' => '100%', 'caption' => 'Select width:']);
+        $this->addField('width', ['enum' => ['25%', '50%', '75%', '100%'], 'default' => '25%', 'caption' => 'Select width:']);
 
-        $this->addField('position', ['enum' => ['topLeft', 'topCenter', 'topRight', 'bottomLeft', 'bottomCenter', 'bottomRight', 'center'], 'default' => 'topCenter', 'caption' => 'Select position:']);
+        $this->addField('position', ['enum' => ['topLeft', 'topCenter', 'topRight', 'bottomLeft', 'bottomCenter', 'bottomRight', 'center'], 'default' => 'topRight', 'caption' => 'Select position:']);
 
         $this->addField('attach', ['enum' => ['Body', 'Form'], 'default' => 'Body', 'caption' => 'Attach to:']);
     }
@@ -38,8 +38,8 @@ $f_p = $form->addGroup(['Set Text and Icon:']);
 $f_p->addField('text', ['width'=>'eight']);
 $f_p->addField('icon', ['width'=>'four']);
 
-$f_p1 = $form->addGroup(['Set Type, Transition and Width:']);
-$f_p1->addField('type', ['width'=>'four']);
+$f_p1 = $form->addGroup(['Set Color, Transition and Width:']);
+$f_p1->addField('color', ['width'=>'four']);
 $f_p1->addField('transition', ['width'=>'four']);
 $f_p1->addField('width', ['width'=>'four']);
 
@@ -48,20 +48,17 @@ $f_p2->addField('position', ['width'=>'four']);
 $f_p2->addField('attach', ['width'=>'four']);
 
 $form->onSubmit(function ($f) {
-    $options = [
-        'type'           => $f->model['type'],
-        'position'       => $f->model['position'],
-        'width'          => $f->model['width'],
-        'openTransition' => $f->model['transition'],
-        'icon'           => $f->model['icon'],
-        'content'        => $f->model['text'],
-    ];
 
-    if ($f->model['attach'] === 'Body') {
-        $chain = new \atk4\ui\jsChain();
-    } else {
-        $chain = $f->js();
+    $notifier = new \atk4\ui\jsNotify();
+    $notifier->setColor($f->model['color'])
+             ->setPosition($f->model['position'])
+             ->setWidth($f->model['width'])
+             ->setContent($f->model['text'])
+             ->setTransition($f->model['transition'])
+             ->setIcon($f->model['icon']);
+
+    if ($f->model['attach'] !== 'Body') {
+        $notifier->attachTo($f);
     }
-
-    return $chain->atkNotify($options);
+    return $notifier;
 });

--- a/demos/notify.php
+++ b/demos/notify.php
@@ -15,7 +15,7 @@ class Notifier extends \atk4\data\Model
 
         $this->addField('icon', ['default' => 'warning sign', 'caption' => 'Use semantic-ui icon name']);
 
-        $this->addField('color', ['enum' => ['green', 'red', 'orange', 'yellow', 'teal', 'blue','violet', 'purple', 'pink', 'brown'], 'default' => 'green', 'caption' => 'Select color:']);
+        $this->addField('color', ['enum' => ['green', 'red', 'orange', 'yellow', 'teal', 'blue', 'violet', 'purple', 'pink', 'brown'], 'default' => 'green', 'caption' => 'Select color:']);
 
         $this->addField('transition', ['enum' => ['scale', 'fade', 'jiggle', 'flash'], 'default' => 'jiggle', 'caption' => 'Select transition:']);
 

--- a/demos/notify.php
+++ b/demos/notify.php
@@ -15,7 +15,7 @@ class Notifier extends \atk4\data\Model
 
         $this->addField('icon', ['default' => 'warning sign', 'caption' => 'Use semantic-ui icon name']);
 
-        $this->addField('type', ['enum' => ['success', 'info', 'warning', 'error'], 'default' => 'success', 'caption' => 'Select type:']);
+        $this->addField('type', ['enum' => ['green', 'red', 'orange', 'yellow', 'teal', 'blue','violet', 'purple', 'pink', 'brown'], 'default' => 'green', 'caption' => 'Select type:']);
 
         $this->addField('transition', ['enum' => ['scale', 'fade', 'jiggle', 'flash'], 'default' => 'scale', 'caption' => 'Select transition:']);
 

--- a/demos/notify.php
+++ b/demos/notify.php
@@ -86,6 +86,7 @@ $modal_form->set(function ($page) use ($modal_form) {
                 'content'        => 'Thank you '.$f->model['name'],
                 'openTransition' => 'jiggle',
             ]);
+            
             return $js_actions;
         }
     });

--- a/demos/notify.php
+++ b/demos/notify.php
@@ -27,6 +27,7 @@ class Notifier extends \atk4\data\Model
     }
 }
 
+ /*** Notification type form ****/
 $head = $layout->add(['Header', 'Notification Types']);
 
 $form = $layout->add(new \atk4\ui\Form(['segment']));
@@ -51,7 +52,7 @@ $form->onSubmit(function ($f) {
     $notifier = new \atk4\ui\jsNotify();
     $notifier->setColor($f->model['color'])
              ->setPosition($f->model['position'])
-             ->setWidth($f->model['width'])
+             ->setWidth(rtrim($f->model['width'], '%'))
              ->setContent($f->model['text'])
              ->setTransition($f->model['transition'])
              ->setIcon($f->model['icon']);
@@ -62,3 +63,35 @@ $form->onSubmit(function ($f) {
 
     return $notifier;
 });
+
+/**** Notification in modal with form ***/
+
+$modal_form = $layout->add(['Modal', 'title'=>'Add a name']);
+
+$modal_form->set(function($page) use ($modal_form) {
+    $a = [];
+    $m = new \atk4\data\Model(new \atk4\data\Persistence_Array($a));
+    $m->addField('name', ['caption'=>'Add your name']);
+
+    $f = $page->add(new \atk4\ui\Form(['segment'=>true]));
+    $f->setModel($m);
+
+    $f->onSubmit(function ($f) use ($modal_form) {
+        if (empty($f->model['name'])) {
+            return $f->error('name', 'Please add a name!');
+        } else {
+            $js_actions[0] = $modal_form->hide();
+            $js_actions[1] = new \atk4\ui\jsNotify([
+                'position'=> 'topCenter',
+                'content' => 'Thank you '.$f->model['name'],
+                'openTransition' => 'jiggle',
+            ]);
+            return $js_actions;
+        }
+    });
+});
+
+//Bind display modal to page display button.
+$menu_bar = $layout->add(['View', 'ui'=>'buttons']);
+$b = $menu_bar->add('Button')->set('On Modal Close');
+$b->on('click', $modal_form->show());

--- a/demos/notify.php
+++ b/demos/notify.php
@@ -68,7 +68,7 @@ $form->onSubmit(function ($f) {
 
 $modal_form = $layout->add(['Modal', 'title'=>'Add a name']);
 
-$modal_form->set(function($page) use ($modal_form) {
+$modal_form->set(function ($page) use ($modal_form) {
     $a = [];
     $m = new \atk4\data\Model(new \atk4\data\Persistence_Array($a));
     $m->addField('name', ['caption'=>'Add your name']);
@@ -82,8 +82,8 @@ $modal_form->set(function($page) use ($modal_form) {
         } else {
             $js_actions[0] = $modal_form->hide();
             $js_actions[1] = new \atk4\ui\jsNotify([
-                'position'=> 'topCenter',
-                'content' => 'Thank you '.$f->model['name'],
+                'position'       => 'topCenter',
+                'content'        => 'Thank you '.$f->model['name'],
                 'openTransition' => 'jiggle',
             ]);
             return $js_actions;

--- a/js/src/plugins/notify.js
+++ b/js/src/plugins/notify.js
@@ -42,8 +42,8 @@ export default class notify extends atkPlugin {
      */
     getNotifier(options) {
       return `<div class="atk-notify"> 
-                <div class="ui ${options.type} ${options.size} message" style="overflow: auto; display: block !important">
-                    <i class="close icon"></i>
+                <div class="ui ${options.type} ${options.size} inverted segment" style="overflow: auto; display: block !important">
+                    <i class="close icon" style="float:right"></i>
                     <div class="content">
                         <i class="${options.icon} icon" style=""></i>
                         <span>${options.content}</span>
@@ -128,7 +128,7 @@ export default class notify extends atkPlugin {
 
 
 notify.DEFAULTS = {
-    type: 'success',
+    type: 'green',
     size: 'small',
     icon: null,
     content: null,

--- a/js/src/plugins/notify.js
+++ b/js/src/plugins/notify.js
@@ -42,7 +42,7 @@ export default class notify extends atkPlugin {
      */
     getNotifier(options) {
       return `<div class="atk-notify"> 
-                <div class="ui ${options.type} ${options.size} inverted segment" style="overflow: auto; display: block !important">
+                <div class="ui ${options.color} ${options.size} inverted segment" style="overflow: auto; display: block !important">
                     <i class="close icon" style="float:right"></i>
                     <div class="content">
                         <i class="${options.icon} icon" style=""></i>
@@ -128,7 +128,7 @@ export default class notify extends atkPlugin {
 
 
 notify.DEFAULTS = {
-    type: 'green',
+    color: 'green',
     size: 'small',
     icon: null,
     content: null,

--- a/js/src/plugins/notify.js
+++ b/js/src/plugins/notify.js
@@ -12,9 +12,14 @@ export default class notify extends atkPlugin {
     main() {
         let cssStyle;
         this.timer = null;
+        let domElement = 'body';
 
-        cssStyle = this.getClasses();
-        cssStyle.base.width = this.settings.width;
+        if (!$.isEmptyObject(this.$el[0])) {
+          domElement = this.$el;
+        }
+
+        cssStyle = this.getClasses(domElement);
+        cssStyle.base.width = this.settings.width + '%';
         cssStyle.base.opacity = this.settings.opacity;
 
         this.notify = $(this.getNotifier(this.settings)).hide();
@@ -22,17 +27,16 @@ export default class notify extends atkPlugin {
 
         this.notify.on('click', '.icon.close', {self:this}, this.removeNotifier);
 
-        let domElement = 'body';
-        if (!$.isEmptyObject(this.$el[0])) {
-            domElement = this.$el;
-        }
+
         this.notify.appendTo(domElement);
 
         this.notify.transition(this.settings.openTransition);
 
-        this.timer = setTimeout(() => {
+        if (this.settings.duration) {
+          this.timer = setTimeout(() => {
             this.removeNotifier({data:{self:this}});
-        }, this.settings.duration);
+          }, this.settings.duration);
+        }
     }
 
     /**
@@ -67,12 +71,13 @@ export default class notify extends atkPlugin {
     /**
      * Return basis css class use for this notification.
      *
+     * @param el
      * @returns {{base: {position: string, z-index: number}}}
      */
-    getClasses() {
+    getClasses(el) {
         return {
             base: {
-                position: 'absolute',
+                position: (el === 'body') ? 'fixed' : 'absolute',
                 'z-index': 9999
             }
         }
@@ -132,7 +137,7 @@ notify.DEFAULTS = {
     size: 'small',
     icon: null,
     content: null,
-    width: '100%',
+    width: 100,
     closeTransition: 'scale',
     openTransition: 'scale',
     duration: 3000,

--- a/src/CRUD.php
+++ b/src/CRUD.php
@@ -31,7 +31,7 @@ class CRUD extends Grid
      * letters.
      */
     public $ops = ['c'=>true, 'r'=>true, 'u'=>true, 'd'=>true];
-    
+
     public function init()
     {
         parent::init();

--- a/src/CRUD.php
+++ b/src/CRUD.php
@@ -23,6 +23,7 @@ class CRUD extends Grid
     public $fieldsCreate = null;
     public $formCreate = null;
     public $pageCreate = null;
+    public $notify = null;
 
     /**
      * Permitted operatios. You can add more of your own and you don't need to keep
@@ -30,7 +31,7 @@ class CRUD extends Grid
      * letters.
      */
     public $ops = ['c'=>true, 'r'=>true, 'u'=>true, 'd'=>true];
-
+    
     public function init()
     {
         parent::init();
@@ -53,6 +54,13 @@ class CRUD extends Grid
                 $this->itemCreate ?: ['Add new', 'icon'=>'plus'],
                 new jsModal('Add new', $this->pageCreate)
             );
+        }
+
+        if (!$this->notify) {
+            $this->notify = new jsNotify([
+                'content' => 'Data is saved!',
+                'color'   => 'green',
+            ]);
         }
     }
 
@@ -79,6 +87,7 @@ class CRUD extends Grid
                     return [
                         (new jQuery($this))->trigger('reload'),
                         new jsExpression('$(".atk-dialog-content").trigger("close")'),
+                        $this->notify,
                     ];
                 });
             });
@@ -98,6 +107,7 @@ class CRUD extends Grid
                     return [
                         (new jQuery($this))->trigger('reload'),
                         new jsExpression('$(".atk-dialog-content").trigger("close")'),
+                        $this->notify,
                     ];
                 });
             });

--- a/src/Modal.php
+++ b/src/Modal.php
@@ -93,6 +93,15 @@ class Modal extends View
     }
 
     /**
+     * Hide modal from page.
+     * @return mixed
+     */
+    public function hide()
+    {
+        return $this->js()->modal('hide');
+    }
+
+    /**
      * Set modal option.
      *
      * @param $option

--- a/src/Modal.php
+++ b/src/Modal.php
@@ -94,6 +94,7 @@ class Modal extends View
 
     /**
      * Hide modal from page.
+     * 
      * @return mixed
      */
     public function hide()

--- a/src/Modal.php
+++ b/src/Modal.php
@@ -94,7 +94,7 @@ class Modal extends View
 
     /**
      * Hide modal from page.
-     * 
+     *
      * @return mixed
      */
     public function hide()

--- a/src/jsNotify.php
+++ b/src/jsNotify.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace atk4\ui;
+
+/**
+ * Class jsNotify
+ * @package atk4\ui
+ */
+
+class jsNotify implements jsExpressionable
+{
+
+    public $options  = null;
+    public $attachTo = null;
+
+    public function __construct($options = null, $attachTo = null)
+    {
+        if ($options && is_array($options)) {
+            $this->setOptions($options);
+        }
+
+        if ($attachTo) {
+            $this->attachTo = $attachTo;
+        }
+
+    }
+
+    /**
+     * Set Notifier options using array.
+     *
+     * @param $options
+     *
+     * @return $this
+     */
+    public function setOptions($options)
+    {
+        $this->options = $options;
+        return $this;
+    }
+
+    /**
+     * Set notifier option by specifying option name.
+     * @param $option
+     * @param $value
+     *
+     * @return $this
+     */
+    public function setOption($option, $value)
+    {
+        $this->options[$option] = $value;
+        return $this;
+    }
+
+    /**
+     * Set notifier content.
+     * @param $content
+     *
+     * @return $this
+     */
+    public function setContent($content)
+    {
+        $this->setOption('content', $content);
+        return $this;
+    }
+
+    /**
+     * Set notifier color.
+     *  - any colors define in semantic-ui can be used.
+     * @param $color
+     *
+     * @return $this
+     */
+    public function setColor($color)
+    {
+        $this->setOption('color', $color);
+        return $this;
+    }
+
+    /**
+     * Add an icon to the notifier.
+     * @param $icon
+     *
+     * @return $this
+     */
+    public function setIcon($icon)
+    {
+        $this->setOption('icon', $icon);
+        return $this;
+    }
+
+    /**
+     * Set open and close transition for the notifier.
+     *   - any transition define in semantic ui can be used.
+     * @param $openTransition
+     * @param null $closeTransition
+     *
+     * @return $this
+     */
+    public function setTransition($openTransition, $closeTransition = null)
+    {
+        $this->setOption('openTransition', $openTransition);
+
+        if ($closeTransition) {
+            $this->setOption('closeTransition', $closeTransition);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Set open duration in millisecond.
+     * @param $duration : interger
+     *
+     * @return $this
+     */
+    public function setDuration($duration)
+    {
+        $this->setOption('duration', $duration);
+        return $this;
+    }
+
+    /**
+     * Set notifier position within the body of the page or within the attach element.
+     *
+     * @param $position
+     *
+     * @return $this
+     */
+    public function setPosition($position)
+    {
+        $this->setOption('position', $position);
+        return $this;
+    }
+
+    /**
+     * Set the width percentage of the notifier within the body or attached to element.
+     * @param $width: integer
+     *
+     * @return $this
+     */
+    public function setWidth($width)
+    {
+        $this->setOption('width', $width);
+        return $this;
+    }
+
+    /**
+     * Set the opacity of the notifier.
+     * @param $opacity : range from 0 to 1
+     *
+     * @return $this
+     */
+    public function setOpacity($opacity)
+    {
+        $this->setOption('opacity', $opacity);
+        return $this;
+    }
+
+    /**
+     * Attach this notifier to a view object.
+     *  - position and width of notifier will be relative to this view object.
+     *
+     * note: notifier is attach to 'body' element by default.
+     *
+     * @param $to
+     *
+     * @throws Exception
+     */
+    public function attachTo($to)
+    {
+        if (!$to instanceof View) {
+            throw new Exception('You need to attach notifier to a view!');
+        }
+
+        $this->attachTo = $to;
+    }
+
+
+    /**
+     * Render the notifier.
+     * @return string
+     */
+    public function jsRender()
+    {
+        if ($this->attachTo) {
+            $final = $this->attachTo->js();
+        } else {
+            $final = new jsChain();
+        }
+
+        $final->atkNotify($this->options);
+
+        return $final->jsRender();
+    }
+}

--- a/src/jsNotify.php
+++ b/src/jsNotify.php
@@ -4,13 +4,11 @@ namespace atk4\ui;
 
 /**
  * Class jsNotify
- * @package atk4\ui
  */
-
 class jsNotify implements jsExpressionable
 {
 
-    public $options  = null;
+    public $options = null;
     public $attachTo = null;
 
     public function __construct($options = null, $attachTo = null)
@@ -40,6 +38,7 @@ class jsNotify implements jsExpressionable
 
     /**
      * Set notifier option by specifying option name.
+     *
      * @param $option
      * @param $value
      *
@@ -48,11 +47,13 @@ class jsNotify implements jsExpressionable
     public function setOption($option, $value)
     {
         $this->options[$option] = $value;
+
         return $this;
     }
 
     /**
      * Set notifier content.
+     *
      * @param $content
      *
      * @return $this
@@ -60,12 +61,14 @@ class jsNotify implements jsExpressionable
     public function setContent($content)
     {
         $this->setOption('content', $content);
+
         return $this;
     }
 
     /**
      * Set notifier color.
      *  - any colors define in semantic-ui can be used.
+     *
      * @param $color
      *
      * @return $this
@@ -73,11 +76,13 @@ class jsNotify implements jsExpressionable
     public function setColor($color)
     {
         $this->setOption('color', $color);
+
         return $this;
     }
 
     /**
      * Add an icon to the notifier.
+     *
      * @param $icon
      *
      * @return $this
@@ -85,12 +90,14 @@ class jsNotify implements jsExpressionable
     public function setIcon($icon)
     {
         $this->setOption('icon', $icon);
+
         return $this;
     }
 
     /**
      * Set open and close transition for the notifier.
      *   - any transition define in semantic ui can be used.
+     *
      * @param $openTransition
      * @param null $closeTransition
      *
@@ -109,6 +116,7 @@ class jsNotify implements jsExpressionable
 
     /**
      * Set open duration in millisecond.
+     *
      * @param $duration : interger
      *
      * @return $this
@@ -116,6 +124,7 @@ class jsNotify implements jsExpressionable
     public function setDuration($duration)
     {
         $this->setOption('duration', $duration);
+
         return $this;
     }
 
@@ -129,11 +138,13 @@ class jsNotify implements jsExpressionable
     public function setPosition($position)
     {
         $this->setOption('position', $position);
+
         return $this;
     }
 
     /**
      * Set the width percentage of the notifier within the body or attached to element.
+     *
      * @param $width: integer
      *
      * @return $this
@@ -141,11 +152,13 @@ class jsNotify implements jsExpressionable
     public function setWidth($width)
     {
         $this->setOption('width', $width);
+
         return $this;
     }
 
     /**
      * Set the opacity of the notifier.
+     *
      * @param $opacity : range from 0 to 1
      *
      * @return $this
@@ -153,6 +166,7 @@ class jsNotify implements jsExpressionable
     public function setOpacity($opacity)
     {
         $this->setOption('opacity', $opacity);
+
         return $this;
     }
 
@@ -165,6 +179,8 @@ class jsNotify implements jsExpressionable
      * @param $to
      *
      * @throws Exception
+     *
+     * @return $this
      */
     public function attachTo($to)
     {
@@ -173,11 +189,14 @@ class jsNotify implements jsExpressionable
         }
 
         $this->attachTo = $to;
+
+        return $this;
     }
 
 
     /**
      * Render the notifier.
+     *
      * @return string
      */
     public function jsRender()

--- a/src/jsNotify.php
+++ b/src/jsNotify.php
@@ -3,11 +3,10 @@
 namespace atk4\ui;
 
 /**
- * Class jsNotify
+ * Class jsNotify.
  */
 class jsNotify implements jsExpressionable
 {
-
     public $options = null;
     public $attachTo = null;
 
@@ -20,7 +19,6 @@ class jsNotify implements jsExpressionable
         if ($attachTo) {
             $this->attachTo = $attachTo;
         }
-
     }
 
     /**
@@ -33,6 +31,7 @@ class jsNotify implements jsExpressionable
     public function setOptions($options)
     {
         $this->options = $options;
+
         return $this;
     }
 
@@ -193,7 +192,6 @@ class jsNotify implements jsExpressionable
         return $this;
     }
 
-
     /**
      * Render the notifier.
      *
@@ -211,4 +209,5 @@ class jsNotify implements jsExpressionable
 
         return $final->jsRender();
     }
+
 }

--- a/src/jsNotify.php
+++ b/src/jsNotify.php
@@ -115,6 +115,8 @@ class jsNotify implements jsExpressionable
 
     /**
      * Set open duration in millisecond.
+     *  - if you set duration to 0, then notification
+     *    will stay forever until close by user.
      *
      * @param $duration : interger
      *

--- a/src/jsNotify.php
+++ b/src/jsNotify.php
@@ -209,5 +209,4 @@ class jsNotify implements jsExpressionable
 
         return $final->jsRender();
     }
-
 }

--- a/tests/DemoTest.php
+++ b/tests/DemoTest.php
@@ -63,6 +63,7 @@ class DemoTest extends \atk4\core\PHPUnit_AgileTestCase
             ['modal.php'],
             ['sticky.php'],
             ['recursive.php'],
+            ['notify.php'],
         ];
     }
 


### PR DESCRIPTION
## New jsNotify Class

Notifier can now be set using 

```
new jsNotify($options, $viewToAttach);
```
You may also set options one by one using one of the various setOptionName function.

## notify.php demo file

Improve readability of notify.php demo file by setting each option individually.

## Color

Notifier now use one of the semantic ui define color for background, which make them more visible.

#### Note: Since notify.js plugin has change, atk4JS.min.js need to be rebuild.