### PR TITLE
Fix: Typo

### DIFF
--- a/src/CRUD.php
+++ b/src/CRUD.php
@@ -188,7 +188,7 @@ class CRUD extends Grid
             $this->model->load($this->app->stickyGet($this->name));
 
             // Maybe developer has already created form
-            if (!is_object($this->formUpdate) || $this->formUpdate->_initialized) {
+            if (!is_object($this->formUpdate) || !$this->formUpdate->_initialized) {
                 $this->formUpdate = $this->pageUpdate->add($this->formUpdate ?: $this->formDefault);
             }
 

--- a/src/CRUD.php
+++ b/src/CRUD.php
@@ -188,7 +188,7 @@ class CRUD extends Grid
             $this->model->load($this->app->stickyGet($this->name));
 
             // Maybe developer has already created form
-            if (!is_object($this->formUpdate) || $this->formUpdate->_initialied) {
+            if (!is_object($this->formUpdate) || $this->formUpdate->_initialized) {
                 $this->formUpdate = $this->pageUpdate->add($this->formUpdate ?: $this->formDefault);
             }
 


### PR DESCRIPTION
Fixes a typo in CRUD.php - a missing 'z' caused php notices