### PR TITLE
Feature/jsSearch-for-grid

### DIFF
--- a/demos/jssearch.php
+++ b/demos/jssearch.php
@@ -1,0 +1,10 @@
+<?php
+
+require 'init.php';
+require 'database.php';
+
+$g = $app->add('Grid');
+$g->setModel(new Country($db));
+$g->addJsSearch();
+
+$g->ipp = 10;

--- a/js/src/plugin.js
+++ b/js/src/plugin.js
@@ -6,6 +6,7 @@ import ajaxec from "./plugins/ajaxec";
 import createModal from "./plugins/createModal";
 import notify from "./plugins/notify";
 import fileUpload from "./plugins/fileUpload";
+import jsSearch from "./plugins/jsSearch";
 
 /**
  * Generate a jQuery plugin
@@ -40,6 +41,7 @@ plugin('CreateModal', createModal);
 plugin('Notify', notify, true);
 plugin('ServerEvent', serverEvent, true);
 plugin('FileUpload', fileUpload);
+plugin('JsSearch', jsSearch);
 
 export default function plugin(name, className, shortHand = false) {
         // Add atk namespace to jQuery global space.

--- a/js/src/plugins/jsSearch.js
+++ b/js/src/plugins/jsSearch.js
@@ -1,0 +1,77 @@
+import atkPlugin from 'plugins/atkPlugin';
+
+export default class jsSearch extends atkPlugin {
+
+  main() {
+    this.filterState = false;
+    this.textInput = this.$el.find('input[type="text"]');
+    this.searchAction = this.$el.find('.atk-action');
+    this.searchContent = this.searchAction.html();
+
+    this.setAction();
+  }
+
+  /**
+   * Set text input and button event handler.
+   */
+  setAction() {
+    const that = this;
+    this.textInput.on('keydown', function(e) {
+      if (e.keyCode === 13 && e.target.value) {
+        that.setFilterState(true);
+        that.doSearch(that.settings.uri, $.extend({}, that.settings.uri_options, {'_q' : e.target.value}));
+      }
+      if ((e.keyCode === 27 && e.target.value) || (e.keyCode === 13 && e.target.value === '')) {
+        that.setFilterState(false);
+        that.doSearch(that.settings.uri, that.settings.uri_options);
+      }
+    });
+
+    this.searchAction.on('click', function(e){
+      if (that.filterState){
+        that.setFilterState(false);
+        that.doSearch(that.settings.uri, that.settings.uri_options);
+      }
+
+      if (!that.filterState && that.textInput.val()) {
+        that.setFilterState(true);
+        that.doSearch(that.settings.uri, $.extend({}, that.settings.uri_options, {'_q' :that.textInput.val()}));
+      }
+    });
+  }
+
+  setFilterState(isFilterOn) {
+    if (isFilterOn) {
+      this.searchAction.html(this.getEraseContent());
+    } else {
+      this.searchAction.html(this.searchContent);
+      this.textInput.val('');
+    }
+    this.filterState = isFilterOn;
+  }
+
+  doSearch(uri, options) {
+    this.$el.api({
+      on: 'now',
+      url: uri,
+      data: options,
+      method: 'GET',
+      obj: this.$el,
+      stateContext: this.searchAction,
+    });
+  }
+
+  /**
+   * Return the html content for erase action button.
+   *
+   * @returns {string}
+   */
+  getEraseContent() {
+    return `<i class="red remove icon" style=""></i>`;
+  }
+}
+
+jsSearch.DEFAULTS = {
+  uri: null,
+  uri_options: {},
+};

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -228,7 +228,7 @@ class Grid extends View
             $this->table->sort_order = $desc ? 'descending' : 'ascending';
         }
 
-        $this->table->on('click', 'thead>tr>th', new jsReload($this, [$this->name.'_sort' => (new jQuery())->data('column')]));
+        $this->table->on('click', 'thead>tr>th', new jsReload($this->container, [$this->name.'_sort' => (new jQuery())->data('column')]));
     }
 
     public function setModel(\atk4\data\Model $model, $columns = null)

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -69,22 +69,32 @@ class Grid extends View
      */
     public $table = null;
 
+    /**
+     * The container for table and paginator.
+     *
+     * @var View
+     */
+    public $container = null;
+
     public $defaultTemplate = 'grid.html';
 
     public function init()
     {
         parent::init();
 
+        $this->container = $this->add(['View', 'ui'=>'', 'template' => new Template('<div id="{$_id}"><div class="ui table atk-overflow-auto">{$Table}</div>{$Paginator}</div>')]);
+
         if (is_null($this->menu)) {
             $this->menu = $this->add(['Menu', 'activate_on_click' => false], 'Menu');
         }
 
+
         if (is_null($this->table)) {
-            $this->table = $this->add(['Table', 'very compact striped single line', 'reload' => $this], 'Table');
+            $this->table = $this->container->add(['Table', 'very compact striped single line', 'reload' => $this], 'Table');
         }
 
         if (is_null($this->paginator)) {
-            $seg = $this->add(['View'], 'Paginator')->addStyle('text-align', 'center');
+            $seg = $this->container->add(['View'], 'Paginator')->addStyle('text-align', 'center');
             $this->paginator = $seg->add(['Paginator', 'reload' => $this]);
         }
     }
@@ -114,6 +124,42 @@ class Grid extends View
         return $this->menu->addItem()->add(new Button($text));
     }
 
+    /**
+     * Add Search input field using js action.
+     *
+     * @param array $fields
+     *
+     * @throws Exception
+     * @throws \atk4\data\Exception
+     */
+    public function addJsSearch($fields = [])
+    {
+        if (!$fields) {
+            $fields = [$this->model->title_field];
+        }
+
+        if (!$this->menu) {
+            throw new Exception(['Unable to add QuickSearch without Menu']);
+        }
+
+        $view = $this->menu
+            ->addMenuRight()->addItem()->setElement('div')
+            ->add('View');
+
+        $this->quickSearch = $view->add(['jsSearch', 'reload' => $this->container]);
+
+        if (isset($_GET['_q'])) {
+            $q = $_GET['_q'];
+
+            $cond = [];
+            foreach ($fields as $field) {
+                $cond[] = [$field, 'like', '%'.$q.'%'];
+            }
+            $this->model->addCondition($cond);
+            $this->app->stickyGet('_q', $q);
+        }
+    }
+
     public function addQuickSearch($fields = [])
     {
         if (!$fields) {
@@ -140,6 +186,7 @@ class Grid extends View
                 $cond[] = [$field, 'like', '%'.$q.'%'];
             }
             $this->model->addCondition($cond);
+            $this->app->stickyGet($this->name.'_q', $q);
         }
     }
 
@@ -158,7 +205,7 @@ class Grid extends View
             $this->actions = $this->table->addColumn(null, 'Actions');
         }
 
-        return $this->actions->addModal($button, $title, $callback);
+        return $this->actions->addModal($button, $title, $callback, $this);
     }
 
     /**
@@ -214,7 +261,7 @@ class Grid extends View
     {
         // bind with paginator
         if ($this->paginator) {
-            $this->paginator->reload = $this;
+            $this->paginator->reload = $this->container;
 
             $this->paginator->setTotal(ceil($this->model->action('count')->getOne() / $this->ipp));
 

--- a/src/TableColumn/Actions.php
+++ b/src/TableColumn/Actions.php
@@ -41,9 +41,14 @@ class Actions extends Generic
      * Adds a new button which will open a modal dialog and dynamically
      * load contents through $callback. Will pass a virtual page.
      */
-    public function addModal($button, $title, $callback)
+    public function addModal($button, $title, $callback, $owner = null)
     {
-        $modal = $this->owner->owner->add(['Modal', 'title'=>$title]);
+        if (!$owner) {
+            $modal = $this->owner->owner->add(['Modal', 'title'=>$title]);
+        } else {
+            $modal = $owner->add(['Modal', 'title'=>$title]);
+        }
+
         $modal->set(function ($t) use ($callback) {
             call_user_func($callback, $t, $this->app->stickyGet($this->name));
         });

--- a/src/jsSearch.php
+++ b/src/jsSearch.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * A Search input field that will reload View
+ * using the view->url with a _q arguments attach to url.
+ */
+
+namespace atk4\ui;
+
+class jsSearch extends View
+{
+
+    /**
+     * The View to reload using this jsSearch.
+     *
+     * @var View
+     */
+    public $reload = null;
+
+    /**
+     * The input field.
+     *
+     * @var FormField\Line
+     */
+    public $input = null;
+
+    public function init()
+    {
+        parent::init();
+
+        $this->input = $this->add(new \atk4\ui\FormField\Line(['action' => new \atk4\ui\Button(['icon' => 'search', 'ui' => 'button atk-action'])]));
+    }
+
+    public function renderView()
+    {
+        $this->js(true)->atkJsSearch(['uri' => $this->reload->url(), 'uri_options' => ['__atk_reload'=>$this->reload->name]]);
+        parent::renderView();
+    }
+}

--- a/template/semantic-ui/grid.html
+++ b/template/semantic-ui/grid.html
@@ -1,4 +1,2 @@
-<{_element}div{/} id="{$_id}" class="{_ui}ui{/} {$class} {_class}{/}" style="{$style}" {$attributes}>
-{$Menu}
-{$Content}
-<div class="ui table atk-overflow-auto">{$Table}</div>{$Paginator}</{_element}div{/}>
+<{_element}div{/} id="{$_id}" class="{_ui}ui{/} {$class} {_class}{/}" style="{$style}" {$attributes}>{$Menu}
+{$Content}</{_element}div{/}>

--- a/template/semantic-ui/grid.pug
+++ b/template/semantic-ui/grid.pug
@@ -1,7 +1,4 @@
 <{_element}div{/} id="{$_id}" class="{_ui}ui{/} {$class} {_class}{/}" style="{$style}" {$attributes}>
 | {$Menu}
 | {$Content}
-.ui.table.atk-overflow-auto
-  | {$Table}
-| {$Paginator}
 </{_element}div{/}>


### PR DESCRIPTION
## Add jsSearch input field for grid.

This is an attempt to fix issue #365 and another alternative to existing QuickSearch for grid.

A new input field that will reload grid dynamically using semantic-ui api. 

You can test using demos/jssearch.php

### Field feature

- reload filtered grid on pressing enter;
- using escape, when in input field, will clear field and reload grid without filter data;
- display loading indicator when loading data;
- display button erase icon when data is filtered;
- display button search icon when not filtered;
- button is also clickable;

## Grid modification

Grid had to be modified to allow reloading of Grid and Paginator only, ie without reloading menu bar. A new container view that contain Grid and paginator is added, so the jsSearch action will reload container view.

The grid is backward compatible with the old QuickSearch

## Fix

This PR also fix paginator when data is filtered in new jsSearch or existing QuickSearch.

## New js plugin

This pr use a new js plugin atkJsSearch that perform user action on new jsSearch input field.

## Note

atkjs need to be rebuild. 
Atn: this PR does not included fix in modal view. Better to merge this PR after Modal input focus fix.