### PR TITLE
Always pass Console as 1st parameter to model callback method

### DIFF
--- a/src/Console.php
+++ b/src/Console.php
@@ -214,7 +214,7 @@ class Console extends View implements \Psr\Log\LoggerInterface
 
         $this->output('--[ Executing '.get_class($model).'->'.$method.' ]--------------');
         $model->debug = true;
-        $result = call_user_func_array([$model, $method], $args);
+        $result = call_user_func_array([$model, $method], array_merge([$this], $args));
         $this->output('--[ Result: '.json_encode($result).' ]------------');
 
         if (isset($model->app)) {


### PR DESCRIPTION
We almost always need to pass Console object to model method because we use Console for output.
