### PR TITLE
Fix/js sse on non supporting browser

### DIFF
--- a/demos/sse.php
+++ b/demos/sse.php
@@ -2,31 +2,17 @@
 
 require 'init.php';
 
+$btn1 = $app->add('Button')->set('start');
+$btn2 = $app->add('Button')->set('start');
 
-//$vp = $app->add('VirtualPage');
-//
-//$vp->set(function($p){
-//    $p->add(['Message', 'Message'])->text->addParagraph('youhoy');
-//});
-
-$sse = $app->add('SSE'/*new atk4\ui\SSE()*/);
-//$sse->set(function ($p){
-//   $p->add('View')->set('allo');
-//});
-
-$msg = $app->add(['Message', 'Message'])->text->addParagraph('Time is: ' . time());
-
-$sse->addViewEventHandler($msg, function($msg) {
-   $msg->text->addParagraph('Time is: ');
+$sse1 = $btn1->add('SSE')->set(function () use ($btn1) {
+    $btn1->set((string)rand(1, 100));
 });
-$t = 't';
 
-// SSE is a virtual page like and does not output anything
-// SSE::update('eventType', 'event', eventAction = null);
-//      when updating need a way to check if event needs update
-//          probably via timestamps or header check.
-// SSE defaults should be settable, like time to reconnect etc.
-// SSE eventType: jsAction, htmlRender
-// SSE event: the view to act on
-// SSE eventAction: append, replace etc...
-//      Perhaps should output view-id.
+$btn1->on('click', $sse1->run());
+
+$sse2 = $btn2->add('SSE')->set(function () use ($btn2) {
+    $btn2->set((string)rand(1, 100));
+});
+
+$btn2->on('click', $sse2->run());

--- a/demos/sse.php
+++ b/demos/sse.php
@@ -2,21 +2,6 @@
 
 require 'init.php';
 
-$btn1 = $app->add('Button')->set('start');
-$btn2 = $app->add('Button')->set('start');
-
-$sse1 = $btn1->add('SSE')->set(function () use ($btn1) {
-    $btn1->set((string) rand(1, 100));
-});
-
-$btn1->on('click', $sse1->run());
-
-$sse2 = $btn2->add('SSE')->set(function () use ($btn2) {
-    $btn2->set((string) rand(1, 100));
-});
-
-$btn2->on('click', $sse2->run());
-
 $app->add(['ui' => 'divider']);
 
 $bar = $app->add(['View', 'template' => new \atk4\ui\Template('<div id="{$_id}" class="ui teal progress">
@@ -32,9 +17,13 @@ $button = $app->add(['Button', 'Turn On']);
 $sse = $app->add('jsSSE');
 
 $button->on('click', $sse->set(function () use ($sse, $bar) {
-    $sse->send($bar->js()->progress(['percent' => 33]));
+    $sse->send($bar->js()->progress(['percent' => 20]));
+    sleep(0.5);
+    $sse->send($bar->js()->progress(['percent' => 40]));
     sleep(1);
-    $sse->send($bar->js()->progress(['percent' => 66]));
+    $sse->send($bar->js()->progress(['percent' => 60]));
+    sleep(2);
+    $sse->send($bar->js()->progress(['percent' => 80]));
     sleep(1);
 
     // non-SSE way

--- a/demos/sse.php
+++ b/demos/sse.php
@@ -2,9 +2,23 @@
 
 require 'init.php';
 
-$v = $app->add('View')->set('allo');
-$sse = $app->add('SSE'/*new atk4\ui\SSE()*/);
 
+//$vp = $app->add('VirtualPage');
+//
+//$vp->set(function($p){
+//    $p->add(['Message', 'Message'])->text->addParagraph('youhoy');
+//});
+
+$sse = $app->add('SSE'/*new atk4\ui\SSE()*/);
+//$sse->set(function ($p){
+//   $p->add('View')->set('allo');
+//});
+
+$msg = $app->add(['Message', 'Message'])->text->addParagraph('Time is: ' . time());
+
+$sse->addViewEventHandler($msg, function($msg) {
+   $msg->text->addParagraph('Time is: ');
+});
 $t = 't';
 
 // SSE is a virtual page like and does not output anything

--- a/demos/sse.php
+++ b/demos/sse.php
@@ -14,7 +14,7 @@ $button = $app->add(['Button', 'Turn On']);
 // non-SSE way
 //$button->on('click', $bar->js()->progress(['percent'=> 40]));
 
-$sse = $app->add('jsSSE');
+$sse = $app->add(['jsSSE', 'showLoader' => true]);
 
 $button->on('click', $sse->set(function () use ($sse, $bar) {
     $sse->send($bar->js()->progress(['percent' => 20]));

--- a/docs/js.rst
+++ b/docs/js.rst
@@ -557,3 +557,64 @@ other view::
     $t->setModel($m_book);
 
 In this example, filling out and submitting the form will result in table contents being refreshed using AJAX.
+
+
+Background Tasks
+================
+
+Agile UI has addressed one of the big shortcoming with the PHP language - ability to execute running / background
+processes. It's best illustrated with example. 
+
+Say you need to process a large image, resize, find face, watermark, create thumbnails and store externally. For
+the average image this could take 5-10 seconds, so you'd like to user updated about the process. There are
+various ways to do so.
+
+The most basic approach you could probably figure out already::
+
+    $button = $app->add(['Button', 'Process the image']);
+    $button->on('click', function() use($button, $image) {
+
+        sleep(1); // $image->resize();
+        sleep(1); // $image->findFace();
+        sleep(1); // $image->watermark();
+        sleep(1); // $image->createThumbnails();
+
+        return $button->js()->text('Success')->addClass('disabled');
+
+    });
+
+However, it would be nice if you could communicate to the user the progress of your process:
+
+
+Server Side Event (jsSSE)
+-------------------------
+
+.. php:class:: jsSSE
+
+.. php:method:: send(action)
+
+This class implements ability for your PHP code to send messages to the browser in the middle of the process
+execution::
+
+    $button = $app->add(['Button', 'Process the image']);
+
+    $sse = $app->add(['jsSSE']);
+
+    $button->on('click', $sse->set(function() use($sse, $button, $image) {
+
+        $sse->send($button->js()->text('Processing'));
+        sleep(1); // $image->resize();
+
+        $sse->send($button->js()->text('Looking for face'));
+        sleep(1); // $image->findFace();
+
+        $sse->send($button->js()->text('Adding watermark'));
+        sleep(1); // $image->watermark();
+
+        $sse->send($button->js()->text('Creating thumbnail'));
+        sleep(1); // $image->createThumbnails();
+
+        return $button->js()->text('Success')->addClass('disabled');
+
+    });
+

--- a/js/src/plugins/serverEvent.js
+++ b/js/src/plugins/serverEvent.js
@@ -5,13 +5,22 @@ export default class serverEvent extends atkPlugin {
 
   main() {
 
+    const element = this.$el;
+    const hasLoader = this.settings.showLoader;
+
     if (typeof(EventSource) !== "undefined") {
-      let source = new EventSource(`${this.settings.uri}?${this.settings.name}=sse`);
+      let source = new EventSource(`${this.settings.uri}&event=${this.settings.event}`);
+      if(hasLoader) {
+        element.addClass('loading');
+      }
       source.onmessage = function (e) {
         apiService.atkSuccessTest(JSON.parse(e.data));
       };
       source.onerror = function (e) {
           if (e.eventPhase === EventSource.CLOSED) {
+            if (hasLoader) {
+              element.removeClass('loading');
+            }
             source.close();
           }
       };
@@ -19,10 +28,9 @@ export default class serverEvent extends atkPlugin {
         apiService.atkSuccessTest(JSON.parse(e.data));
       }, false);
     } else {
-      console.log('server side event not supported fallback to atkReloadView');
+      //console.log('server side event not supported fallback to atkReloadView');
       this.$el.atkReloadView({
         uri: this.settings.uri,
-        uri_options: {[this.settings.name]:'callback'},
       });
     }
   }
@@ -31,5 +39,6 @@ export default class serverEvent extends atkPlugin {
 serverEvent.DEFAULTS = {
   uri: null,
   uri_options: {},
-  name: '',
+  showLoader: false,
+  event: 'sse',
 };

--- a/js/src/plugins/serverEvent.js
+++ b/js/src/plugins/serverEvent.js
@@ -6,7 +6,7 @@ export default class serverEvent extends atkPlugin {
   main() {
 
     if (typeof(EventSource) !== "undefined") {
-      let source = new EventSource(this.settings.uri);
+      let source = new EventSource(this.settings.uri + `?${this.settings.name}=sse`);
       source.onmessage = function (e) {
         apiService.atkSuccessTest(JSON.parse(e.data));
       };
@@ -19,7 +19,10 @@ export default class serverEvent extends atkPlugin {
         apiService.atkSuccessTest(JSON.parse(e.data));
       }, false);
     } else {
-      console.log('server side event not supported');
+      console.log('server side event not supported fallback to atkAjaxec');
+      this.$el.atkAjaxec({
+        uri: this.settings.uri + `?${this.settings.name}=callback`
+      })
     }
   }
 }
@@ -27,4 +30,5 @@ export default class serverEvent extends atkPlugin {
 serverEvent.DEFAULTS = {
   uri: null,
   uri_options: {},
+  name: '',
 };

--- a/js/src/plugins/serverEvent.js
+++ b/js/src/plugins/serverEvent.js
@@ -19,7 +19,7 @@ export default class serverEvent extends atkPlugin {
         apiService.atkSuccessTest(JSON.parse(e.data));
       }, false);
     } else {
-      console.log('server side event not supported fallback to atkAjaxec');
+      console.log('server side event not supported fallback to atkReloadView');
       this.$el.atkReloadView({
         uri: this.settings.uri,
         uri_options: {[this.settings.name]:'callback'},

--- a/js/src/plugins/serverEvent.js
+++ b/js/src/plugins/serverEvent.js
@@ -1,4 +1,5 @@
 import atkPlugin from 'plugins/atkPlugin';
+import apiService from '../services/ApiService';
 
 export default class serverEvent extends atkPlugin {
 
@@ -7,11 +8,10 @@ export default class serverEvent extends atkPlugin {
     if (typeof(EventSource) !== "undefined") {
       let source = new EventSource(this.settings.uri);
       source.onmessage = function (e) {
-        //console.log('event', e.lastEventId, e.data);
-        console.log('event', JSON.parse(e.data));
+        // console.log('event', JSON.parse(e.data));
+        apiService.atkSuccessTest(JSON.parse(e.data));
       };
       source.onerror = function (e) {
-        //console.log('error', e);
       }
     } else {
       console.log('server side event not supported');

--- a/js/src/plugins/serverEvent.js
+++ b/js/src/plugins/serverEvent.js
@@ -8,11 +8,16 @@ export default class serverEvent extends atkPlugin {
     if (typeof(EventSource) !== "undefined") {
       let source = new EventSource(this.settings.uri);
       source.onmessage = function (e) {
-        // console.log('event', JSON.parse(e.data));
         apiService.atkSuccessTest(JSON.parse(e.data));
       };
       source.onerror = function (e) {
-      }
+          if (e.eventPhase === EventSource.CLOSED) {
+            source.close();
+          }
+      };
+      source.addEventListener("jsAction", function(e) {
+        apiService.atkSuccessTest(JSON.parse(e.data));
+      }, false);
     } else {
       console.log('server side event not supported');
     }

--- a/js/src/plugins/serverEvent.js
+++ b/js/src/plugins/serverEvent.js
@@ -6,7 +6,7 @@ export default class serverEvent extends atkPlugin {
   main() {
 
     if (typeof(EventSource) !== "undefined") {
-      let source = new EventSource(this.settings.uri + `?${this.settings.name}=sse`);
+      let source = new EventSource(`${this.settings.uri}?${this.settings.name}=sse`);
       source.onmessage = function (e) {
         apiService.atkSuccessTest(JSON.parse(e.data));
       };
@@ -20,9 +20,10 @@ export default class serverEvent extends atkPlugin {
       }, false);
     } else {
       console.log('server side event not supported fallback to atkAjaxec');
-      this.$el.atkAjaxec({
-        uri: this.settings.uri + `?${this.settings.name}=callback`
-      })
+      this.$el.atkReloadView({
+        uri: this.settings.uri,
+        uri_options: {[this.settings.name]:'callback'},
+      });
     }
   }
 }

--- a/js/src/services/ApiService.js
+++ b/js/src/services/ApiService.js
@@ -112,7 +112,7 @@ class ApiService {
      * @param response
      * @param content
      */
-    atkSuccessTest(response, content) {
+    atkSuccessTest(response, content = null) {
         if (response.success) {
             this.onSuccess(response, content);
         } else {

--- a/src/jsSSE.php
+++ b/src/jsSSE.php
@@ -1,46 +1,135 @@
 <?php
 
 namespace atk4\ui;
-
 /**
  * Implements a class that can be mapped into arbitrary JavaScript expression.
  */
+
+use atk4\core\InitializerTrait;
 class jsSSE extends jsCallback
 {
+    use InitializerTrait;
     // Allows us to fall-back to standard functionality of jsCallback if browser does not support SSE
     public $browserSupport = false;
 
     public function init()
     {
-        parent::init();
-
-        if ($this->triggered() == 'sse') {
+        //parent::init();
+        $this->_initialized = true;
+        if ($this->triggered() === 'callback') {
             $this->browserSupport = true;
+            $this->initSse();
         }
     }
 
-    public function send($action)
+    public function jsRender()
+    {
+        if (!$this->app) {
+            throw new Exception(['Call-back must be part of a RenderTree']);
+        }
+
+        return (new jQuery())->atkServerEvent([
+            'uri' => $this->getURL(),
+        ])->jsRender();
+    }
+
+    public function send($action, $success = true)
     {
         if ($this->browserSupport) {
             $ajaxec = $this->getAjaxec($action);
-
-            // TODO: implement
-            $this->sendBlock($ajaxec);
-            $this->flush();
+            $this->sendEvent('js', json_encode(['success' => $success, 'message' => 'Success', 'atkjs' => $ajaxec]), 'jsAction');
         } // else ignore event
     }
 
     public function terminate($ajaxec, $success = true)
     {
         if ($this->browserSupport) {
-
-            // if !success, then log error to console
-            $this->sendBlock($ajaxec);
+            $this->sendEvent('js', json_encode(['success' => $success, 'message' => 'Success', 'atkjs' => $ajaxec]), 'jsAction');
 
             // no further output please
             $this->app->terminate();
         } else {
             $this->app->terminate(json_encode(['success' => $success, 'message' => 'Success', 'atkjs' => $ajaxec]));
         }
+    }
+
+    /**
+     * Output a SSE Event.
+     *
+     * @param $id
+     * @param $data
+     * @param $eventName
+     */
+    public function sendEvent($id, $data, $eventName)
+    {
+        $this->sendBlock($id, $data, $eventName);
+        $this->flush();
+    }
+
+    /**
+     * Send Data in buffer to client.
+     */
+    public function flush()
+    {
+        @ob_flush();
+        @flush();
+    }
+
+    /**
+     * Send Data.
+     *
+     * @param string $content
+     */
+    private function output($content)
+    {
+        print($content);
+    }
+
+    /**
+     * Send a SSE data block.
+     *
+     * @param mixed  $id   Event ID
+     * @param string $data Event Data
+     * @param string $name Event Name
+     */
+    public function sendBlock($id, $data, $name = null)
+    {
+        $this->output("id: {$id}\n");
+        if (strlen($name) && $name !== null) {
+            $this->output("event: {$name}\n");
+        }
+        $this->output($this->wrapData($data)."\n\n");
+    }
+
+    /**
+     * Create SSE data string.
+     *
+     * @param string $string data to be processed
+     *
+     * @return string
+     */
+    private function wrapData($string)
+    {
+        return 'data:'.str_replace("\n", "\ndata: ", $string);
+    }
+
+    protected function initSse()
+    {
+        @set_time_limit(0); // Disable time limit
+        // Prevent buffering
+        if (function_exists('apache_setenv')) {
+            @apache_setenv('no-gzip', 1);
+        }
+        @ini_set('zlib.output_compression', 0);
+        @ini_set('implicit_flush', 1);
+        while (ob_get_level() != 0) {
+            ob_end_flush();
+        }
+        ob_implicit_flush(1);
+        //Somehow header has to be set right away.
+        header('Content-Type: text/event-stream');
+        header('Cache-Control: no-cache');
+        header('Cache-Control: private');
+        header('Pragma: no-cache');
     }
 }

--- a/src/jsSSE.php
+++ b/src/jsSSE.php
@@ -18,7 +18,7 @@ class jsSSE extends jsCallback
     {
         //parent::init();
         $this->_initialized = true;
-        if ($this->triggered() === 'callback') {
+        if ($this->triggered() === 'sse') {
             $this->browserSupport = true;
             $this->initSse();
         }
@@ -31,7 +31,8 @@ class jsSSE extends jsCallback
         }
 
         return (new jQuery())->atkServerEvent([
-            'uri' => $this->getURL(),
+            'uri'  => $this->getURL(),
+            'name' => $this->name,
         ])->jsRender();
     }
 
@@ -101,6 +102,18 @@ class jsSSE extends jsCallback
             $this->output("event: {$name}\n");
         }
         $this->output($this->wrapData($data)."\n\n");
+    }
+
+    /**
+     * Return URL that will trigger action on this call-back.
+     *
+     * @param string $mode
+     *
+     * @return string
+     */
+    public function getURL()
+    {
+        return $this->app->url();
     }
 
     /**

--- a/src/jsSSE.php
+++ b/src/jsSSE.php
@@ -13,12 +13,13 @@ class jsSSE extends jsCallback
     use InitializerTrait;
     // Allows us to fall-back to standard functionality of jsCallback if browser does not support SSE
     public $browserSupport = false;
+    public $showLoader = false;
 
     public function init()
     {
         //parent::init();
         $this->_initialized = true;
-        if ($this->triggered() === 'sse') {
+        if (@$_GET['event'] === 'sse') {
             $this->browserSupport = true;
             $this->initSse();
         }
@@ -30,10 +31,12 @@ class jsSSE extends jsCallback
             throw new Exception(['Call-back must be part of a RenderTree']);
         }
 
-        return (new jQuery())->atkServerEvent([
-            'uri'  => $this->getURL('sse'),
-            'name' => $this->name,
-        ])->jsRender();
+        $options = ['uri' => $this->getURL()];
+        if ($this->showLoader) {
+            $options['showLoader'] = $this->showLoader;
+        }
+
+        return (new jQuery())->atkServerEvent($options)->jsRender();
     }
 
     public function send($action, $success = true)
@@ -103,20 +106,6 @@ class jsSSE extends jsCallback
         }
         $this->output($this->wrapData($data)."\n\n");
     }
-
-    /**
-     * Return URL that will trigger action on this call-back.
-     *
-     * @param string $mode
-     *
-     * @return string
-     */
-    /*
-    public function getURL($mode = 'callback')
-    {
-        return $this->app->url();
-    }
-     */
 
     /**
      * Create SSE data string.

--- a/src/jsSSE.php
+++ b/src/jsSSE.php
@@ -1,11 +1,13 @@
 <?php
 
 namespace atk4\ui;
-/**
+
+/*
  * Implements a class that can be mapped into arbitrary JavaScript expression.
  */
 
 use atk4\core\InitializerTrait;
+
 class jsSSE extends jsCallback
 {
     use InitializerTrait;
@@ -82,7 +84,7 @@ class jsSSE extends jsCallback
      */
     private function output($content)
     {
-        print($content);
+        echo $content;
     }
 
     /**


### PR DESCRIPTION
# Fix jsSse to run callback function on non supporting browser.

On non supporting browser, like IE, the set callback function is never run.
Using this fix, the atkServerEvent.js plugin will fallback with using atkAjaxec.js when this occur, in order for the callback function define in set to be able to run and at least complete.