### PR TITLE
fix #327: title_field and id_field

### DIFF
--- a/src/FormField/AutoComplete.php
+++ b/src/FormField/AutoComplete.php
@@ -128,14 +128,13 @@ class AutoComplete extends Input
             }
         }
 
-      
         //fix #327: https://github.com/atk4/ui/issues/327
         $data = [];
-		$res = $this->model->export([$this->model->id_field, $this->model->title_field]);
-		foreach($res as $item) {
-			$data[] = ['id' => $item[$this->model->id_field], 'name' => $item[$this->model->title_field]];
-		}
-		
+        $res = $this->model->export([$this->model->id_field, $this->model->title_field]);
+        foreach ($res as $item) {
+            $data[] = ['id' => $item[$this->model->id_field], 'name' => $item[$this->model->title_field]];
+        }
+        
         if ($this->empty) {
             array_unshift($data, ['id' => 0, 'name' => $this->empty]);
         }

--- a/src/FormField/AutoComplete.php
+++ b/src/FormField/AutoComplete.php
@@ -128,10 +128,16 @@ class AutoComplete extends Input
             }
         }
 
-        $data = $this->model->export([$this->model->id_field, $this->model->title_field]);
-
+      
+        //fix #327: https://github.com/atk4/ui/issues/327
+        $data = [];
+		$res = $this->model->export([$this->model->id_field, $this->model->title_field]);
+		foreach($res as $item) {
+			$data[] = ['id' => $item[$this->model->id_field], 'name' => $item[$this->model->title_field]];
+		}
+		
         if ($this->empty) {
-            array_unshift($data, [$this->model->id_field => 0, $this->model->title_field => $this->empty]);
+            array_unshift($data, ['id' => 0, 'name' => $this->empty]);
         }
 
         $this->app->terminate(json_encode([


### PR DESCRIPTION
defined in init(), the Autocomplete field requires getting data 'name' and 'id'.
If model->title_field was not 'name' or model->id_field was not 'id', the AutoComplete broke.
I fixed getData() to always return the data as ['id' =>..., 'name' =>...]
A fix in init() was not possible as init() might not know the model.

fixes #327