### PR TITLE
Feature/add dbconnect

### DIFF
--- a/docs/app.rst
+++ b/docs/app.rst
@@ -243,6 +243,18 @@ so well.  Example::
 
 No much magic in these methods.
 
+Database Connection
+-------------------
+
+.. php:method:: dbConnect(dsn)
+
+This method should be used instead of manually calling Persistence::connect. This will
+properly propogate Persistence's "api" property to $this, so that you can refrence::
+
+    $this->app->...
+
+inside your model code.
+
 Execution Termination
 ---------------------
 

--- a/docs/app.rst
+++ b/docs/app.rst
@@ -246,7 +246,9 @@ No much magic in these methods.
 Database Connection
 -------------------
 
-.. php:method:: dbConnect(dsn)
+.. php:method:: dbConnect(dsn, $user = null, $password = null, $args = [])
+
+(Arguments are identical to `Persistence::connect <http://agile-data.readthedocs.io/en/develop/persistence.html?highlight=connect#associating-with-persistence>`_.
 
 This method should be used instead of manually calling Persistence::connect. This will
 properly propogate Persistence's "api" property to $this, so that you can refrence::

--- a/src/App.php
+++ b/src/App.php
@@ -391,9 +391,9 @@ class App
 
     public $db = null;
 
-    public function dbConnect($dsn)
+    public function dbConnect($dsn, $user = null, $password = null, $args = [])
     {
-        return $this->db = $this->add(\atk4\data\Persistence::connect($dsn));
+        return $this->db = $this->add(\atk4\data\Persistence::connect($dsn, $user, $password, $args));
     }
 
     protected function getRequestURI()

--- a/src/App.php
+++ b/src/App.php
@@ -389,6 +389,13 @@ class App
         return $template;
     }
 
+    public $db = null;
+
+    public function dbConnect($dsn)
+    {
+        return $this->db = $this->add(\atk4\data\Persistence::connect($dsn));
+    }
+
     protected function getRequestURI()
     {
         if (isset($_SERVER['HTTP_X_REWRITE_URL'])) { // IIS


### PR DESCRIPTION
Implementation of `app::dbConnect()`. While this method has a sentimental value to ATK4 legacy users, it also has some some reasons to exist:

 - UI depends on Data anyway, so might as well introduce a method for it.
 - Most of the docs use $app->db = blah, but this property is not defined.
 - this method also does $app->add($db) meaning $db->app property is set.

This should be THE DEFAULT way now to connect to database from Agile UI, so if there is any
documentation, please update.

Workaround: `$app->add($app->db)`.