### PR TITLE
Improvements for Tables, CRUDS and few other areas.

### DIFF
--- a/demos/table2.php
+++ b/demos/table2.php
@@ -3,10 +3,10 @@
 date_default_timezone_set('UTC');
 include 'init.php';
 
-$data = [ 
-    ['id'=>1, 'action'=>'Salary', 'amount'=>200], 
-    ['id'=>2, 'action'=>'Purchase goods', 'amount'=>-120], 
-    ['id'=>3, 'action'=>'Tax', 'amount'=>-40], 
+$data = [
+    ['id'=>1, 'action'=>'Salary', 'amount'=>200],
+    ['id'=> 2, 'action'=>'Purchase goods', 'amount'=>-120],
+    ['id'=> 3, 'action'=>'Tax', 'amount'=>-40],
 ];
 
 $p = new \atk4\data\Persistence_Array($data);
@@ -21,18 +21,15 @@ $table->setModel($m);
 $table->template->appendHTML('SubHead', '<tr class="center aligned"><th colspan=2>This is sub-header, goes inside "thead" tag</th></tr>');
 $table->template->appendHTML('Body', '<tr class="center aligned"><td colspan=2>This is part of body, goes before other rows</td></tr>');
 
-$table->addHook('beforeRow', function($table) {
+$table->addHook('beforeRow', function ($table) {
     if ($table->current_id == 2) {
         $table->template->appendHTML('Body', '<tr class="center aligned"><td colspan=2>This goes above row with ID=2 ('.$table->current_row['action'].')</th></tr>');
     } elseif ($table->current_id == 3) {
-
         $table->renderRow();
         $table->model->set(['action'=>'manually injected row after Tax', 'amount'=>0]);
     }
 });
 
-
 $table->template->appendHTML('Foot', '<tr class="center aligned"><td colspan=2>This will appear above totals</th></tr>');
-
 
 $table->addTotals(['action' => 'Totals:', 'amount' => ['sum']]);

--- a/demos/table2.php
+++ b/demos/table2.php
@@ -1,0 +1,38 @@
+<?php
+
+date_default_timezone_set('UTC');
+include 'init.php';
+
+$data = [ 
+    ['id'=>1, 'action'=>'Salary', 'amount'=>200], 
+    ['id'=>2, 'action'=>'Purchase goods', 'amount'=>-120], 
+    ['id'=>3, 'action'=>'Tax', 'amount'=>-40], 
+];
+
+$p = new \atk4\data\Persistence_Array($data);
+$m = new \atk4\data\Model($p);
+
+$m->addField('action');
+$m->addField('amount', ['type'=>'money']);
+
+$table = $app->add('Table');
+$table->setModel($m);
+
+$table->template->appendHTML('SubHead', '<tr class="center aligned"><th colspan=2>This is sub-header, goes inside "thead" tag</th></tr>');
+$table->template->appendHTML('Body', '<tr class="center aligned"><td colspan=2>This is part of body, goes before other rows</td></tr>');
+
+$table->addHook('beforeRow', function($table) {
+    if ($table->current_id == 2) {
+        $table->template->appendHTML('Body', '<tr class="center aligned"><td colspan=2>This goes above row with ID=2 ('.$table->current_row['action'].')</th></tr>');
+    } elseif ($table->current_id == 3) {
+
+        $table->renderRow();
+        $table->model->set(['action'=>'manually injected row after Tax', 'amount'=>0]);
+    }
+});
+
+
+$table->template->appendHTML('Foot', '<tr class="center aligned"><td colspan=2>This will appear above totals</th></tr>');
+
+
+$table->addTotals(['action' => 'Totals:', 'amount' => ['sum']]);

--- a/docs/virtualpage.rst
+++ b/docs/virtualpage.rst
@@ -92,39 +92,12 @@ This code will perform identically as the previous example, however 'LoremIpsum'
 unless you are requesting VirtualPage specifically, saving some CPU time. Capability of defining callback
 also makes it possible for VirtualPage to be embedded into any :ref:`component` quite reliably.
 
-To illustrate, how :php:class:`Tabs` component rely on VirtualPage, the following code::
+To illustrate, see how :php:class:`Tabs` component rely on VirtualPage, the following code::
 
     $t = $layout->add('Tabs');
 
     $t->addTab('Tab1')->add('LoremIpsum'); // regular tab
     $t->addTab('Tab2', function($p){ $p->add('LoremIpsum'); }); // dynamic tab
-
-uses the following implementation of addTab()::
-
-    public function addTab($name = null, $action = null)
-    {
-        // add tabs menu item
-        $item = $this->add([$item, 'class'=>['item']], 'Menu');
-        $item->setElement('a');
-        $item->setAttr('data-tab', $item->name);
-
-        // add tabs sub-view
-        $sub = $this->add(['View', 'class'=>['ui tab']], 'Tabs');
-        $sub->setAttr('data-tab', $item->name);
-
-        // if there is callback action, then
-        if ($action && is_callable($action)) {
-            $vp = $sub->add('VirtualPage');
-            $item->setPath($vp->getUrl());
-
-            $vp->set($action);
-        }
-
-        return  $sub;
-    }
-
-You do not need to fully understand the code to notice that Dynamic Content support requires just
-few lines of extra code.
 
 .. php:method:: getURL($html_wrapping)
 

--- a/src/Table.php
+++ b/src/Table.php
@@ -344,7 +344,6 @@ class Table extends Lister
 
             $this->renderRow($this->model);
 
-
             $rows++;
         }
 
@@ -360,8 +359,8 @@ class Table extends Lister
         return View::renderView();
     }
 
-    function renderRow() {
-
+    public function renderRow()
+    {
         $this->t_row->set($this->model);
 
         if ($this->use_html_tags) {

--- a/src/Table.php
+++ b/src/Table.php
@@ -178,42 +178,6 @@ class Table extends Lister
             throw new Exception(['Value of $columnDecorator argument is incorrect', 'columnDecorator' => $columnDecorator]);
         }
 
-        /*
-        $field = null;
-        if (is_string($name)) {
-            $field = $this->model->hasElement($name);
-        }
-
-        // No such field or not a string, so use it as columnDef
-        if (!$field && !$columnDef) {
-            $columnDef = $name;
-            $name = null;
-        }
-
-        // At this point $columnDef is surely there and we might have field also.
-        if ($columnDef === null) {
-            $columnDef = $this->_columnFactory($field);
-        } elseif (is_string($columnDef) || is_array($columnDef)) {
-            if (!$this->app) {
-                throw new Exception(['You can only specify column type by name if Table is in a render-tree']);
-            }
-
-            $columnDef = $this->factory($columnDef);
-        }
-
-        $columnDef->table = $this;
-        if (isset($columnDef->_initializerTrait) && !$columnDef->_initialized) {
-            $this->_add($columnDef);
-        }
-
-        if (!$columnDef instanceof TableColumn\Generic) {
-            throw new Exception([
-                'Table columns must extend TableColumn\Generic',
-                'column'=> $columnDef,
-            ]);
-        }
-         */
-
         if (is_null($name)) {
             $this->columns[] = $columnDecorator;
         } elseif (!is_string($name)) {
@@ -372,44 +336,14 @@ class Table extends Lister
         $rows = 0;
         foreach ($this->model as $this->current_id => $tmp) {
             $this->current_row = $this->model->get();
+            $this->hook('beforeRow');
 
             if ($this->totals_plan) {
                 $this->updateTotals();
             }
 
-            $this->t_row->set($this->model);
+            $this->renderRow($this->model);
 
-            if ($this->use_html_tags) {
-                // Prepare row-specific HTML tags.
-                $html_tags = [];
-
-                foreach ($this->hook('getHTMLTags', [$this->model]) as $ret) {
-                    if (is_array($ret)) {
-                        $html_tags = array_merge($html_tags, $ret);
-                    }
-                }
-
-                foreach ($this->columns as $name => $columns) {
-                    if (!is_array($columns)) {
-                        $columns = [$columns];
-                    }
-                    $field = $this->model->hasElement($name);
-                    foreach ($columns as $column) {
-                        if (!method_exists($column, 'getHTMLTags')) {
-                            continue;
-                        }
-                        $html_tags = array_merge($column->getHTMLTags($this->model, $field), $html_tags);
-                    }
-                }
-
-                // Render row and add to body
-                $this->t_row->setHTML($html_tags);
-                $this->t_row->set('_id', $this->model->id);
-                $this->template->appendHTML('Body', $this->t_row->render());
-                $this->t_row->del(array_keys($html_tags));
-            } else {
-                $this->template->appendHTML('Body', $this->t_row->render());
-            }
 
             $rows++;
         }
@@ -424,6 +358,43 @@ class Table extends Lister
         }
 
         return View::renderView();
+    }
+
+    function renderRow() {
+
+        $this->t_row->set($this->model);
+
+        if ($this->use_html_tags) {
+            // Prepare row-specific HTML tags.
+            $html_tags = [];
+
+            foreach ($this->hook('getHTMLTags', [$this->model]) as $ret) {
+                if (is_array($ret)) {
+                    $html_tags = array_merge($html_tags, $ret);
+                }
+            }
+
+            foreach ($this->columns as $name => $columns) {
+                if (!is_array($columns)) {
+                    $columns = [$columns];
+                }
+                $field = $this->model->hasElement($name);
+                foreach ($columns as $column) {
+                    if (!method_exists($column, 'getHTMLTags')) {
+                        continue;
+                    }
+                    $html_tags = array_merge($column->getHTMLTags($this->model, $field), $html_tags);
+                }
+            }
+
+            // Render row and add to body
+            $this->t_row->setHTML($html_tags);
+            $this->t_row->set('_id', $this->model->id);
+            $this->template->appendHTML('Body', $this->t_row->render());
+            $this->t_row->del(array_keys($html_tags));
+        } else {
+            $this->template->appendHTML('Body', $this->t_row->render());
+        }
     }
 
     /**

--- a/template/semantic-ui/table.html
+++ b/template/semantic-ui/table.html
@@ -1,6 +1,8 @@
 <table id="{$_id}" class="{_ui}ui{/} {$class} {_class}{/}" style="{$style}" {$attributes}>
 <thead>{Head}
-  <tr>{$cells}</tr>{/}
+  <tr>{$cells}</tr>
+  {/}
+  {$SubHead}
 </thead>
 <tbody>
   {Body}

--- a/template/semantic-ui/table.pug
+++ b/template/semantic-ui/table.pug
@@ -5,6 +5,7 @@ thead
     | {Head}
     tr {$cells}
     | {/}
+    | {$SubHead}
 
 tbody
     | {Body}


### PR DESCRIPTION
Tables are good for outputting data from a model, but sometimes you need to add that extra row, some sub-header or subtotal. 

This adds example on how you can do that and adds two new hooks into table: `beforeRow` and `afterRow`

``` php
$table->template->appendHTML('SubHead', '<tr class="center aligned"><th colspan=2>This is sub-header, goes inside "thead" tag</th></tr>');
```

<img width="1171" alt="screen shot 2017-11-30 at 21 52 16" src="https://user-images.githubusercontent.com/453929/33456901-c04c1434-d618-11e7-85dc-2102203e9dbb.png">
