### PR TITLE
Feature/refactor region population

### DIFF
--- a/src/View.php
+++ b/src/View.php
@@ -354,11 +354,11 @@ class View implements jsExpressionable
     }
 
     /**
-     * In addition to adding a child object, set up it's template
+     * In addition to adding a child object, sets up it's template
      * and associate it's output with the region in our template.
      *
-     * @param View|string  $object New object to add
-     * @param string|array $region (or array for full set of defaults)
+     * @param mixed  $seed   New object to add
+     * @param string $region
      *
      * @throws Exception
      *

--- a/src/View.php
+++ b/src/View.php
@@ -49,7 +49,7 @@ class View implements jsExpressionable
      *
      * @var string
      */
-    public $region = 'Content';
+    public $region = null; //'Content';
 
     /**
      * Enables UI keyword for Semantic UI indicating that this is a
@@ -320,10 +320,21 @@ class View implements jsExpressionable
             $this->initDefaultApp();
         }
 
-        // set up template
-        if (is_string($this->defaultTemplate) && is_null($this->template)) {
-            $this->template = $this->app->loadTemplate($this->defaultTemplate);
+        if ($this->region && !$this->template && !$this->defaultTemplate && $this->owner && $this->owner->template) {
+            $this->template = $this->owner->template->cloneRegion($this->region);
+
+            $this->owner->template->del($this->region);
+        } else {
+            // set up template
+            if (is_string($this->defaultTemplate) && is_null($this->template)) {
+                $this->template = $this->app->loadTemplate($this->defaultTemplate);
+            }
+
+            if (!$this->region) {
+                $this->region = 'Content';
+            }
         }
+
 
         // add default objects
         foreach ($this->_add_later as list($object, $region)) {
@@ -354,18 +365,25 @@ class View implements jsExpressionable
      *
      * @return View
      */
-    public function add($seed, $defaults = null)
+    public function add($seed, $region = null)
     {
         if (!$this->app) {
-            $this->_add_later[] = [$seed, $defaults];
+            $this->_add_later[] = [$seed, $region];
 
             return $seed;
         }
 
-        if (is_array($defaults)) {
+        if (is_array($region)) {
             throw new Exception('Second argument to add must be region or null!');
         }
 
+        /*
+        if (is_string($defaults)) {
+            $defaults = ['region'=>$defaults];
+        }
+         */
+
+        /*
         $region = null;
         if (is_array($defaults) && isset($defaults['region'])) {
             $region = $defaults['region'];
@@ -377,13 +395,10 @@ class View implements jsExpressionable
             $region = $defaults;
             $defaults = null;
         }
+         */
 
         // Create object first
-        $object = $this->factory($this->mergeSeeds($seed, ['View']), $defaults);
-
-        if ($object instanceof self && $region) {
-            $object->region = $region;
-        }
+        $object = $this->factory($this->mergeSeeds($seed, ['View']), $region ? ['region'=>$region]: null);
 
         // Will call init() of the object
         $object = $this->_add($object);
@@ -393,6 +408,7 @@ class View implements jsExpressionable
         }
 
         // We are adding a new view, so do a bit more
+        /*
         if (!$object->template && $object->region && $this->template) {
             $object->template = $this->template->cloneRegion($object->region);
         }
@@ -404,6 +420,7 @@ class View implements jsExpressionable
 
             $this->template->del($object->region);
         }
+         */
 
         return $object;
     }

--- a/src/View.php
+++ b/src/View.php
@@ -335,7 +335,6 @@ class View implements jsExpressionable
             }
         }
 
-
         // add default objects
         foreach ($this->_add_later as list($object, $region)) {
             $this->add($object, $region);
@@ -398,7 +397,7 @@ class View implements jsExpressionable
          */
 
         // Create object first
-        $object = $this->factory($this->mergeSeeds($seed, ['View']), $region ? ['region'=>$region]: null);
+        $object = $this->factory($this->mergeSeeds($seed, ['View']), $region ? ['region'=>$region] : null);
 
         // Will call init() of the object
         $object = $this->_add($object);

--- a/tests/DemoTest.php
+++ b/tests/DemoTest.php
@@ -34,10 +34,12 @@ class DemoTest extends \atk4\core\PHPUnit_AgileTestCase
     public function testDemo($page)
     {
         $this->expectOutputRegex($this->regex);
+
         try {
             $this->inc($page)->run();
         } catch (\atk4\core\Exception $e) {
             $e->addMoreInfo('test', $page);
+
             throw $e;
         }
     }

--- a/tests/DemoTest.php
+++ b/tests/DemoTest.php
@@ -34,7 +34,12 @@ class DemoTest extends \atk4\core\PHPUnit_AgileTestCase
     public function testDemo($page)
     {
         $this->expectOutputRegex($this->regex);
-        $this->inc($page)->run();
+        try {
+            $this->inc($page)->run();
+        } catch (\atk4\core\Exception $e) {
+            $e->addMoreInfo('test', $page);
+            throw $e;
+        }
     }
 
     public function demoList()


### PR DESCRIPTION
When you execute `$view->add('Lister', 'MyTag')` then region is cloned from "MyTag" inside view. Currently this is happening AFTER Lister::init(). This is inconsistent to when defaultTemplate is specified, which populates region BEFORE init().

This PR will refactor and cleanup 'region' so that it happens inside View::init() and not inside add().

``` php

class MyLister extends Lister {
    function init() {
        parent::init();
        $this->template->set('foo', 'bar');
    }
}

$app->add('MyLister', 'MyTemplate');
```

 - Documentation: n/a
 - Demo: n/a

