### PR TITLE
Feature/add form label support

### DIFF
--- a/demos/field2.php
+++ b/demos/field2.php
@@ -10,13 +10,20 @@ $field = $app->add(new \atk4\ui\FormField\Line());
 
 $field->set('hello world');
 
-$button = $app->add(['Button', 'check value']);
+$button = $field->addAction('check value');
 $button->on('click', new \atk4\ui\jsExpression('alert("field value is: "+[])', [$field->jsInput()->val()]));
 
 $app->add(['Header', 'Line in a Form']);
 $form = $app->add('Form');
-$field = $form->addField('name', new \atk4\ui\FormField\Line());
+$field = $form->addField('name', ['Line', 'hint'=>'this is sample hint that escapes <html> characters']);
 $field->set('value in a form');
+
+$field = $form->addField('surname', new \atk4\ui\FormField\Line([
+    'hint'=>new \atk4\ui\Text(
+        'Click <a href="http://example.com/" target="_blank">here</a>'
+    )
+]));
+
 $form->onSubmit(function ($f) {
     return $f->model['name'];
 });

--- a/demos/field2.php
+++ b/demos/field2.php
@@ -16,16 +16,15 @@ $button->on('click', new \atk4\ui\jsExpression('alert("field value is: "+[])', [
 $app->add(['Header', 'Line in a Form']);
 $form = $app->add('Form');
 
-$field = $form->addField('Title', null, ['values'=>['Mr','Mrs','Miss'], 'ui'=>['hint'=>'select one']]);
+$field = $form->addField('Title', null, ['values'=>['Mr', 'Mrs', 'Miss'], 'ui'=>['hint'=>'select one']]);
 
 $field = $form->addField('name', ['Line', 'hint'=>'this is sample hint that escapes <html> characters']);
 $field->set('value in a form');
 
-
 $field = $form->addField('surname', new \atk4\ui\FormField\Line([
-    'hint'=>['template'=>new \atk4\ui\Template(
+    'hint'=> ['template'=> new \atk4\ui\Template(
         'Click <a href="http://example.com/" target="_blank">here</a>'
-    )]
+    )],
 ]));
 
 $form->onSubmit(function ($f) {

--- a/demos/field2.php
+++ b/demos/field2.php
@@ -19,9 +19,9 @@ $field = $form->addField('name', ['Line', 'hint'=>'this is sample hint that esca
 $field->set('value in a form');
 
 $field = $form->addField('surname', new \atk4\ui\FormField\Line([
-    'hint'=>new \atk4\ui\Text(
+    'hint'=> new \atk4\ui\Text(
         'Click <a href="http://example.com/" target="_blank">here</a>'
-    )
+    ),
 ]));
 
 $form->onSubmit(function ($f) {

--- a/demos/field2.php
+++ b/demos/field2.php
@@ -15,13 +15,17 @@ $button->on('click', new \atk4\ui\jsExpression('alert("field value is: "+[])', [
 
 $app->add(['Header', 'Line in a Form']);
 $form = $app->add('Form');
+
+$field = $form->addField('Title', null, ['values'=>['Mr','Mrs','Miss'], 'ui'=>['hint'=>'select one']]);
+
 $field = $form->addField('name', ['Line', 'hint'=>'this is sample hint that escapes <html> characters']);
 $field->set('value in a form');
 
+
 $field = $form->addField('surname', new \atk4\ui\FormField\Line([
-    'hint'=> new \atk4\ui\Text(
+    'hint'=>['template'=>new \atk4\ui\Template(
         'Click <a href="http://example.com/" target="_blank">here</a>'
-    ),
+    )]
 ]));
 
 $form->onSubmit(function ($f) {

--- a/docs/field.rst
+++ b/docs/field.rst
@@ -91,6 +91,36 @@ properly:
  - Input (abstract, extends Generic) - Easiest since it alrady implements `<input>` and various
    ways to attach button to the input with markup of Semantic UI field.
 
+Hints
+-----
+
+.. php:attr: hint
+
+When Field appears in a Form, then you can specify a Hint also. It appears below the field and
+although it intends to be "extra info" or "extra help" due to current limitation of Semantic UI
+the only way we can display hint is using a gray bubble. In the future version of Agile UI we
+will update to use a more suitable control.
+
+Hint can be specified either inside field decorator seed or inside the Field::ui attribute::
+
+
+    $form->addField('title', null, ['values'=>['Mr', 'Mrs', 'Miss'], 'hint'=>'select one']);
+
+    $form->addField('name', ['hint'=>'Full Name Only']);
+
+Text will have HTML characters escaped. You may also specify hint value as an object::
+
+    $form->addField('name', ['hint'=>new \atk4\ui\Text(
+        'Click <a href="http://example.com/" target="_blank">here</a>'
+    )]);
+
+or you can inject a view with a custom template::
+
+    $form->addField('name', ['hint'=>['template'=>new \atk4\ui\Template(
+        'Click <a href="http://example.com/" target="_blank">here</a>'
+    )]]);
+
+
 Relatioship with Model
 ======================
 

--- a/src/Form.php
+++ b/src/Form.php
@@ -289,7 +289,7 @@ class Form extends View //implements \ArrayAccess - temporarily so that our buil
             throw new Exception(['Argument 1 for decoratorFactory must be \atk4\data\Field or null', 'f' => $f]);
         }
 
-        $fallback_seed = 'Line';
+        $fallback_seed = ['Line'];
 
         if ($f->enum) {
             $fallback_seed = ['DropDown', 'values' => array_combine($f->enum, $f->enum)];
@@ -297,6 +297,10 @@ class Form extends View //implements \ArrayAccess - temporarily so that our buil
             $fallback_seed = ['DropDown', 'values' => $f->values];
         } elseif (isset($f->reference)) {
             $fallback_seed = ['DropDown', 'model' => $f->reference->refModel()];
+        }
+
+        if (isset($f->ui['hint'])) {
+            $fallback_seed['hint'] = $f->ui['hint'];
         }
 
         $seed = $this->mergeSeeds(

--- a/src/FormField/Generic.php
+++ b/src/FormField/Generic.php
@@ -43,7 +43,7 @@ class Generic extends View
      * Placed as a pointing label below the field. This only works when FormField appears in a form. You can also
      * set this to object, such as 'Text' otherwise HTML characters are escaped.
      *
-     * @var string|\atk4\ui\View
+     * @var string|\atk4\ui\View|array
      */
     public $hint = null;
 

--- a/src/FormField/Generic.php
+++ b/src/FormField/Generic.php
@@ -39,6 +39,12 @@ class Generic extends View
      */
     public $caption = null;
 
+    /**
+     * Placed as a pointing label below the field. This only works when FormField appears in a form. You can also
+     * set this to object, such as 'Text' otherwise HTML characters are escaped.
+     */
+    public $hint = null;
+
     public function init()
     {
         parent::init();

--- a/src/FormField/Generic.php
+++ b/src/FormField/Generic.php
@@ -42,6 +42,8 @@ class Generic extends View
     /**
      * Placed as a pointing label below the field. This only works when FormField appears in a form. You can also
      * set this to object, such as 'Text' otherwise HTML characters are escaped.
+     *
+     * @var string|\atk4\ui\View
      */
     public $hint = null;
 

--- a/src/FormLayout/Generic.php
+++ b/src/FormLayout/Generic.php
@@ -274,7 +274,7 @@ class Generic extends View
 
             if ($el->hint) {
                 $hint = new \atk4\ui\Label([null, 'pointing', 'id'=>$el->id.'_hint']);
-                if (is_object($el->hint)) {
+                if (is_object($el->hint) || is_array($el->hint)) {
                     $hint->add($el->hint);
                 } else {
                     $hint->set($el->hint);

--- a/src/FormLayout/Generic.php
+++ b/src/FormLayout/Generic.php
@@ -272,6 +272,16 @@ class Generic extends View
                 $template->append('field_class', $el->width.' wide ');
             }
 
+            if ($el->hint) {
+                $hint = new \atk4\ui\Label([null, 'pointing', 'id'=>$el->id.'_hint']);
+                if (is_object($el->hint)) {
+                    $hint->add($el->hint);
+                } else {
+                    $hint->set($el->hint);
+                }
+                $template->setHTML('Hint', $hint->getHTML());
+            }
+
             $this->template->appendHTML('Content', $template->render());
         }
 

--- a/template/semantic-ui/formlayout/generic.html
+++ b/template/semantic-ui/formlayout/generic.html
@@ -3,7 +3,7 @@
 {LabeledGroup}
 <div class="{$field_class} field">
   <label>{$label}</label>
-  <div class="{$width} {$class} fields">{$Content}</div>
+  <div class="{$width} {$class} fields">{$Content}</div>{$Hint}
 </div>
 {/}
 {NoLabelGroup}
@@ -13,7 +13,9 @@
 {/}
 {InputField}
 <div class="{$field_class} field">
-  <label for="{$label_for}">{$label}</label>{$Input}
+  <label for="{$label_for}">{$label}</label>
+  {$Input}
+  {$Hint}
 </div>
 {/}
 {InputNoLabel}

--- a/template/semantic-ui/formlayout/generic.pug
+++ b/template/semantic-ui/formlayout/generic.pug
@@ -5,6 +5,7 @@ div(class="{$field_class} field")
     label {$label}
     div(class="{$width} {$class} fields")
         | {$Content}
+    | {$Hint}
 | {/}
 
 | {NoLabelGroup}
@@ -17,6 +18,7 @@ div(class="{$field_class} field")
 div(class="{$field_class} field")
     label(for="{$label_for}") {$label}
     | {$Input}
+    | {$Hint}
 | {/}
 
 | {InputNoLabel}

--- a/tests/DemoTest.php
+++ b/tests/DemoTest.php
@@ -94,37 +94,6 @@ class DemoTest extends \atk4\core\PHPUnit_AgileTestCase
         }, $copy_paste);
 
         return $copy_paste;
-        var_dump($copy_paste);
-
-        return [
-            ['autocomplete.php'],
-            ['button.php'],
-            ['js.php'],
-            ['checkbox.php'],
-
-            ['table.php'],
-            ['form.php'],
-            ['form2.php'],
-            ['multitable.php'],
-            ['grid.php'],
-            ['crud.php'],
-            ['crud2.php'],
-
-            ['view.php'],
-            ['field.php'],
-            ['message.php'],
-            ['header.php'],
-            ['label.php'],
-            ['menu.php'],
-            ['tabs.php'],
-            ['paginator.php'],
-
-            ['reloading.php'],
-            ['modal.php'],
-            ['sticky.php'],
-            ['recursive.php'],
-            ['notify.php'],
-        ];
     }
 
     public function testLayout()


### PR DESCRIPTION
Adds a new property to FormField\Generic `hint`. Setting this property will display hint below the field:

<img width="343" alt="screen shot 2018-02-21 at 09 16 01" src="https://user-images.githubusercontent.com/453929/36471852-dc12e71e-16e7-11e8-8f08-3866a4c6a6b7.png">

It supports plain text and embedding objects (for HTML)

TODO:
 - [x] add documentation
 - [x] add demo and include into test-suite
 - [x] add integration into $modelfield->ui['hint'];
