### PR TITLE
Fix/#356 Upload Field Set

### DIFF
--- a/demos/upload.php
+++ b/demos/upload.php
@@ -49,6 +49,7 @@ $field->onUpload(function ($files) use ($form, $field) {
         return $form->error('file', 'Error uploading file.');
     }
     $field->setFileId('a_token');
+
     return new atk4\ui\jsNotify(['content' => 'File is uploaded!', 'color' => 'green']);
 });
 

--- a/demos/upload.php
+++ b/demos/upload.php
@@ -5,7 +5,12 @@ require 'init.php';
 $form = $app->add('Form');
 
 $img = $form->addField('img', ['UploadImg', ['defaultSrc' => './images/default.png', 'placeholder' => 'Click to add an image.']]);
+//$img->set('afile-name');
+//$img->setThumbnailSrc('./images/logo.png');
+
 $field = $form->addField('file', ['Upload', ['accept' => ['.png', '.jpg']]]);
+
+$field->set('original-file-name', 'a_generated_token');
 
 $img->onDelete(function ($fileId) use ($img) {
     $img->clearThumbnail('./images/default.png');
@@ -24,6 +29,7 @@ $img->onUpload(function ($files) use ($form, $img) {
 
     $img->setThumbnailSrc('./images/logo.png');
     $img->setFileId('123456');
+    $img->set($files['name'].' (token: 123456)');
     //Do file processing here...
 
     /* This will get caught by jsCallback and show via modal. */

--- a/demos/upload.php
+++ b/demos/upload.php
@@ -3,14 +3,15 @@
 require 'init.php';
 
 $form = $app->add('Form');
-
 $img = $form->addField('img', ['UploadImg', ['defaultSrc' => './images/default.png', 'placeholder' => 'Click to add an image.']]);
-//$img->set('afile-name');
+
+//$img->set('a_new_token', 'an-img-file-name');
 //$img->setThumbnailSrc('./images/logo.png');
 
 $field = $form->addField('file', ['Upload', ['accept' => ['.png', '.jpg']]]);
 
-$field->set('original-file-name', 'a_generated_token');
+//$field->set('a_generated_token', 'a-file-name');
+//$field->set('a_generated_token');
 
 $img->onDelete(function ($fileId) use ($img) {
     $img->clearThumbnail('./images/default.png');
@@ -28,8 +29,8 @@ $img->onUpload(function ($files) use ($form, $img) {
     }
 
     $img->setThumbnailSrc('./images/logo.png');
-    $img->setFileId('123456');
-    $img->set($files['name'].' (token: 123456)');
+    $img->set('123456', $files['name'].' (token: 123456)');
+
     //Do file processing here...
 
     /* This will get caught by jsCallback and show via modal. */
@@ -43,11 +44,11 @@ $img->onUpload(function ($files) use ($form, $img) {
     return new atk4\ui\jsNotify(['content' => 'File is uploaded!', 'color' => 'green']);
 });
 
-$field->onUpload(function ($files) use ($form, $img) {
+$field->onUpload(function ($files) use ($form, $field) {
     if ($files === 'error') {
         return $form->error('file', 'Error uploading file.');
     }
-
+    $field->setFileId('a_token');
     return new atk4\ui\jsNotify(['content' => 'File is uploaded!', 'color' => 'green']);
 });
 

--- a/js/README.md
+++ b/js/README.md
@@ -97,6 +97,11 @@ This command will output the atkjs-ui.min.js file, also in /public folder.
 
 ## Release note
 
+### version 1.0.2
+
+  - update uploadField plugin.
+    - Allow initial value to be displayed.
+
 ### version 1.0.1
 
 - add new function for exporting package version number;

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atkjs-ui",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Agile Toolkit Javascript library.",
   "main": "lib/atkjs-ui.js",
   "scripts": {

--- a/js/src/plugins/fileUpload.js
+++ b/js/src/plugins/fileUpload.js
@@ -4,7 +4,6 @@ import uploadService from "../services/UploadService";
 export default class fileUpload extends atkPlugin {
 
   main() {
-    this.$el.data().fileId = this.settings.id;
     this.textInput = this.$el.find('input[type="text"]');
     this.hiddenInput = this.$el.find('input[type="hidden"]');
 
@@ -31,10 +30,28 @@ export default class fileUpload extends atkPlugin {
     })
       .hide();
 
-    // check for existing file input value and adjust state accordingly.
-    if (this.hiddenInput.val()) {
-      this.textInput.val(this.hiddenInput.val());
+    this.$el.data().fileId = this.settings.file.id;
+    this.hiddenInput.val(this.settings.file.id);
+    this.textInput.val(this.settings.file.name);
+    if (this.settings.file.id) {
       this.setState('delete');
+    }
+  }
+
+  /**
+   * Update input value.
+   *
+   * @param fileId
+   * @param fileName
+   */
+  updateField(fileId, fileName) {
+    this.$el.data().fileId = fileId;
+    this.hiddenInput.val(fileId);
+
+    if (fileName === '' || typeof fileName === 'undefined' || fileName === null) {
+      this.textInput.val(fileId);
+    } else {
+      this.textInput.val(fileName);
     }
   }
 
@@ -76,10 +93,6 @@ export default class fileUpload extends atkPlugin {
         //that.doFileUpload(e.target.files[0]);
         that.doFileUpload(e.target.files);
       }
-    });
-
-    this.hiddenInput.on('updateInput', function(e) {
-      that.textInput.val(e.target.value);
     });
   }
 
@@ -132,7 +145,7 @@ export default class fileUpload extends atkPlugin {
       if (that.settings.submit) {
         $('#'+that.settings.submit).removeClass('disabled');
       }
-    }
+    };
 
     // setup progress bar update via xhr.
     let xhrCb = function() {
@@ -144,7 +157,7 @@ export default class fileUpload extends atkPlugin {
         }
       }, false);
       return xhr;
-    }
+    };
 
     that.bar.show();
     uploadService.uploadFiles(
@@ -193,7 +206,7 @@ export default class fileUpload extends atkPlugin {
 
 fileUpload.DEFAULTS = {
   uri: null,
-  id: null,
+  file: {id: null, name: null},
   uri_options: {},
   hasFocus: true,
   action: null,

--- a/js/src/plugins/fileUpload.js
+++ b/js/src/plugins/fileUpload.js
@@ -4,8 +4,7 @@ import uploadService from "../services/UploadService";
 export default class fileUpload extends atkPlugin {
 
   main() {
-    const that = this;
-
+    this.$el.data().fileId = this.settings.id;
     this.textInput = this.$el.find('input[type="text"]');
     this.hiddenInput = this.$el.find('input[type="hidden"]');
 
@@ -13,15 +12,37 @@ export default class fileUpload extends atkPlugin {
     this.action = $('#' + this.settings.action);
     this.actionContent = this.action.html();
 
-    this.bar = this.$el.find('.progress')
-      .progress({
-        text : {
-          percent: '{percent}%',
-          active: '{percent}%',
-        }
-      })
+    this.bar = this.$el.find('.progress');
+    this.setEventHandler();
+    this.setInitialState();
+
+  }
+
+  /**
+   * Setup field initial state.
+   */
+  setInitialState() {
+    // Set progress bar.
+    this.bar.progress({
+      text : {
+        percent: '{percent}%',
+        active: '{percent}%',
+      }
+    })
       .hide();
 
+    // check for existing file input value and adjust state accordingly.
+    if (this.hiddenInput.val()) {
+      this.textInput.val(this.hiddenInput.val());
+      this.setState('delete');
+    }
+  }
+
+  /**
+   * Add event handler to input element.
+   */
+  setEventHandler() {
+    const that = this;
     // Open file dialog on focus.
     if (this.settings.hasFocus) {
       this.textInput.on('focus', function(e) {
@@ -41,7 +62,7 @@ export default class fileUpload extends atkPlugin {
         // Check if that id exist and send it with
         // delete callback, If not, default to file name.
         let id = that.$el.data().fileId;
-        if (id === '' || typeof id === 'undefined') {
+        if (id === '' || typeof id === 'undefined' || id === null) {
           id = that.textInput.val();
         }
         that.doFileDelete(id);
@@ -55,7 +76,11 @@ export default class fileUpload extends atkPlugin {
         //that.doFileUpload(e.target.files[0]);
         that.doFileUpload(e.target.files);
       }
-    })
+    });
+
+    this.hiddenInput.on('updateInput', function(e) {
+      that.textInput.val(e.target.value);
+    });
   }
 
   /**
@@ -103,6 +128,7 @@ export default class fileUpload extends atkPlugin {
         that.bar.progress('set label', that.settings.completeLabel);
         that.setState('delete');
       }
+
       if (that.settings.submit) {
         $('#'+that.settings.submit).removeClass('disabled');
       }
@@ -167,6 +193,7 @@ export default class fileUpload extends atkPlugin {
 
 fileUpload.DEFAULTS = {
   uri: null,
+  id: null,
   uri_options: {},
   hasFocus: true,
   action: null,

--- a/src/FormField/Upload.php
+++ b/src/FormField/Upload.php
@@ -7,8 +7,7 @@ use atk4\ui\Template;
 use atk4\ui\View;
 
 /**
- * Class Upload
- *
+ * Class Upload.
  */
 class Upload extends Input
 {

--- a/src/FormField/Upload.php
+++ b/src/FormField/Upload.php
@@ -209,7 +209,7 @@ class Upload extends Input
 
                         return $this->jsActions;
                     });
-                } elseif ($action === null || $files['file']['error']) {
+                } elseif ($action === null || isset($files['file']['error'])) {
                     $this->cb->set(function () use ($fx, $files) {
                         return call_user_func($fx, 'error');
                     });
@@ -242,7 +242,7 @@ class Upload extends Input
         $this->js(true)->atkFileUpload([
             'uri'      => $this->cb->getURL(),
             'action'   => $this->action->name,
-            'file'     => ['id' => $this->fileId, 'name' => $this->getInputValue()],
+            'file'     => ['id' => $this->fileId ?: $this->field->get(), 'name' => $this->getInputValue()],
             'hasFocus' => $this->hasFocusEnable,
             'submit'   => ($this->form->buttonSave) ? $this->form->buttonSave->name : null,
         ]);

--- a/src/FormField/Upload.php
+++ b/src/FormField/Upload.php
@@ -88,6 +88,26 @@ class Upload extends Input
     }
 
     /**
+     * Allow to set file name and file id.
+     *  - Value will be display to user, ex: file name.
+     *  - fileId is the file id send when using onDelete callback.
+     *      If null, onDelete receive the file name.
+     *
+     * @param mixed|null  $value  // Field value, display to user.
+     * @param string|null $fileId // Field id.
+     *
+     * @return $this|void
+     */
+    public function set($value, $fileId = null)
+    {
+        if ($fileId) {
+            $this->setFileId($fileId);
+        }
+
+        return parent::set($value);
+    }
+
+    /**
      * Set file id.
      *
      * @param $id
@@ -145,14 +165,18 @@ class Upload extends Input
             if ($this->cb->triggered()) {
                 $action = @$_POST['action'];
                 if ($files = @$_FILES) {
+                    //set fileId to file name as default.
                     $this->fileId = $files['file']['name'];
+                    // display file name to user as default.
+                    $this->set($this->fileId);
                 }
                 if ($action === 'upload' && !$files['file']['error']) {
                     $this->cb->set(function () use ($fx, $files) {
                         $this->addJsAction(call_user_func_array($fx, $files));
+                        $value = $this->field ? $this->field->get() : $this->content;
                         $this->addJsAction([
                             $this->js()->data('fileId', $this->fileId),
-                            $this->jsInput()->val($this->fileId),
+                            $this->jsInput()->val($value)->trigger('updateInput'),
                         ]);
 
                         return $this->jsActions;
@@ -189,6 +213,7 @@ class Upload extends Input
         $this->js(true)->atkFileUpload([
             'uri'      => $this->cb->getURL(),
             'action'   => $this->action->name,
+            'id'       => $this->fileId,
             'hasFocus' => $this->hasFocusEnable,
             'submit'   => ($this->form->buttonSave) ? $this->form->buttonSave->name : null,
         ]);

--- a/src/FormField/Upload.php
+++ b/src/FormField/Upload.php
@@ -102,7 +102,7 @@ class Upload extends Input
      *
      * @return $this|void
      */
-    public function set($fileId, $fileName = null, $junk = null)
+    public function set($fileId = null, $fileName = null, $junk = null)
     {
         $this->setFileId($fileId);
 

--- a/src/FormField/UploadImg.php
+++ b/src/FormField/UploadImg.php
@@ -14,6 +14,13 @@ class UploadImg extends Upload
     public $thumbnail = null;
 
     /**
+     * The image src for thumbnail.
+     *
+     * @var string|null
+     */
+    public $src = null;
+
+    /**
      * The template region where to add the thumbnail view.
      * Default to AfterAfterInput.
      *
@@ -54,6 +61,7 @@ class UploadImg extends Upload
      */
     public function setThumbnailSrc($src)
     {
+        $this->src = $src;
         $action = $this->thumbnail->js();
         $action->attr('src', $src);
         $this->addJSAction($action);
@@ -74,5 +82,11 @@ class UploadImg extends Upload
             $action->removeAttr('src');
         }
         $this->addJSAction($action);
+    }
+
+    public function renderView()
+    {
+        $this->src ? $this->thumbnail->js(true)->attr('src', $this->src) : null;
+        parent::renderView();
     }
 }

--- a/src/FormField/UploadImg.php
+++ b/src/FormField/UploadImg.php
@@ -14,13 +14,6 @@ class UploadImg extends Upload
     public $thumbnail = null;
 
     /**
-     * The image src for thumbnail.
-     *
-     * @var string|null
-     */
-    public $src = null;
-
-    /**
      * The template region where to add the thumbnail view.
      * Default to AfterAfterInput.
      *
@@ -44,11 +37,12 @@ class UploadImg extends Upload
         }
 
         if (!$this->thumbnail) {
-            $this->thumbnail = new View(['element'=>'img', 'class' => ['right', 'floated', 'image'], 'ui' => true]);
+            $this->thumbnail = (new View(['element'=>'img', 'class' => ['right', 'floated', 'image'], 'ui' => true]))
+                                    ->setAttr(['width' => '36px', 'height' => '36px']);
         }
 
         if ($this->defaultSrc) {
-            $this->thumbnail->setAttr(['src' => $this->defaultSrc, 'width' => '36px', 'height' => '36px']);
+            $this->thumbnail->setAttr(['src' => $this->defaultSrc]);
         }
 
         $this->add($this->thumbnail, $this->thumnailRegion);
@@ -61,7 +55,7 @@ class UploadImg extends Upload
      */
     public function setThumbnailSrc($src)
     {
-        $this->src = $src;
+        $this->thumbnail->setAttr(['src' => $src]);
         $action = $this->thumbnail->js();
         $action->attr('src', $src);
         $this->addJSAction($action);
@@ -82,11 +76,5 @@ class UploadImg extends Upload
             $action->removeAttr('src');
         }
         $this->addJSAction($action);
-    }
-
-    public function renderView()
-    {
-        $this->src ? $this->thumbnail->js(true)->attr('src', $this->src) : null;
-        parent::renderView();
     }
 }


### PR DESCRIPTION
## Allow to set field value on page load.

$field->set(‘name’, ‘token’) 

Enable setting field name and token to specify pre existing file name and/or token.

```
   /**
     * Allow to set file id and file name
     *  - fileId will be the file id sent with onDelete callback.
     *  - fileName is the field value display to user.
     *
     * @param string      $fileId   // Field id for onDelete Callback.
     * @param string|null $fileName // Field name display to user.
     * @param mixed       $junk
     *
     * @return $this|void
     */
    public function set($fileId, $fileName = null, $junk = null)
    {
        $this->setFileId($fileId);

        if (!$fileName) {
            $fileName = $fileId;
        }

        return $this->setInput($fileName, $junk);
    }
```
## Enable to set thumbnail src for pre existing field.

```
$img->setThumbnailSrc('./images/logo.png');
```

### Js package need to be rebuild.
