### PR TITLE
Fix renderRow in case of hierarchical template

### DIFF
--- a/src/Table.php
+++ b/src/Table.php
@@ -448,10 +448,10 @@ class Table extends Lister
                     $this->totals[$key] = 0;
                 }
 
-                // closure support
+                // callable support
                 // arguments - current value, key, \atk4\ui\Table object
-                if ($f instanceof \Closure) {
-                    $this->totals[$key] += ($f($this->model[$key], $key, $this) ?: 0);
+                if (is_callable($f)) {
+                    $this->totals[$key] += (call_user_func_array($f, [$this->model[$key], $key, $this]) ?: 0);
                 }
                 // built-in methods
                 elseif (is_string($f)) {

--- a/src/Table.php
+++ b/src/Table.php
@@ -371,6 +371,7 @@ class Table extends Lister
     {
         $this->t_row = new Template($this->t_row_master);
         $this->t_row->app = $this->app;
+        $this->t_row->set('_id', $this->model->id);
         $this->t_row->set($m ?: $this->model);
 
         if ($this->use_html_tags) {
@@ -399,7 +400,6 @@ class Table extends Lister
         }
 
         // Render row and add to body
-        $this->t_row->set('_id', $this->model->id);
         $this->template->appendHTML('Body', $this->t_row->render());
     }
 

--- a/src/Table.php
+++ b/src/Table.php
@@ -439,9 +439,9 @@ class Table extends Lister
     {
         foreach ($this->totals_plan as $key => $f) {
 
-            // backward-compatibility
-            if (is_array($f) && isset($f[0]) && !is_object($f[0])) {
-                $f = $f[0];
+            // if it's just string, then it's a title - we ignore that
+            if (is_string($f)) {
+                continue;
             }
 
             // initial value is always 0
@@ -450,6 +450,9 @@ class Table extends Lister
             }
 
             // built-in methods
+            if (is_array($f) && isset($f[0]) && !is_callable($f)) {
+                $f = $f[0];
+            }
             if (is_string($f)) {
                 switch ($f) {
                     case 'sum':

--- a/src/Table.php
+++ b/src/Table.php
@@ -401,7 +401,6 @@ class Table extends Lister
         // Render row and add to body
         $this->t_row->set('_id', $this->model->id);
         $this->template->appendHTML('Body', $this->t_row->render());
-
     }
 
     /**

--- a/src/Template.php
+++ b/src/Template.php
@@ -314,14 +314,12 @@ class Template implements \ArrayAccess
             $tag = $this->app->ui_persistence->typecastSaveRow($tag, $tag->get());
         }
 
-        if (is_array($tag)) {
-            if (is_null($value)) {
-                foreach ($tag as $s => $v) {
-                    $this->trySet($s, $v, $encode);
-                }
-
-                return $this;
+        if (is_array($tag) && $value === null) {
+            foreach ($tag as $s => $v) {
+                $this->trySet($s, $v, $encode);
             }
+
+            return $this;
         }
 
         if (is_array($value)) {


### PR DESCRIPTION
Fix renderRow in case of hierarchical Template.

We need to get fresh row template on each iteration! That's especially important in case of hierarchical row template.
This solution is also needed in case we use custom getHTMLTags which not always return same set of tags.

For example, row template:
```
{link}<a href="{$url}">{$text}</a>{/link}
```

And getHTMLTags:
```
    public function getHTMLTags($row, $field)
    {
        $v = $field->get();

        // If no value, then don't show link at all
        if (!$v) {
            return ['link' => ''];
        }

        // otherwise show link and fill url and text
        return ['url' => $v, 'text' => 'Click here'];
    }
```

Without this fix the first row without value will delete {link} tag from template at all and following rows which have value will not render <a>, because it's not in template anymore.