### PR TITLE
fix/#318 Form error

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -375,7 +375,7 @@ class Form extends View //implements \ArrayAccess - temporarily so that our buil
 
         $cb->set(function () {
             $caught = function ($e) {
-                return new jsExpression('$([html]).modal("show")', [
+                return new jsExpression('$([html]).modal("hide others").modal("show")', [
                     'html' => '<div class="ui fullscreen modal"> <i class="close icon"></i> <div class="header"> '.
                     htmlspecialchars(get_class($e)).
                     ' </div> <div class="content"> '.


### PR DESCRIPTION
This PR fix modal behaviour when an exception is thrown during Form::save()

Somehow, semantic-ui create the modal generated by the exception with css position attribute set to ‘static’, therefore static positioned element are alway stacked under other positioned element, regardless of the z-index attribute.

The fix will close others open modal in order to only show the modal containing the exception thrown by Form::save()