### PR TITLE
includeJS -> requireJS / includeCSS -> requireCSS

### DIFF
--- a/docs/js.rst
+++ b/docs/js.rst
@@ -130,7 +130,7 @@ Including JS/CSS
 ----------------
 
 Sometimes you need to include an additional .js or .css file for your code
-to work. See :php:meth:`App::includeJS()` and :php:meth:`App::includeCSS()`
+to work. See :php:meth:`App::requireJS()` and :php:meth:`App::requireCSS()`
 for details.
 
 


### PR DESCRIPTION
Methods named App::includeJS and App::includeCSS is not found. They seems to be named requireJS and requireCSS.

Implementation of `<new feature>` (see ticket #..). Simple use:

``` php
$app->add(['new component']);
..
```

Typical use case of new feature explained here.

Drag a SCREENSHOT here:

 - Documentation: [docs/file.rst](docs/file.rst)
 - Demo: [demos/file.php](demos/file.php)

p.s. set label "in review" and assign reviewers if PR is complete. Otherwise set "work in progress" label.
