### PR TITLE
feature/Error-modal(fix#318)

### DIFF
--- a/js/src/services/ApiService.js
+++ b/js/src/services/ApiService.js
@@ -148,12 +148,21 @@ class ApiService {
         //catch application error and display them in a new modal window.
         var m = $("<div>")
             .appendTo('body')
-            .addClass('ui scrolling modal')
+            .addClass('ui modal')
             .css('padding', '1em')
             .html(errorMsg);
+        var trace = m.find('.atk-stack').css({'max-height':'120px', 'overflow': 'scroll'}).hide();
+
+        if (trace.length > 0) {
+            m.prepend($('<div class="ui button">Trace</div>').on('click', function() {
+                trace.toggle();
+            }));
+        }
         m.modal({
             duration: 100,
-            allowMultiple: false,
+            allowMultiple: true,
+            detachable: true,
+            observeChanges: false,
             onHide: function() {
                 m.children().remove();
                 return true;

--- a/src/Form.php
+++ b/src/Form.php
@@ -375,13 +375,12 @@ class Form extends View //implements \ArrayAccess - temporarily so that our buil
 
         $cb->set(function () {
             $caught = function ($e) {
-                return new jsExpression('$([html]).modal("show")', [
-                    'html' => '<div class="ui fullscreen modal"> <i class="close icon"></i> <div class="header"> '.
-                    htmlspecialchars(get_class($e)).
-                    ' </div> <div class="content"> '.
-                    ($e instanceof \atk4\core\Exception ? $e->getHTML() : nl2br(htmlspecialchars($e->getMessage())))
-                    .' </div> </div>',
-                ]);
+                $html = '<div class="header"> '.
+                        htmlspecialchars(get_class($e)).
+                        ' </div> <div class="content"> '.
+                        ($e instanceof \atk4\core\Exception ? $e->getHTML() : nl2br(htmlspecialchars($e->getMessage())))
+                        .' </div>';
+                $this->app->terminate(json_encode(['success' => false, 'message' => $html]));
             };
 
             try {


### PR DESCRIPTION
## Enhance error display in modal by hiding the stack trace by default

This PR will change how modal display error, by hiding stack trace in order for Error modal to stay on top of other modals.
It allow for other modal to stay open and get a chance to re-save form data.

Stack trace view can be toggle on or off by clicking the Trace button on top of modal.
 - note that stack trace view has a maximum height and must be scroll to view it’s content.

### Note: 
seem like if modal content is longer than window content, i.e. when displaying trace content, semantic-ui will position the modal as ‘static’. This means that it will always show under other modal. 

## Important
For this pr to work, atk4JS need rebuild and Core Exception::getHtml() method need to be changed as follow:

```
public function getHtml()
{
//previous code…
//add class atk-stack to this div
$output .= '<div class="ui top attached segment atk-stack">';
$output .= '<div class="ui top attached label">Stack Trace</div>';
//previous code…
}
```


![trace-close](https://user-images.githubusercontent.com/2204478/34958011-054f0790-f9fe-11e7-908b-df94bfbcaf5e.png)
![trace-open](https://user-images.githubusercontent.com/2204478/34958016-08ccef4a-f9fe-11e7-9ecc-47055ece1aeb.png)
