### PR TITLE
Move cloneRegion into lister's init

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -292,6 +292,8 @@ class Form extends View //implements \ArrayAccess - temporarily so that our buil
 
         if ($f->enum) {
             $fallback_seed = ['DropDown', 'values' => array_combine($f->enum, $f->enum)];
+        } elseif ($f->values) {
+            $fallback_seed = ['DropDown', 'values' => $f->values];
         } elseif (isset($f->reference)) {
             $fallback_seed = ['DropDown', 'model' => $f->reference->refModel()];
         }

--- a/src/Lister.php
+++ b/src/Lister.php
@@ -4,29 +4,44 @@ namespace atk4\ui;
 
 class Lister extends View
 {
-    // @var Template
-    protected $t_row = null;
+    use \atk4\core\HookTrait;
 
     // @var Template
-    protected $t_totals = null;
+    public $t_row = null;
 
-    // @inheritdoc
+    // @var Template
+    public $t_totals = null;
+
     public $defaultTemplate = null;
 
-    /**
-     * {@inheritdoc}
-     */
+    public function init()
+    {
+        parent::init();
+
+        $this->initChunks();
+    }
+
+    public function initChunks()
+    {
+        $this->t_row = $this->template->cloneRegion('row');
+        $this->template->del('rows');
+    }
+
     public function renderView()
     {
         if (!$this->template) {
             throw new Exception(['Lister requires you to specify template explicitly']);
         }
-        $this->t_row = $this->template->cloneRegion('row');
+        $this->t_row->trySet('_id', $this->name);
         //$this->t_totals = isset($this->template['totals']) ? $this->template->cloneRegion('totals') : null;
 
-        $this->template->del('rows');
 
         foreach ($this->model as $this->current_id => $this->current_row) {
+            if ($this->hook('beforeRow') === false) {
+                continue;
+            }
+
+
             $rowHTML = $this->t_row->set($this->current_row)->render();
             $this->template->appendHTML('rows', $rowHTML);
         }

--- a/src/Lister.php
+++ b/src/Lister.php
@@ -35,12 +35,10 @@ class Lister extends View
         $this->t_row->trySet('_id', $this->name);
         //$this->t_totals = isset($this->template['totals']) ? $this->template->cloneRegion('totals') : null;
 
-
         foreach ($this->model as $this->current_id => $this->current_row) {
             if ($this->hook('beforeRow') === false) {
                 continue;
             }
-
 
             $rowHTML = $this->t_row->set($this->current_row)->render();
             $this->template->appendHTML('rows', $rowHTML);

--- a/src/Table.php
+++ b/src/Table.php
@@ -69,28 +69,28 @@ class Table extends Lister
      *
      * @var Template
      */
-    protected $t_head;
+    public $t_head;
 
     /**
      * Contain the template for the "Body" type row.
      *
      * @var Template
      */
-    protected $t_row;
+    public $t_row;
 
     /**
      * Contain the template for the "Foot" type row.
      *
      * @var Template
      */
-    protected $t_totals;
+    public $t_totals;
 
     /**
      * Contains the output to show if table contains no rows.
      *
      * @var Template
      */
-    protected $t_empty;
+    public $t_empty;
 
     public $sortable = null;
 
@@ -249,14 +249,12 @@ class Table extends Lister
     }
 
     /**
-     * Init method will create one column object that will be used to render
+     * initChunks method will create one column object that will be used to render
      * all columns in the table unless you have specified a different
      * column object.
      */
-    public function init()
+    public function initChunks()
     {
-        parent::init();
-
         if (!$this->t_head) {
             $this->t_head = $this->template->cloneRegion('Head');
             $this->t_row_master = $this->template->cloneRegion('Row');

--- a/src/Table.php
+++ b/src/Table.php
@@ -6,8 +6,6 @@ namespace atk4\ui;
 
 class Table extends Lister
 {
-    use \atk4\core\HookTrait;
-
     // Overrides
     public $defaultTemplate = 'table.html';
     public $ui = 'table';


### PR DESCRIPTION
Implementation of #292 needs to specify "name" for radio buttons from inside Radio class. Unfortunately currently Radio does not have access to Lister's template.

This PR requires #293 which makes Lister's template available inside init() so we can clone regions right away. This enables the following code:

``` php
$myview->add('Lister', 'MyRows');
$myview->t_row['_name'] = 'abc';
```

 - Documentation: n/a
 - Demo: n/a

