### PR TITLE
fix/#387-Allow a js function to run after reload is complete.

### DIFF
--- a/demos/reloading.php
+++ b/demos/reloading.php
@@ -5,7 +5,7 @@ require 'init.php';
 // Test 1 - Basic reloading
 $app->add(['Header', 'Button reloading segment']);
 $v = $app->add(['View', 'ui' => 'segment'])->set((string) rand(1, 100));
-$app->add(['Button', 'Reload random number'])->js('click', new \atk4\ui\jsReload($v));
+$app->add(['Button', 'Reload random number'])->js('click', new \atk4\ui\jsReload($v, [], new \atk4\ui\jsExpression('console.log("Output with afterSuccess");')));
 
 // Test 2 - Reloading self
 $app->add(['Header', 'JS-actions will be re-applied']);
@@ -61,4 +61,4 @@ $app->add(['Button', 'Set value to "hello"'])->js('click', new \atk4\ui\jsReload
 $app->add(['Button', 'Set value to "world"'])->js('click', new \atk4\ui\jsReload($v, ['val' => 'world']));
 
 $val = $app->add(['FormField/Line', '']);
-$val->addAction('Set Custom Value')->js('click', new \atk4\ui\jsReload($v, ['val' => $val->jsInput()->val()]));
+$val->addAction('Set Custom Value')->js('click', new \atk4\ui\jsReload($v, ['val' => $val->jsInput()->val()], $val->jsInput()->focus()));

--- a/js/README.md
+++ b/js/README.md
@@ -97,6 +97,11 @@ This command will output the atkjs-ui.min.js file, also in /public folder.
 
 ## Release note
 
+### version 1.1.0
+
+  - update reloadView plugin to accept new parameter for executing callback.
+  - update apiService to execute callback after on Success has run.
+
 ### version 1.0.2
 
   - update uploadField plugin.

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atkjs-ui",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Agile Toolkit Javascript library.",
   "main": "lib/atkjs-ui.js",
   "scripts": {

--- a/js/src/plugins/reloadView.js
+++ b/js/src/plugins/reloadView.js
@@ -1,16 +1,23 @@
 import atkPlugin from 'plugins/atkPlugin';
+import apiService from "../services/ApiService";
 
 export default class reloadView extends atkPlugin {
 
     main() {
 
         if(this.settings.uri) {
+            const that  = this;
             this.$el.api({
                 on: 'now',
                 url: this.settings.uri,
                 data: this.settings.uri_options,
                 method: 'GET',
-                obj: this.$el
+                obj: this.$el,
+                onComplete: function(response, content) {
+                    if (that.settings.afterSuccess) {
+                      apiService.onAfterSuccess(that.settings.afterSuccess);
+                    }
+                }
             });
         }
     }
@@ -19,4 +26,5 @@ export default class reloadView extends atkPlugin {
 reloadView.DEFAULTS = {
     uri: null,
     uri_options: {},
+    afterSuccess: null,
 };

--- a/js/src/services/ApiService.js
+++ b/js/src/services/ApiService.js
@@ -15,6 +15,7 @@ class ApiService {
   constructor() {
     if (!this.instance) {
       this.instance = this;
+      this.afterSuccessCallbacks = [];
     }
     return this.instance;
   }
@@ -80,6 +81,14 @@ class ApiService {
           // Call evalResponse with proper context, js code and jQuery as $ var.
           apiService.evalResponse.call(this, response.atkjs.replace(/<\/?script>/g, ''), jQuery);
         }
+        if (apiService.afterSuccessCallbacks.length > 0) {
+          const self = this;
+          let callbacks = apiService.afterSuccessCallbacks;
+          callbacks.forEach(function(callback){
+            apiService.evalResponse.call(self, callback, jQuery);
+          });
+          apiService.afterSuccessCallbacks.splice(0);
+        }
       } else if (response.isServiceError) {
         // service can still throw an error
         throw ({message:response.message});
@@ -87,6 +96,16 @@ class ApiService {
     } catch (e) {
         apiService.showErrorModal(apiService.getErrorHtml(e.message));
     }
+  }
+
+  /**
+   * Accumulate callbacks function to run after onSuccess.
+   * Callback is a string containing code to be eval.
+   *
+   * @param callback
+   */
+  onAfterSuccess(callback) {
+    this.afterSuccessCallbacks.push(callback);
   }
 
   /**

--- a/src/jsReload.php
+++ b/src/jsReload.php
@@ -9,7 +9,12 @@ class jsReload implements jsExpressionable
 {
     public $view = null;
 
-    public $cb = null;
+    /**
+     * A Js function to execute after reload is complete and onSuccess is execute.
+     *
+     * @var jsExpression
+     */
+    public $afterSuccess = null;
 
     /**
      * If defined, they will be added at the end of your URL.
@@ -17,31 +22,23 @@ class jsReload implements jsExpressionable
      */
     public $args = [];
 
-    public function __construct($view, $args = [])
+    public function __construct($view, $args = [], $afterSuccess = null)
     {
-        $this->view = $view;
-
-        $this->args = $args;
+        $this->view         = $view;
+        $this->args         = $args;
+        $this->afterSuccess = $afterSuccess;
     }
-
-    /*
-
-        $this->cb = $this->view->_add(new CallbackLater());
-        $this->cb->set(function () {
-            $this->view->app->terminate($this->view->renderJSON());
-        });
-    }
-     */
 
     public function jsRender()
     {
         $final = (new jQuery($this->view))
-          ->atkReloadView(
-          [
-              'uri'         => $this->view->jsURL(['__atk_reload'=>$this->view->name]),
-              'uri_options' => $this->args,
-          ]
-        );
+            ->atkReloadView(
+                [
+                    'uri'          => $this->view->jsURL(['__atk_reload'=>$this->view->name]),
+                    'uri_options'  => $this->args,
+                    'afterSuccess' => $this->afterSuccess ? $this->afterSuccess->jsRender() : null,
+                ]
+            );
 
         return $final->jsRender();
     }


### PR DESCRIPTION
Will allow a js function to be run after api onSuccess.

ex: 
```
$val = $app->add(['FormField/Line', '']);
$val->addAction('Set Custom Value')->js('click', new \atk4\ui\jsReload($v, ['val' => $val->jsInput()->val()], $val->jsInput()->focus()));
```

## File Change 
 - jsReload.php
 - reloadView.js
 - apiService.js file.

Note: atkjs-ui need to be rebuild.