### PR TITLE
feature/Error-Modal-Rev(fix#318)

### DIFF
--- a/demos/console.php
+++ b/demos/console.php
@@ -5,7 +5,6 @@ require 'init.php';
 class Test extends \atk4\data\Model
 {
     use \atk4\core\DebugTrait;
-    use \atk4\core\AppScopeTrait;
 
     public function generateReport()
     {

--- a/demos/form.php
+++ b/demos/form.php
@@ -108,8 +108,20 @@ $tab->add(['Header', 'Form shows Agile exceptions', 'size' => 2]);
 $form = $tab->add('Form');
 $form->addField('email');
 $form->onSubmit(function ($form) {
-    $form->factory([]);
+    throw new \atk4\core\Exception(['testing', 'arg1'=>'val1']);
+    return 'somehow it did not crash';
 });
+
+$form->add(['Button', 'Modal Test', 'secondary'])->on('click', $form->add('Modal')
+    ->set(function($p){ 
+        $form = $p->add('Form');
+        $form->addField('email');
+        $form->onSubmit(function ($form) {
+            throw new \atk4\core\Exception(['testing', 'arg1'=>'val1']);
+            return 'somehow it did not crash';
+        });
+    })->show());
+
 
 /////////////////////////////////////////////////////////////////////
 $tab = $tabs->addTab('Complex Examples');

--- a/demos/form.php
+++ b/demos/form.php
@@ -113,7 +113,7 @@ $form->onSubmit(function ($form) {
 });
 
 $form->add(['Button', 'Modal Test', 'secondary'])->on('click', $form->add('Modal')
-    ->set(function($p){ 
+    ->set(function ($p) {
         $form = $p->add('Form');
         $form->addField('email');
         $form->onSubmit(function ($form) {
@@ -121,7 +121,6 @@ $form->add(['Button', 'Modal Test', 'secondary'])->on('click', $form->add('Modal
             return 'somehow it did not crash';
         });
     })->show());
-
 
 /////////////////////////////////////////////////////////////////////
 $tab = $tabs->addTab('Complex Examples');

--- a/demos/form.php
+++ b/demos/form.php
@@ -113,14 +113,14 @@ $form->onSubmit(function ($form) {
 });
 
 $form->add(['Button', 'Modal Test', 'secondary'])->on('click', $form->add('Modal')
-    ->set(function ($p) {
-        $form = $p->add('Form');
-        $form->addField('email');
-        $form->onSubmit(function ($form) {
-            throw new \atk4\core\Exception(['testing', 'arg1'=>'val1']);
-            return 'somehow it did not crash';
-        });
-    })->show());
+                                                                    ->set(function ($p) {
+                                                                        $form = $p->add('Form');
+                                                                        $form->addField('email');
+                                                                        $form->onSubmit(function ($form) {
+                                                                            throw new \atk4\core\Exception(['testing', 'arg1'=>'val1']);
+                                                                            return 'somehow it did not crash';
+                                                                        });
+                                                                    })->show());
 
 /////////////////////////////////////////////////////////////////////
 $tab = $tabs->addTab('Complex Examples');

--- a/js/src/services/ApiService.js
+++ b/js/src/services/ApiService.js
@@ -179,7 +179,7 @@ class ApiService {
           'padding':'4px',
           'width': '100%',
           'height': '100%',
-          'position': 'absolute',
+          'position': 'fixed',
           'top': 0,
           'bottom': 0,
           'z-index': '100000',

--- a/js/src/services/ApiService.js
+++ b/js/src/services/ApiService.js
@@ -172,33 +172,37 @@ class ApiService {
    * @param errorMsg
    */
     showErrorWindow(errorMsg) {
-      var m = $('<div class="atk-exception">')
-        .appendTo('body')
+      var error = $('<div class="atk-exception">')
         .css({
           'padding':'8px',
           'background-color': 'rgba(0, 0, 0, 0.5)',
-          'padding':'1em',
-          'position': 'absolute',
-          'height': '100%',
+          'padding':'4px',
           'width': '100%',
-          'top': '0px',
-          'left': '0px',
+          'height': '100%',
+          'position': 'absolute',
+          'top': 0,
+          'bottom': 0,
           'z-index': '100000',
-          'overflow': 'scroll'
+          'overflow-y': 'scroll',
         })
         .html($('<div>')
           .css({
             'width': '70%',
-            'margin': 'auto',
+            'margin-top': '4%',
+            'margin-bottom': '4%',
+            'margin-left': 'auto',
+            'margin-right': 'auto',
             'background': 'white',
-            'padding': '4px'
+            'padding': '4px',
+            'overflow-x': 'scroll'
           }).html(errorMsg)
-          .prepend($('<i class="ui big close icon"></i>').css('float', 'right').click(function(){
+            .prepend($('<i class="ui big close icon"></i>').css('float', 'right').click(function(){
               var $this = $(this).parents('.atk-exception');
               $this.hide();
               $this.remove();
           }))
         );
+      error.appendTo('body');
     }
 }
 

--- a/js/src/services/ApiService.js
+++ b/js/src/services/ApiService.js
@@ -128,7 +128,11 @@ class ApiService {
     onFailure(response) {
         // if json is returned, it should contains the error within message property
         if (response.hasOwnProperty('success') && !response.success) {
-            apiService.showErrorModal(response.message);
+            if (response.hasOwnProperty('useWindow') && response.useWindow) {
+              apiService.showErrorWindow(response.message)
+            } else {
+              apiService.showErrorModal(response.message);
+            }
         } else {
             //check if we have html returned by server with <body> content.
             var body = response.match(/<body[^>]*>[\s\S]*<\/body>/gi);
@@ -163,6 +167,39 @@ class ApiService {
             .modal('refresh');
     }
 
+  /**
+   * Display App error in a separate window.
+   * @param errorMsg
+   */
+    showErrorWindow(errorMsg) {
+      var m = $('<div class="atk-exception">')
+        .appendTo('body')
+        .css({
+          'padding':'8px',
+          'background-color': 'rgba(0, 0, 0, 0.5)',
+          'padding':'1em',
+          'position': 'absolute',
+          'height': '100%',
+          'width': '100%',
+          'top': '0px',
+          'left': '0px',
+          'z-index': '100000',
+          'overflow': 'scroll'
+        })
+        .html($('<div>')
+          .css({
+            'width': '70%',
+            'margin': 'auto',
+            'background': 'white',
+            'padding': '4px'
+          }).html(errorMsg)
+          .prepend($('<i class="ui big close icon"></i>').css('float', 'right').click(function(){
+              var $this = $(this).parents('.atk-exception');
+              $this.hide();
+              $this.remove();
+          }))
+        );
+    }
 }
 
 const apiService = new ApiService();

--- a/src/Form.php
+++ b/src/Form.php
@@ -374,14 +374,13 @@ class Form extends View //implements \ArrayAccess - temporarily so that our buil
             ->setStyle(['display' => 'none']);
 
         $cb->set(function () {
-            $caught = function ($e) {
-                return new jsExpression('$([html]).modal("show")', [
-                    'html' => '<div class="ui fullscreen modal"> <i class="close icon"></i> <div class="header"> '.
-                    htmlspecialchars(get_class($e)).
-                    ' </div> <div class="content"> '.
-                    ($e instanceof \atk4\core\Exception ? $e->getHTML() : nl2br(htmlspecialchars($e->getMessage())))
-                    .' </div> </div>',
-                ]);
+            $caught = function ($e, $useWindow) {
+                $html = '<div class="header"> '.
+                        htmlspecialchars(get_class($e)).
+                        ' </div> <div class="content"> '.
+                        ($e instanceof \atk4\core\Exception ? $e->getHTML() : nl2br(htmlspecialchars($e->getMessage()))).
+                        ' </div>';
+                $this->app->terminate(json_encode(['success' => false, 'message' => $html, 'useWindow' => $useWindow]));
             };
 
             try {
@@ -416,9 +415,9 @@ class Form extends View //implements \ArrayAccess - temporarily so that our buil
 
                 return $response;
             } catch (\Error $e) {
-                return $caught($e);
+                return $caught($e, false);
             } catch (\Exception $e) {
-                return $caught($e);
+                return $caught($e, true);
             }
 
             return $response;


### PR DESCRIPTION
# Alternative to PR#329

When Agile UI encounters an error, it displays a modal window with stack trace and error details. If error happens WHILE modal window is opened, then the new window goes under the existing one causing problems (see #318). 

This patch will  generate a complete new window on error, by passing ui-sematic modal. It consumes entire screen, has it's own scrolling element and can be removed without accidentally closing existing Modal window. 

 - [x] Opens on fullscreen
 - [x] Handles scrollbar proprely
 - [ ] Captures ESC button
 - [x] Can be used for copy-pasting error easily
 - [ ] Looks great! 
 - [x] Has a demo

To try example, go to "demos/form.php" and use 3rd tab, then 3rd example titled "Form shows Agile exception". (both buttons)


Code example:
```
 $this->app->terminate(json_encode(['success' => false, 'message' => $html, 'useWindow' =>true]));
```

Backward compatible when error are send to modal as before.

## Note
To try this locally, switch to the branch and you must run JS build:

```
git fetch
git checkout 'feature/Error-Modal-Rev(fix#318)'
cd js
npm run build
```

empty browser cache.