### PR TITLE
Fix/#379

### DIFF
--- a/features/form.feature
+++ b/features/form.feature
@@ -6,6 +6,6 @@ Feature: Form
 Scenario:
  Given I am on "form.php"
  When I fill in "email" with "foo@bar"
- And I use form with button "Subscribe"
+ And I press button "Subscribe"
  Then I should see "Subscribed foo@bar to newsletter."
 

--- a/src/Form.php
+++ b/src/Form.php
@@ -97,8 +97,9 @@ class Form extends View //implements \ArrayAccess - temporarily so that our buil
 
         // Layout needs to have a save button
         $this->buttonSave = $this->layout->addButton(['Save', 'primary']);
-        $this->buttonSave->setElement('button');
+        $this->buttonSave->setAttr('tabindex', 0);
         $this->buttonSave->on('click', $this->js()->form('submit'));
+        $this->buttonSave->on('keypress', new jsExpression('if (event.keyCode === 13){$([name]).form("submit");}', ['name' => '#'.$this->name]));
     }
 
     /**


### PR DESCRIPTION
Revert button element to « div » instead of « button » and add ability for
button to use focus on tab and submit form via js.