### PR TITLE
Autocomplete to use $title_field instead of 'name'

### DIFF
--- a/src/FormField/AutoComplete.php
+++ b/src/FormField/AutoComplete.php
@@ -100,7 +100,7 @@ class AutoComplete extends Input
                 $modal_chain = new jQuery('.atk-modal');
                 $modal_chain->modal('hide');
                 $ac_chain = new jQuery('#'.$this->name.'-ac');
-                $ac_chain->dropdown('set value', $id)->dropdown('set text', $f->model['name']);
+                $ac_chain->dropdown('set value', $id)->dropdown('set text', $f->model[$this->model->title_field]);
 
                 return [
                     $modal_chain,


### PR DESCRIPTION
Changed
``` $f->model['name'] ```
to
``` $f->model[$this->model->title_field] ```