### PR TITLE
Cleanup of Pr/397: Added getField-method to Generic FormLayout

### DIFF
--- a/src/FormLayout/Generic.php
+++ b/src/FormLayout/Generic.php
@@ -135,6 +135,18 @@ class Generic extends View
 
         return $model;
     }
+    
+    /**
+     * Return Field decorator associated with
+     * the form's field.
+     */
+    public function getField($name)
+    {
+        if (empty($this->form))
+            throw new Exception(['Incorrect value for $form', 'form' => $this->form]);
+        
+        return $this->form->getField($name);
+    }
 
     /**
      * Adds Button.

--- a/src/FormLayout/Generic.php
+++ b/src/FormLayout/Generic.php
@@ -135,16 +135,16 @@ class Generic extends View
 
         return $model;
     }
-    
+
     /**
      * Return Field decorator associated with
      * the form's field.
      */
     public function getField($name)
     {
-        if (empty($this->form))
+        if (empty($this->form)) {
             throw new Exception(['Incorrect value for $form', 'form' => $this->form]);
-        
+        }
         return $this->form->getField($name);
     }
 

--- a/src/FormLayout/Generic.php
+++ b/src/FormLayout/Generic.php
@@ -145,6 +145,7 @@ class Generic extends View
         if (empty($this->form)) {
             throw new Exception(['Incorrect value for $form', 'form' => $this->form]);
         }
+
         return $this->form->getField($name);
     }
 

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -5,10 +5,9 @@ namespace atk4\ui\tests;
 class FormTest extends \atk4\core\PHPUnit_AgileTestCase
 {
     /**
-     * Some tests for form
-     *
+     * Some tests for form.
      */
-    function testGetField()
+    public function testGetField()
     {
         $f = new \atk4\ui\Form();
         $f->init();

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace atk4\ui\tests;
+
+class FormTest extends \atk4\core\PHPUnit_AgileTestCase
+{
+    /**
+     * Some tests for form
+     *
+     */
+    function testGetField()
+    {
+        $f = new \atk4\ui\Form();
+        $f->init();
+
+        $f->addField('test');
+
+        $this->assertTrue($f->getField('test') instanceof \atk4\ui\FormField\Generic);
+        $this->assertInstanceOf(\atk4\ui\FormField\Generic::class, $f->layout->getField('test'));
+    }
+}


### PR DESCRIPTION
See: https://github.com/atk4/ui/pull/397

---

Added getField-method to Generic Form Layout

See also:
https://forum.agiletoolkit.org/t/split-existing-form-into-tab/447/4