### PR TITLE
feature/Modal observes changes

### DIFF
--- a/src/Modal.php
+++ b/src/Modal.php
@@ -148,6 +148,19 @@ class Modal extends View
     }
 
     /**
+     * Whether any change in modal DOM should automatically refresh cached positions.
+     * Allow modal window to add scrolling when adding content dynamically after modal creation.
+     *
+     * @return $this
+     */
+    public function observeChanges()
+    {
+        $this->setOptions(['observeChanges' => true]);
+
+        return $this;
+    }
+
+    /**
      * Add scrolling capability to modal.
      *
      * @return $this


### PR DESCRIPTION
## New method Modal::observeChanges()

Shortcut method to add observeChanges setting in semantic-ui modal.
observesChange setting allow for re positioning when DOM content changes in modal.

See example in issue: https://github.com/atk4/ui/issues/324