### PR TITLE
Removed empty first line

### DIFF
--- a/template/semantic-ui/formfield/input.html
+++ b/template/semantic-ui/formfield/input.html
@@ -1,4 +1,3 @@
-
 <div id="{$_id}" class="{_ui}ui{/} {$class} {$_class}" style="{$style}" {$attributes}>
 {$BeforeInput}{$AfterBeforeInput}{Input}<input type="{input_type}text{/}" {$input_attributes}/>{/}{$AfterInput}{$AfterAfterInput}
 </div>


### PR DESCRIPTION
This empty first line caused a space between the <label> and the <div><input><div> which is not neccessary. (In my case caused a problem aligning label and input in one row trying to use 100% width for both of it).

![bildschirmfoto vom 2017-12-22 22-11-17](https://user-images.githubusercontent.com/33204878/34312525-227fc97c-e765-11e7-82eb-77b76fe0512b.png)
