### PR TITLE
Fix implementation of Radio field

### DIFF
--- a/demos/checkbox.php
+++ b/demos/checkbox.php
@@ -18,6 +18,7 @@ require 'init.php';
     $app->add(['FormField\CheckBox', 'Look for the clues', 'disabled toggle'])->set(true);
 
     $app->add(new \atk4\ui\View(['ui' => 'divider']));
+<<<<<<< HEAD
     $app->add(['FormField\CheckBox', 'Custom setting?'])->js(true)->checkbox('set indeterminate');
 
     $app->add(['Header', 'CheckBoxes in a form', 'size'=>2]);
@@ -25,3 +26,11 @@ $form = $app->add('Form');
 $form->addField('test', ['CheckBox']);
 $form->addField('test_checked', ['CheckBox'])->set(true);
 $form->addField('also_checked', 'Hello World', 'boolean')->set(true);
+=======
+    $app->add(new \atk4\ui\FormField\CheckBox(['Custom setting?']))->js(true)->checkbox('set indeterminate');
+
+    $app->add(new \atk4\ui\View(['ui' => 'divider']));
+    $c = new \atk4\ui\FormField\CheckBox(['Selected checkbox by default']);
+    $c->set(true);
+    $app->add($c);
+>>>>>>> 41da2ce8cf51903a3d743a3a28df8cda15a4a047

--- a/demos/checkbox.php
+++ b/demos/checkbox.php
@@ -18,7 +18,6 @@ require 'init.php';
     $app->add(['FormField\CheckBox', 'Look for the clues', 'disabled toggle'])->set(true);
 
     $app->add(new \atk4\ui\View(['ui' => 'divider']));
-<<<<<<< HEAD
     $app->add(['FormField\CheckBox', 'Custom setting?'])->js(true)->checkbox('set indeterminate');
 
     $app->add(['Header', 'CheckBoxes in a form', 'size'=>2]);
@@ -26,11 +25,8 @@ $form = $app->add('Form');
 $form->addField('test', ['CheckBox']);
 $form->addField('test_checked', ['CheckBox'])->set(true);
 $form->addField('also_checked', 'Hello World', 'boolean')->set(true);
-=======
-    $app->add(new \atk4\ui\FormField\CheckBox(['Custom setting?']))->js(true)->checkbox('set indeterminate');
 
     $app->add(new \atk4\ui\View(['ui' => 'divider']));
     $c = new \atk4\ui\FormField\CheckBox(['Selected checkbox by default']);
     $c->set(true);
     $app->add($c);
->>>>>>> 41da2ce8cf51903a3d743a3a28df8cda15a4a047

--- a/demos/checkbox.php
+++ b/demos/checkbox.php
@@ -4,15 +4,24 @@
  */
 require 'init.php';
 
-    $app->add(new \atk4\ui\Header(['CheckBoxes', 'size' => 2]));
+    $app->add(['Header', 'CheckBoxes', 'size'=>2]);
 
     $app->add(new \atk4\ui\FormField\CheckBox('Make my profile visible'));
+    $app->add(new \atk4\ui\FormField\CheckBox('Make my profile visible ticked'))->set(true);
 
     $app->add(new \atk4\ui\View(['ui' => 'divider']));
-    $app->add(new \atk4\ui\FormField\CheckBox(['Accept terms and conditions', 'slider']));
+    $app->add(['FormField\CheckBox', 'Accept terms and conditions', 'slider']);
 
     $app->add(new \atk4\ui\View(['ui' => 'divider']));
-    $app->add(new \atk4\ui\FormField\CheckBox(['Subscribe to weekly newsletter', 'toggle']));
+    $app->add(['FormField\CheckBox', 'Subscribe to weekly newsletter', 'toggle']);
+    $app->add(new \atk4\ui\View(['ui' => 'divider']));
+    $app->add(['FormField\CheckBox', 'Look for the clues', 'disabled toggle'])->set(true);
 
     $app->add(new \atk4\ui\View(['ui' => 'divider']));
-    $app->add(new \atk4\ui\FormField\CheckBox(['Custom setting?']))->js(true)->checkbox('set indeterminate');
+    $app->add(['FormField\CheckBox', 'Custom setting?'])->js(true)->checkbox('set indeterminate');
+
+    $app->add(['Header', 'CheckBoxes in a form', 'size'=>2]);
+$form = $app->add('Form');
+$form->addField('test', ['CheckBox']);
+$form->addField('test_checked', ['CheckBox'])->set(true);
+$form->addField('also_checked', 'Hello World', 'boolean')->set(true);

--- a/demos/field2.php
+++ b/demos/field2.php
@@ -16,6 +16,7 @@ $button->on('click', new \atk4\ui\jsExpression('alert("field value is: "+[])', [
 $app->add(['Header', 'Line in a Form']);
 $form = $app->add('Form');
 $field = $form->addField('name', new \atk4\ui\FormField\Line());
+$field->set('value in a form');
 $form->onSubmit(function ($f) {
     return $f->model['name'];
 });

--- a/demos/form5.php
+++ b/demos/form5.php
@@ -23,7 +23,7 @@ $f->addField('three', ['caption' => 'Caption2']);
 $f->addField('four', ['CheckBox', 'caption' => 'Caption2']);
 
 // Use explicit object for user-defined or 3rd party field
-$f->addField('five', new \atk4\ui\FormField\CheckBox());
+$f->addField('five', new \atk4\ui\FormField\CheckBox())->set(true);
 
 // Objects still accept seed
 $f->addField('six', new \atk4\ui\FormField\CheckBox(['caption' => 'Caption3']));

--- a/demos/form6.php
+++ b/demos/form6.php
@@ -15,7 +15,6 @@ $f->addField('two', ['Radio'], ['enum'=>['female', 'male']])->set('male');
 
 $f->addField('three', null, ['values'=>['female', 'male']])->set(1);
 $f->addField('four', ['Radio'], ['values'=>['female', 'male']])->set(1);
-$f->onSubmit(function($f) {
+$f->onSubmit(function ($f) {
     echo json_encode($f->model->get());
 });
-

--- a/demos/form6.php
+++ b/demos/form6.php
@@ -15,6 +15,13 @@ $f->addField('two', ['Radio'], ['enum'=>['female', 'male']])->set('male');
 
 $f->addField('three', null, ['values'=>['female', 'male']])->set(1);
 $f->addField('four', ['Radio'], ['values'=>['female', 'male']])->set(1);
+
+$f->addField('five', null, ['values'=>[5=>'female', 7=>'male']])->set(7);
+$f->addField('six', ['Radio'], ['values'=>[5=>'female', 7=>'male']])->set(7);
+
+$f->addField('seven', null, ['values'=>['F'=>'female', 'M'=>'male']])->set('M');
+$f->addField('eight', ['Radio'], ['values'=>['F'=>'female', 'M'=>'male']])->set('M');
+
 $f->onSubmit(function ($f) {
     echo json_encode($f->model->get());
 });

--- a/demos/form6.php
+++ b/demos/form6.php
@@ -1,0 +1,21 @@
+<?php
+
+require 'init.php';
+
+$app->add(new \atk4\ui\View([
+    'Forms below demonstrate how to work with multi-value selectors',
+    'ui' => 'ignored warning message',
+]));
+
+$cc = $app->add('Columns');
+$f = $cc->addColumn()->add(new \atk4\ui\Form());
+
+$f->addField('one', null, ['enum'=>['female', 'male']])->set('male');
+$f->addField('two', ['Radio'], ['enum'=>['female', 'male']])->set('male');
+
+$f->addField('three', null, ['values'=>['female', 'male']])->set(1);
+$f->addField('four', ['Radio'], ['values'=>['female', 'male']])->set(1);
+$f->onSubmit(function($f) {
+    echo json_encode($f->model->get());
+});
+

--- a/features/loader.feature
+++ b/features/loader.feature
@@ -1,9 +1,0 @@
-Feature: Loader
-    In order to have an awesome PHP UI Framework
-    As a responsible open-source developer
-    I need to write tests for our demo pages
-
-Scenario:
- Given I am on "loader.php"
- Then I should see "Loader #1"
-

--- a/src/FormField/CheckBox.php
+++ b/src/FormField/CheckBox.php
@@ -13,7 +13,20 @@ class CheckBox extends Generic
 
     public $defaultTemplate = 'formfield/checkbox.html';
 
-    public $label;
+    /**
+     * Label appears to the right of the checkbox. If label is not set specifically
+     * then the $caption property will be displayed as a label instead.
+     */
+    public $label = null;
+
+
+    public function __construct($label = null, $class = null) {
+        $this->label = $label;
+
+        if ($class) {
+            $this->addClass($class);
+        }
+    }
 
     public function init()
     {
@@ -31,8 +44,29 @@ class CheckBox extends Generic
         }
     }
 
+    public function set($value = null, $junk = null)
+    {
+        if (!is_bool($value)) {
+            throw new Exception(['Field\CheckBox::set() needs value to be a boolean', 'value'=>$value]);
+        }
+
+        parent::set($value);
+    }
+
     public function renderView()
     {
+        $this->template['label'] = $this->label ?: $this->caption;
+
+        if ($this->field ? $this->field->get() : $this->content) {
+            $this->template->set('checked', 'checked');
+        }
+
+        /**
+         * We don't want this displayed, because it can only affect "checked" status anyway
+         */
+        $this->content = null;
+
+
         $this->js(true)->checkbox();
 
         return parent::renderView();

--- a/src/FormField/CheckBox.php
+++ b/src/FormField/CheckBox.php
@@ -19,8 +19,8 @@ class CheckBox extends Generic
      */
     public $label = null;
 
-
-    public function __construct($label = null, $class = null) {
+    public function __construct($label = null, $class = null)
+    {
         $this->label = $label;
 
         if ($class) {
@@ -61,7 +61,7 @@ class CheckBox extends Generic
             $this->template->set('checked', 'checked');
         }
 
-        /**
+        /*
          * We don't want this displayed, because it can only affect "checked" status anyway
          */
         $this->content = null;

--- a/src/FormField/CheckBox.php
+++ b/src/FormField/CheckBox.php
@@ -32,7 +32,7 @@ class CheckBox extends Generic
     {
         parent::init();
 
-        // checkboxes are annoying becasue they don't send value
+        // checkboxes are annoying because they don't send value
         // when they are not ticked. We assume they are ticked and
         // sent "false" as a workaround
         if ($this->form) {
@@ -66,9 +66,9 @@ class CheckBox extends Generic
          */
         $this->content = null;
 
-
         $this->js(true)->checkbox();
 
+        $this->content = null; // no content again
         return parent::renderView();
     }
 }

--- a/src/FormField/Generic.php
+++ b/src/FormField/Generic.php
@@ -59,6 +59,18 @@ class Generic extends View
         return $this;
     }
 
+    /*
+     * Method similar to View::js() however will adjust selector
+     * to target the "input" element.
+     *
+     * $field->jsInput(true)->val(123);
+     */
+    public function jsInput($when = null, $action = null)
+    {
+        return $this->js($when, $action, '#'.$this->id.'_input');
+    }
+
+
     /**
      * It only makes sense to have "name" property inside a field if
      * it was used inside a form.

--- a/src/FormField/Generic.php
+++ b/src/FormField/Generic.php
@@ -61,17 +61,6 @@ class Generic extends View
         return $this;
     }
 
-    /*
-     * Method similar to View::js() however will adjust selector
-     * to target the "input" element.
-     *
-     * $field->jsInput(true)->val(123);
-     */
-    public function jsInput($when = null, $action = null)
-    {
-        return $this->js($when, $action, '#'.$this->id.'_input');
-    }
-
     /**
      * It only makes sense to have "name" property inside a field if
      * it was used inside a form.

--- a/src/FormField/Generic.php
+++ b/src/FormField/Generic.php
@@ -22,6 +22,14 @@ class Generic extends View
 
     public $width = null;
 
+    /**
+     * Caption is a text that must appear somewhere nearby the field. For a form with layout, this
+     * will typically place caption above the input field, but checkbox this may appear next to the
+     * checkbox itself. If Form Layout does not have captions above the input field, then caption
+     * will appear as a placeholder of the input fields and it may also appear as a tooltip.
+     *
+     * Caption is usually specified by a model.
+     */
     public $caption = null;
 
     public function init()
@@ -34,6 +42,21 @@ class Generic extends View
             }
             $this->form->fields[$this->field->short_name] = $this;
         }
+    }
+
+    /**
+     * Sets the value of this field. If field is a part of the form and is associated with
+     * the model, then the model's value will also be affected.
+     */
+    public function set($value = null, $junk = null)
+    {
+        if ($this->field) {
+            $this->field->set($value);
+            return $this;
+        }
+
+        $this->content = $value;
+        return $this;
     }
 
     /**

--- a/src/FormField/Generic.php
+++ b/src/FormField/Generic.php
@@ -52,10 +52,12 @@ class Generic extends View
     {
         if ($this->field) {
             $this->field->set($value);
+
             return $this;
         }
 
         $this->content = $value;
+
         return $this;
     }
 
@@ -69,7 +71,6 @@ class Generic extends View
     {
         return $this->js($when, $action, '#'.$this->id.'_input');
     }
-
 
     /**
      * It only makes sense to have "name" property inside a field if

--- a/src/FormField/Generic.php
+++ b/src/FormField/Generic.php
@@ -24,11 +24,13 @@ class Generic extends View
 
     /**
      * Caption is a text that must appear somewhere nearby the field. For a form with layout, this
-     * will typically place caption above the input field, but checkbox this may appear next to the
+     * will typically place caption above the input field, but for checkbox this may appear next to the
      * checkbox itself. If Form Layout does not have captions above the input field, then caption
      * will appear as a placeholder of the input fields and it may also appear as a tooltip.
      *
      * Caption is usually specified by a model.
+     *
+     * @var string
      */
     public $caption = null;
 
@@ -47,6 +49,11 @@ class Generic extends View
     /**
      * Sets the value of this field. If field is a part of the form and is associated with
      * the model, then the model's value will also be affected.
+     *
+     * @param mixed $value
+     * @param mixed $junk
+     *
+     * @return $this
      */
     public function set($value = null, $junk = null)
     {

--- a/src/FormField/Input.php
+++ b/src/FormField/Input.php
@@ -50,25 +50,6 @@ class Input extends Generic
     public $width = null;
 
     /**
-     * Method similar to View::js() however will adjust selector
-     * to target the "input" element.
-     *
-     * $field->jsInput(true)->val(123);
-     */
-    public function jsInput($when = null, $action = null)
-    {
-        return $this->js($when, $action, '#'.$this->id.'_input');
-    }
-
-    /**
-     * Returns presentable value to be inserted into input tag.
-     */
-    public function getValue()
-    {
-        return isset($this->field) ? $this->app->ui_persistence->typecastSaveField($this->field, $this->field->get()) : $this->content ?: '';
-    }
-
-    /**
      * returns <input .../> tag.
      */
     public function getInput()
@@ -104,7 +85,6 @@ class Input extends Generic
 
     public function renderView()
     {
-
         // TODO: I don't think we need the loading state at all.
         if ($this->loading) {
             if (!$this->icon) {
@@ -164,9 +144,6 @@ class Input extends Generic
                 $this->addClass('left action');
             }
         }
-
-        $this->template->setHTML('Input', $this->getInput());
-        $this->content = null;
 
         parent::renderView();
     }

--- a/src/FormField/Input.php
+++ b/src/FormField/Input.php
@@ -111,7 +111,7 @@ class Input extends Generic
 
         return $label;
     }
-    
+
     /**
      * Used only from renderView().
      *

--- a/src/FormField/Input.php
+++ b/src/FormField/Input.php
@@ -30,10 +30,14 @@ class Input extends Generic
     public $loading = null;
 
     /**
-     * Set to a text.
+     * Some fields also support $label. For Input the label can be placed to the left or to the right of
+     * the field and you can fit "$" inside a label. Input label will appear on the left.
      */
     public $label = null;
 
+    /**
+     * Set label that will appear to the right of the input field
+     */
     public $labelRight = null;
 
     public $action = null;
@@ -176,10 +180,5 @@ class Input extends Generic
         $this->action = $this->add(new Button($defaults), 'AfterInput');
 
         return $this->action;
-    }
-
-    public function set($value = null, $junk = null)
-    {
-        $this->content = $value;
     }
 }

--- a/src/FormField/Input.php
+++ b/src/FormField/Input.php
@@ -164,6 +164,9 @@ class Input extends Generic
             }
         }
 
+        $this->template->setHTML('Input', $this->getInput());
+        $this->content = null;
+
         parent::renderView();
     }
 

--- a/src/FormField/Input.php
+++ b/src/FormField/Input.php
@@ -50,6 +50,25 @@ class Input extends Generic
     public $width = null;
 
     /**
+     * Method similar to View::js() however will adjust selector
+     * to target the "input" element.
+     *
+     * $field->jsInput(true)->val(123);
+     */
+    public function jsInput($when = null, $action = null)
+    {
+        return $this->js($when, $action, '#'.$this->id.'_input');
+    }
+
+    /**
+     * Returns presentable value to be inserted into input tag.
+     */
+    public function getValue()
+    {
+        return isset($this->field) ? $this->app->ui_persistence->typecastSaveField($this->field, $this->field->get()) : $this->content ?: '';
+    }
+
+    /**
      * returns <input .../> tag.
      */
     public function getInput()

--- a/src/FormField/Input.php
+++ b/src/FormField/Input.php
@@ -36,7 +36,7 @@ class Input extends Generic
     public $label = null;
 
     /**
-     * Set label that will appear to the right of the input field
+     * Set label that will appear to the right of the input field.
      */
     public $labelRight = null;
 

--- a/src/FormField/Input.php
+++ b/src/FormField/Input.php
@@ -31,12 +31,17 @@ class Input extends Generic
 
     /**
      * Some fields also support $label. For Input the label can be placed to the left or to the right of
-     * the field and you can fit "$" inside a label. Input label will appear on the left.
+     * the field and you can fit currency symbol "$" inside a label for example.
+     * For Input field label will appear on the left.
+     *
+     * @var string|object
      */
     public $label = null;
 
     /**
      * Set label that will appear to the right of the input field.
+     *
+     * @var string|object
      */
     public $labelRight = null;
 
@@ -85,8 +90,13 @@ class Input extends Generic
 
     /**
      * Used only from renderView().
+     *
+     * @param string|object $label Label class or object
+     * @param string        $spot  Template spot
+     *
+     * @return Label
      */
-    private function prepareRenderLabel($label, $spot)
+    protected function prepareRenderLabel($label, $spot)
     {
         if (!is_object($label)) {
             $label = $this->add(new Label(), $spot)
@@ -100,6 +110,27 @@ class Input extends Generic
         }
 
         return $label;
+    }
+    
+    /**
+     * Used only from renderView().
+     *
+     * @param string|object $button Button class or object
+     * @param string        $spot   Template spot
+     *
+     * @return Button
+     */
+    protected function prepareRenderButton($button, $spot)
+    {
+        if (!is_object($button)) {
+            $button = new Button($button);
+        }
+        if (!$button->_initialized) {
+            $this->add($button, $spot);
+            $this->addClass('action');
+        }
+
+        return $button;
     }
 
     public function renderView()
@@ -117,6 +148,7 @@ class Input extends Generic
             }
         }
 
+        // icons
         if ($this->icon && !is_object($this->icon)) {
             $this->icon = $this->add(new Icon($this->icon), 'AfterInput');
             $this->addClass('icon');
@@ -127,6 +159,7 @@ class Input extends Generic
             $this->addClass('left icon');
         }
 
+        // labels
         if ($this->label) {
             $this->label = $this->prepareRenderLabel($this->label, 'BeforeInput');
         }
@@ -140,30 +173,22 @@ class Input extends Generic
             $this->addClass('labeled');
         }
 
+        // width
         if ($this->width) {
             $this->addClass($this->width.' wide');
         }
 
+        // actions
         if ($this->action) {
-            if (!is_object($this->action)) {
-                $this->action = new Button($this->action);
-            }
-            if (!$this->action->_initialized) {
-                $this->add($this->action, 'AfterInput');
-                $this->addClass('action');
-            }
+            $this->action = $this->prepareRenderButton($this->action, 'AfterInput');
         }
 
         if ($this->actionLeft) {
-            if (!is_object($this->actionLeft)) {
-                $this->actionLeft = new Button($this->actionLeft);
-            }
-            if (!$this->actionLeft->_initialized) {
-                $this->add($this->actionLeft, 'BeforeInput');
-                $this->addClass('left action');
-            }
+            $this->actionLeft = $this->prepareRenderButton($this->actionLeft, 'BeforeInput');
+            $this->addClass('left');
         }
 
+        // set template
         $this->template->setHTML('Input', $this->getInput());
         $this->content = null;
 

--- a/src/FormField/Radio.php
+++ b/src/FormField/Radio.php
@@ -13,17 +13,22 @@ class Radio extends Generic
 
     /**
      * Contains a lister that will render individual radio buttons.
+     *
+     * @var Lister
      */
     public $lister = null;
 
     /**
      * List of values.
+     *
+     * @var array
      */
     public $values = [];
 
     public function init()
     {
         parent::init();
+
         $this->lister = $this->add('Lister', 'Radio');
         $this->lister->t_row['_name'] = $this->short_name;
     }

--- a/src/FormField/Radio.php
+++ b/src/FormField/Radio.php
@@ -37,12 +37,12 @@ class Radio extends Generic
     {
         if (!$this->model) {
             $p = new \atk4\data\Persistence_Static($this->values);
-            $m = new \atk4\data\Model($p);
+            $this->model = new \atk4\data\Model($p);
         }
 
         $value = $this->field ? $this->field->get() : $this->content;
 
-        $this->lister->setModel($m);
+        $this->lister->setModel($this->model);
         $this->lister->addHook('beforeRow', function ($lister) use ($value) {
             $lister->t_row->set('checked', $value == $lister->model->id ? 'checked' : '');
         });

--- a/src/FormField/Radio.php
+++ b/src/FormField/Radio.php
@@ -2,38 +2,46 @@
 
 namespace atk4\ui\FormField;
 
-use atk4\ui\Form;
-use atk4\ui\Lister;
-
 /**
  * Input element for a form field.
  */
 class Radio extends Generic
 {
-    /**
-     * {@inheritdoc}
-     */
-    public $ui = 'radio checkbox';
+    public $ui = false;
 
-    /**
-     * {@inheritdoc}
-     */
     public $defaultTemplate = 'formfield/radio.html';
 
     /**
-     * {@inheritdoc}
+     * Contains a lister that will render individual radio buttons
      */
-    public function setModel(\atk4\data\Model $m)
-    {
-        $this->add(new Lister(), 'Radio')->setModel($m);
-    }
+    public $lister = null;
 
     /**
-     * {@inheritdoc}
+     * List of values
      */
+    public $values = [];
+
+    public function init()
+    {
+        parent::init();
+        $this->lister = $this->add('Lister', 'Radio');
+        $this->lister->t_row['_name'] = $this->short_name;
+    }
+
     public function renderView()
     {
-        $this->js(true)->checkbox();
+
+        if (!$this->model) {
+            $p = new \atk4\data\Persistence_Static($this->values);
+            $m = new \atk4\data\Model($p);
+        }
+
+        $value = $this->field ? $this->field->get() : $this->content;
+
+        $this->lister->setModel($m);
+        $this->lister->addHook('beforeRow', function($lister) use($value) {
+            $lister->t_row->set('checked', $value == $lister->model->id ? 'checked':'');
+        });
 
         return parent::renderView();
     }

--- a/src/FormField/Radio.php
+++ b/src/FormField/Radio.php
@@ -12,12 +12,12 @@ class Radio extends Generic
     public $defaultTemplate = 'formfield/radio.html';
 
     /**
-     * Contains a lister that will render individual radio buttons
+     * Contains a lister that will render individual radio buttons.
      */
     public $lister = null;
 
     /**
-     * List of values
+     * List of values.
      */
     public $values = [];
 
@@ -30,7 +30,6 @@ class Radio extends Generic
 
     public function renderView()
     {
-
         if (!$this->model) {
             $p = new \atk4\data\Persistence_Static($this->values);
             $m = new \atk4\data\Model($p);
@@ -39,8 +38,8 @@ class Radio extends Generic
         $value = $this->field ? $this->field->get() : $this->content;
 
         $this->lister->setModel($m);
-        $this->lister->addHook('beforeRow', function($lister) use($value) {
-            $lister->t_row->set('checked', $value == $lister->model->id ? 'checked':'');
+        $this->lister->addHook('beforeRow', function ($lister) use ($value) {
+            $lister->t_row->set('checked', $value == $lister->model->id ? 'checked' : '');
         });
 
         return parent::renderView();

--- a/src/FormField/Radio.php
+++ b/src/FormField/Radio.php
@@ -37,7 +37,7 @@ class Radio extends Generic
     {
         if (!$this->model) {
             $p = new \atk4\data\Persistence_Static($this->values);
-            $this->model = new \atk4\data\Model($p);
+            $this->setModel(new \atk4\data\Model($p));
         }
 
         $value = $this->field ? $this->field->get() : $this->content;

--- a/src/FormLayout/Generic.php
+++ b/src/FormLayout/Generic.php
@@ -82,7 +82,7 @@ class Generic extends View
             }
 
             if (is_string($decorator)) {
-                $decorator = $this->form->decoratorFactory($field, null, ['caption' => $decorator]);
+                $decorator = $this->form->decoratorFactory($field, ['caption' => $decorator]);
             } elseif (is_array($decorator)) {
                 $decorator = $this->form->decoratorFactory($field, $decorator);
             } elseif (!$decorator) {

--- a/src/View.php
+++ b/src/View.php
@@ -413,7 +413,7 @@ class View implements jsExpressionable
     // {{{ Manipulating classes and view properties
 
     /**
-     * Override this method without compatibility with parrent, if you wish
+     * Override this method without compatibility with parent, if you wish
      * to set your own things your own way for your view.
      *
      * @param string|array $arg1
@@ -441,7 +441,7 @@ class View implements jsExpressionable
             ]);
         }
 
-        if (is_string($arg1)) {
+        if (is_scalar($arg1)) {
             $this->content = $arg1;
 
             return $this;

--- a/template/semantic-ui/formfield/checkbox.html
+++ b/template/semantic-ui/formfield/checkbox.html
@@ -1,3 +1,6 @@
+
 <div id="{$_id}" class="{_ui}ui{/} {$class} {$_class}" style="{$style}" {$attributes}>
-<input class="hidden" id="{$_id}_input" type="checkbox" name="{$name}"/>
-<label>{$Content}</label></div>
+<input id="{$_id}_input" type="checkbox" class="hidden" name="{$name}" {$checked}>
+<label>{Content}{$label}{/}</label>
+</input>
+</div>

--- a/template/semantic-ui/formfield/checkbox.pug
+++ b/template/semantic-ui/formfield/checkbox.pug
@@ -1,4 +1,5 @@
 | <div id="{$_id}" class="{_ui}ui{/} {$class} {$_class}" style="{$style}" {$attributes}>
-input(id="{$_id}_input" type="checkbox" class="hidden" name="{$name}")
-label {$Content}
+| <input id="{$_id}_input" type="checkbox" class="hidden" name="{$name}" {$checked}>
+label {Content}{$label}{/}
+| </input>
 | </div>

--- a/template/semantic-ui/formfield/radio.html
+++ b/template/semantic-ui/formfield/radio.html
@@ -1,3 +1,9 @@
-<div id="{$_id}" class="{_ui}ui{/} {$class} {$_class}" style="{$style}" {$attributes}>
-<input class="hidden" id="{$_id}_input" type="radio" name="{$name}"/>
+
+<div id="{$_id}" class="{$class} grouped fields" style="{$style}" {$attributes}>
+{Radio}{rows}{row}
+<div class="field"><div class="ui radio checkbox">
+<input id="{$_id}_{$id}" type="radio" name="{$_name}" value="{$id}" {$checked}/>
+<label for="{$_id}_{$id}">{$name}</label>
+</div></div>
+{/row}{/rows}{/}
 <label>{$Content}</label></div>

--- a/template/semantic-ui/formfield/radio.pug
+++ b/template/semantic-ui/formfield/radio.pug
@@ -1,6 +1,9 @@
-| <div id="{$_id}" class="{_ui}ui{/} {$class} {$_class}" style="{$style}" {$attributes}>
-{Radio}{Rows}{Row}
-input(id="{$_id}_input" type="radio" class="hidden" name="{$name}")
-{/Row}{/Rows}{/}
+| <div id="{$_id}" class="{$class} grouped fields" style="{$style}" {$attributes}>
+| {Radio}{rows}{row}
+| <div class="field"><div class="ui radio checkbox">
+| <input id="{$_id}_{$id}" type="radio" name="{$_name}" value="{$id}" {$checked}/>
+| <label for="{$_id}_{$id}">{$name}</label>
+| </div></div>
+| {/row}{/rows}{/}
 label {$Content}
 | </div>


### PR DESCRIPTION
Implementation of radio selection field. Depends on #294. Simple use:

``` php
$form->addField('gender', ['Radio', 'values'=>['F'=>'Female', 'M'=>'Male']]);
```

Works with `enum` and `values`.

<img width="441" alt="screen shot 2017-12-16 at 17 23 58" src="https://user-images.githubusercontent.com/453929/34072813-f62ff844-e285-11e7-8fa0-6bfd8ca6cbb6.png">


 - Documentation: [docs/file.rst](docs/file.rst) TODO
 - Demo: [demos/file.php](demos/file.php) TODO

