### PR TITLE
Fix/#364 #270

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -27,6 +27,16 @@ class FeatureContext extends RawMinkContext implements Context
     }
 
     /**
+     * @When I use form with button :arg1
+     */
+    public function iUseFormWithButton($arg1)
+    {
+        $button = $this->getSession()->getPage()->find('xpath', '//button[text()="'.$arg1.'"]');
+        $this->button_id = $button->getAttribute('id');
+        $button->click();
+    }
+
+    /**
      * @When I press button :arg1
      */
     public function iPressButton($arg1)

--- a/features/form.feature
+++ b/features/form.feature
@@ -6,6 +6,6 @@ Feature: Form
 Scenario:
  Given I am on "form.php"
  When I fill in "email" with "foo@bar"
- And I press button "Subscribe"
+ And I use form with button "Subscribe"
  Then I should see "Subscribed foo@bar to newsletter."
 

--- a/js/README.md
+++ b/js/README.md
@@ -101,6 +101,7 @@ This command will output the atkjs-ui.min.js file, also in /public folder.
 
   - update uploadField plugin.
     - Allow initial value to be displayed.
+  - add Autofocus to modal when using form.
 
 ### version 1.0.1
 

--- a/js/src/services/ModalService.js
+++ b/js/src/services/ModalService.js
@@ -71,6 +71,9 @@ class ModalService {
                         response.isServiceError = true;
                         response.message = 'Modal service error: Unable to replace atk-dialog content in modal from server response. Empty Content.';
                     } else {
+                        if ($modal.modal.settings.autofocus) {
+                            modalService.doAutoFocus($modal);
+                        }
                         $modal.modal('refresh');
                         //content is replace no need to do it in api
                         response.id = null;
@@ -101,6 +104,16 @@ class ModalService {
         this.modals.pop();
         this.setCloseTriggerEventInModals();
         this.hideShowCloseIcon();
+    }
+
+    doAutoFocus(modal) {
+      let inputs = modal.find('[tabindex], :input').filter(':visible');
+      let autofocus = inputs.filter('[autofocus]');
+      let input = (autofocus.length > 0)? autofocus.first() : inputs.first();
+
+      if(input.length > 0) {
+        input.focus().select();
+      }
     }
 
     /**

--- a/src/Form.php
+++ b/src/Form.php
@@ -97,6 +97,7 @@ class Form extends View //implements \ArrayAccess - temporarily so that our buil
 
         // Layout needs to have a save button
         $this->buttonSave = $this->layout->addButton(['Save', 'primary']);
+        $this->buttonSave->setElement('button');
         $this->buttonSave->on('click', $this->js()->form('submit'));
     }
 


### PR DESCRIPTION
Will autofocus on first field in modal using form.

### Change on ModalService

On dynamic modal, like when use in CRUD, the onShow and onVisible callback are fire prior modal content is loaded.
Therefore semantic-ui modal autofocus has no effects. 

To fix this, we need to manually trigger our autofocus handler function (doAutoFocus) after content is loaded in modal.

The doAutoFocus function is call when modal autofocus is set to true. True is also the default value for modal settings.

### Change on Form.php

To allow for save button to be focusable, the html tag for button is change from div to button. 

### Note

js package need to be rebuild.
