### PR TITLE
Fix/callback get url

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -390,11 +390,16 @@ class App
      * Build a URL that application can use for call-backs.
      *
      * @param array|string $page URL as string or array with page name as first element and other GET arguments
+     * @param boolean $needRequestUri Simply return $_SERVER['REQUEST_URI'] if needed
      *
      * @return string
      */
-    public function url($page = [])
+    public function url($page = [], $needRequestUri = false)
     {
+        if ($needRequestUri) {
+            return $_SERVER['REQUEST_URI'];
+        }
+
         $sticky = $this->sticky_get_arguments;
         $result = [];
 

--- a/src/App.php
+++ b/src/App.php
@@ -389,8 +389,8 @@ class App
     /**
      * Build a URL that application can use for call-backs.
      *
-     * @param array|string $page URL as string or array with page name as first element and other GET arguments
-     * @param boolean $needRequestUri Simply return $_SERVER['REQUEST_URI'] if needed
+     * @param array|string $page           URL as string or array with page name as first element and other GET arguments
+     * @param bool         $needRequestUri Simply return $_SERVER['REQUEST_URI'] if needed
      *
      * @return string
      */

--- a/src/Callback.php
+++ b/src/Callback.php
@@ -114,10 +114,6 @@ class Callback
      */
     public function getURL($mode = 'callback')
     {
-        if ($this->POST_trigger) {
-            return $_SERVER['REQUEST_URI'];
-        }
-
-        return $this->app->url([$this->name => $mode]);
+        return $this->app->url([$this->name => $mode], $this->POST_trigger);
     }
 }


### PR DESCRIPTION
Delegate full control to App:url() method from Callback::getUrl() by passing an extra argument to App::url().

Prior to this, an hosting app did not have full control of url argument creation when using Callback with Form or Callback using POST_trigger property set to true. 
By delegating the url creation to App::url() method, now an hosting app will have full control of arguments needed with returning url.