### PR TITLE
Implement "Multiformat" column decorator for table

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -45,76 +45,76 @@ checks:
       threshold: 150
 
 
-engines:
-  duplication:
-    enabled: true
-    config:
-      languages:
-        php:
-          mass_threshold: 50
-  fixme:
-    enabled: true
-  phpmd:
-    enabled: true
-    exclude_fingerprints:
-    - 9d462b7c90c564bf28007ee399340fad # table() NPath is too complex.
-    - 7c90035f65bb3bdbd2c03c648a705aac # we use static for factory, so it's good
-    - 80ef7f404dd4f054ca51d9ee12d9e9dd # we exit from toStrign() because it can't throw exceptions
-    - ae61f5e0cda0328c140f3b7298dbb8af # don't complain about call to static connection, as it's a fallback
-    - e71149b967391adfaf3347a53d3c0023 # don't complain about $junk used in foreach when we only need keys
-    checks:
-      CyclomaticComplexity:            # because we solve complex stuff
-        enabled: false
-      Naming/LongVariable:             # because we have variable naming patterns
-        enabled: false
-      UnusedFormalParameter:           # because when we extend methods/hooks we wish to keep unified method call interface
-        enabled: false
-      Design/TooManyPublicMethods:     # because we follow our internal design patters
-        enabled: false
-      Design/TooManyMethods:           # because we solve complex stuff
-        enabled: false
-      Design/LongMethod:               # because methods are as long as we need them to be
-        enabled: false
-      ExcessivePublicCount:            # because Model has too many public methods
-        enabled: false
-      Design/TooManyFields:            # because we solve complex things
-        enabled: false
-      Design/NpathComplexity:          # because splitting up complex stuff into methods makes things even more complex
-        enabled: false
-      Design/WeightedMethodCount:      # because we we solve complex stuff
-        enabled: false
-      Design/LongClass:                # because we design carefully what is native and what is extension
-        enabled: false
-      Controversial/CamelCaseMethodName:    # because we need certain method naming patterns, render_blah for rendering [blah]
-        enabled: false
-      Controversial/CamelCaseParameterName: #
-        enabled: false
-      Controversial/CamelCasePropertyName:  # because we use _better_dont_change properties
-        enabled: false
-      Controversial/CamelCaseVariableName:  #
-        enabled: false
-      Controversial/CamelCaseClassName:     # Because we use Join_SQL where we specifically include _
-        enabled: false
-      Naming/ShortVariable:             # because sometimes variables should be short
-        enabled: false
-      CleanCode/ElseExpression:         # because following this makes code more complex
-        enabled: false
-
-  radon:
-    enabled: true
-ratings:
-  paths:
-  - "src/**"
-exclude_paths:
-- "docs/**"
-- "tests/**"
-- "vendor/**"
-# exclude obsolete classes
-- "src/Field_Many.php"
-- "src/Field_One.php"
-- "src/Field_SQL_One.php"
-- "src/Relation_Many.php"
-- "src/Relation_One.php"
-- "src/Relation_SQL_One.php"
-# exclude classes completely inherited from other repos
-- "src/Exception.php"
+#engines:
+#  duplication:
+#    enabled: true
+#    config:
+#      languages:
+#        php:
+#          mass_threshold: 50
+#  fixme:
+#    enabled: true
+#  phpmd:
+#    enabled: true
+#    exclude_fingerprints:
+#    - 9d462b7c90c564bf28007ee399340fad # table() NPath is too complex.
+#    - 7c90035f65bb3bdbd2c03c648a705aac # we use static for factory, so it's good
+#    - 80ef7f404dd4f054ca51d9ee12d9e9dd # we exit from toStrign() because it can't throw exceptions
+#    - ae61f5e0cda0328c140f3b7298dbb8af # don't complain about call to static connection, as it's a fallback
+#    - e71149b967391adfaf3347a53d3c0023 # don't complain about $junk used in foreach when we only need keys
+#    checks:
+#      CyclomaticComplexity:            # because we solve complex stuff
+#        enabled: false
+#      Naming/LongVariable:             # because we have variable naming patterns
+#        enabled: false
+#      UnusedFormalParameter:           # because when we extend methods/hooks we wish to keep unified method call interface
+#        enabled: false
+#      Design/TooManyPublicMethods:     # because we follow our internal design patters
+#        enabled: false
+#      Design/TooManyMethods:           # because we solve complex stuff
+#        enabled: false
+#      Design/LongMethod:               # because methods are as long as we need them to be
+#        enabled: false
+#      ExcessivePublicCount:            # because Model has too many public methods
+#        enabled: false
+#      Design/TooManyFields:            # because we solve complex things
+#        enabled: false
+#      Design/NpathComplexity:          # because splitting up complex stuff into methods makes things even more complex
+#        enabled: false
+#      Design/WeightedMethodCount:      # because we we solve complex stuff
+#        enabled: false
+#      Design/LongClass:                # because we design carefully what is native and what is extension
+#        enabled: false
+#      Controversial/CamelCaseMethodName:    # because we need certain method naming patterns, render_blah for rendering [blah]
+#        enabled: false
+#      Controversial/CamelCaseParameterName: #
+#        enabled: false
+#      Controversial/CamelCasePropertyName:  # because we use _better_dont_change properties
+#        enabled: false
+#      Controversial/CamelCaseVariableName:  #
+#        enabled: false
+#      Controversial/CamelCaseClassName:     # Because we use Join_SQL where we specifically include _
+#        enabled: false
+#      Naming/ShortVariable:             # because sometimes variables should be short
+#        enabled: false
+#      CleanCode/ElseExpression:         # because following this makes code more complex
+#        enabled: false
+#
+#  radon:
+#    enabled: true
+#ratings:
+#  paths:
+#  - "src/**"
+#exclude_paths:
+#- "docs/**"
+#- "tests/**"
+#- "vendor/**"
+## exclude obsolete classes
+#- "src/Field_Many.php"
+#- "src/Field_One.php"
+#- "src/Field_SQL_One.php"
+#- "src/Relation_Many.php"
+#- "src/Relation_One.php"
+#- "src/Relation_SQL_One.php"
+## exclude classes completely inherited from other repos
+#- "src/Exception.php"

--- a/demos/init.php
+++ b/demos/init.php
@@ -37,9 +37,9 @@ if (isset($layout->leftMenu)) {
 
     $form = $layout->leftMenu->addGroup(['Grid and Table', 'icon' => 'table']);
     $form->addItem('Data table with formatted columns', ['table']);
+    $form->addItem('Advanced table examples', ['table2']);
     $form->addItem('Table interractions', ['multitable']);
     $form->addItem('Grid - Table+Bar+Search+Paginator', ['grid']);
-    //$form->addItem('Interactivity - Modals and Expanders', ['expander']);
     $form->addItem('CRUD - Full editing solution', ['crud']);
 
     $basic = $layout->leftMenu->addGroup(['Basics', 'icon' => 'cubes']);

--- a/demos/table2.php
+++ b/demos/table2.php
@@ -3,33 +3,70 @@
 date_default_timezone_set('UTC');
 include 'init.php';
 
+$app->add(['Header', 'Table with various headers', 'subHeader'=>'Demonstrates how you can add subheaders, footnotes and other insertions into your data table', 'icon'=>'table']);
+
 $data = [
     ['id'=>1, 'action'=>'Salary', 'amount'=>200],
     ['id'=> 2, 'action'=>'Purchase goods', 'amount'=>-120],
     ['id'=> 3, 'action'=>'Tax', 'amount'=>-40],
 ];
 
-$p = new \atk4\data\Persistence_Array($data);
-$m = new \atk4\data\Model($p);
-
-$m->addField('action');
-$m->addField('amount', ['type'=>'money']);
+$m = new \atk4\data\Model(new \atk4\data\Persistence_Static($data));
+$m->getElement('amount')->type = 'money';
 
 $table = $app->add('Table');
-$table->setModel($m);
+$table->setModel($m, ['action']);
+$table->addColumn('amount', ['Money']);
 
+// Table template can be tweaked directly
 $table->template->appendHTML('SubHead', '<tr class="center aligned"><th colspan=2>This is sub-header, goes inside "thead" tag</th></tr>');
 $table->template->appendHTML('Body', '<tr class="center aligned"><td colspan=2>This is part of body, goes before other rows</td></tr>');
 
+// Hook can be used to display data before row. You can also inject and format extra rows.
 $table->addHook('beforeRow', function ($table) {
     if ($table->current_id == 2) {
         $table->template->appendHTML('Body', '<tr class="center aligned"><td colspan=2>This goes above row with ID=2 ('.$table->current_row['action'].')</th></tr>');
-    } elseif ($table->current_id == 3) {
+    } elseif ($table->current_row['action'] == 'Tax') {
+        // renders current row
         $table->renderRow();
-        $table->model->set(['action'=>'manually injected row after Tax', 'amount'=>0]);
+
+        // adjusts data for next render
+        $table->model->set(['action'=>'manually injected row after Tax', 'amount'=>-0.02]);
     }
 });
 
 $table->template->appendHTML('Foot', '<tr class="center aligned"><td colspan=2>This will appear above totals</th></tr>');
-
 $table->addTotals(['action' => 'Totals:', 'amount' => ['sum']]);
+
+
+$app->add(['Header', 'Columns with multiple formats', 'subHeader'=>'Single column can use logic to swap out formatters', 'icon'=>'table']);
+
+$table = $app->add('Table');
+$table->setModel($m, ['action']);
+
+// copy of amount through a PHP callback
+$m->addField('amount_copy', ['Callback', function($m) { return $m['amount']; }, 'type'=>'money']);
+
+// column with 2 decorators that stack. Money will use red ink and alignment, format will change text.
+$table->addColumn('amount', ['Money']);
+$table->addDecorator('amount', ['Template', 'Refunded: {$amount}']);
+
+// column which uses selective format depending on condition
+$table->addColumn('amount_copy', ['Multiformat', 'callback'=>function($a, $b) {
+
+    if($a['amount_copy'] > 0) {
+        // Two formatters together
+        return ['Link', 'Money'];
+    } elseif (abs($a['amount_copy']) < 50) {
+
+        // One formatter, but inject template and some attributes
+        return [[
+            'Template',
+            'too <b>little</b> to <u>matter</u>', 
+            'attr' => ['all' => ['class' => ['right aligned single line']]] 
+        ]];
+    }
+
+    // Short way is to simply return seed
+    return 'Money';
+}]);

--- a/demos/table2.php
+++ b/demos/table2.php
@@ -69,4 +69,4 @@ $table->addColumn('amount_copy', ['Multiformat', 'callback'=>function($a, $b) {
 
     // Short way is to simply return seed
     return 'Money';
-}]);
+}, 'attr'=>['all'=>['class'=>['right aligned singel line']]]]);

--- a/demos/table2.php
+++ b/demos/table2.php
@@ -53,7 +53,7 @@ $table->addColumn('amount', ['Money']);
 $table->addDecorator('amount', ['Template', 'Refunded: {$amount}']);
 
 // column which uses selective format depending on condition
-$table->addColumn('amount_copy', ['Multiformat', 'callback'=>function ($a, $b) {
+$table->addColumn('amount_copy', ['Multiformat', function ($a, $b) {
     if ($a['amount_copy'] > 0) {
         // Two formatters together
         return ['Link', 'Money'];

--- a/docs/table.rst
+++ b/docs/table.rst
@@ -427,6 +427,132 @@ getDataCellHTML can be left as-is and will be handled correctly. If you have ove
 getDataCellHTML only, then your column will still work OK provided that it's used as a
 last decorator.
 
+Standard Decorators
+===================
+
+In addition to :php:class:`TableColumn\Generic`, Agile UI includes several column implementations.
+
+Link
+----
+
+.. php:class:: TableColumn\Link
+
+Put `<a href..` link over the value of the cell. The page property can be specified to constructor. There
+are two usage patterns. With the first you can specify full URL as a string::
+
+    $table->addColumn('name', ['Link', 'http://google.com/?q={$name}']);
+
+The URL may also be specified as an array. It will be passed to App::url() which will encode arguments::
+
+    $table->addColumn('name', ['Link', ['details', 'id'=>123, 'q'=>$anything]]);
+    
+In this case even if `$anything = '{$name}'` the substitution will not take place for safety reasons. To
+pass on some values from your model, use second argument to constructor::
+    
+    $table->addColumn('name', ['Link', ['details', 'id'=>123], ['q'=>'name']]);
+
+
+Money
+-----
+
+.. php:class:: TableColumn\Money
+
+Helps decorating monetary values. Will align value to the right and if value is less than zero will also
+use red text (td class "negative" for semantic ui). The money cells are not wrapped.
+
+For the actual number formatting, see :ref:`ui_persistence`
+
+Status
+------
+
+.. php:class:: TableColumn\Status
+
+Allow you to set highlight class and icon based on column value. This is most suitable for columns that
+contain pre-defined values.
+
+If your column "status" can be one of the following "pending", "declined", "archived" and "paid" and you would like
+to use different icons and colors to emphasise status::
+
+
+    $states = [ 'positive'=>['paid', 'archived'], 'negative'=>['declined'] ];
+
+    $table->addColumn('status', new \atk4\ui\TableColumn\Status($states));
+
+Current list of states supported:
+
+ - positive (icon checkmark)
+ - negative (icon close)
+ - and the default/unspecified state (icon question)
+
+(list of states may be expanded furteher)
+
+Template
+--------
+
+.. php:class:: TableColumn\Template
+
+This column is suitable if you wish to have custom cell formatting but do not wish to go through
+the trouble of setting up your own class.
+
+If you wish to display movie rating "4 out of 10" based around the column "rating", you can use::
+
+    $table->addColumn('rating', new \atk4\ui\TableColumn\Template('{$rating} out of 10'));
+
+Template may incorporate values from multiple fields in a data row, but current implementation
+will only work if you asign it to a primary column (by passing 1st argument to addColumn).
+
+(In the future it may be optional with the ability to specify caption).
+
+CheckBox
+--------
+
+.. php:class:: TableColumn\CheckBox
+
+.. php:method:: jsChecked()
+
+Adding this column will render checkbox for each row. This column must not be used on a field.
+CheckBox column provides you with a handy jsChecked() method, which you can use to reference
+current item selection. The next code will allow you to select the checkboxes, and when you
+click on the button, it will reload $segment component while passing all the id's::
+
+    $box = $table->addColumn(new \atk4\ui\TableColumn\CheckBox());
+
+    $button->on('click', new jsReload($segment, ['ids'=>$box->jsChecked()]));
+
+jsChecked expression represents a JavaScript string which you can place inside a form field,
+use as argument etc.
+
+Actions
+-------
+
+.. php:class:: TableColumn\Actions
+
+This column can have number of buttons (or similar views) inside a column. This would allow you
+to interract with each row directly.
+
+The basic usage format is::
+
+    $act = $table->addColumn(new \atk4\ui\TableColumn\Actions());
+
+
+Multiformat
+-----------
+
+Sometimes your formatting may change depending on value. For example you may want to place link
+only on certain rows. For this you can use a 'Multiformat' decorator::
+
+    $table->addColumn('amount', ['Multiformat', 'callback'=>function($a, $b) {
+
+        if($a['is_invoiced'] > 0) {
+            return ['Link', 'invoice', ['invoice_id'=>'id']];
+        } elseif (abs($a['is_refunded']) < 50) {
+            return ['Template', 'Amount was <b>refunded</b>'];
+        }
+
+        return ['Money'];
+    }]);
+
+
 Advanced Usage
 ==============
 
@@ -513,105 +639,4 @@ with row value or injected HTML.
 
 For further examples of and advanced usage, see implementation of :php:class:`TableColumn\Status`.
 
-
-Standard Column Types
-=====================
-
-In addition to :php:class:`TableColumn\Generic`, Agile UI includes several column implementations.
-
-Link
-----
-
-.. php:class:: TableColumn\Link
-
-Put `<a href..` link over the value of the cell. The page property can be specified to constructor. There
-are two usage patterns. With the first you can specify full URL as a string::
-
-    $table->addColumn('name', new \atk4\ui\TableColumn\Link('http://google.com/?q={$name}'));
-
-The name value will be automatically inserted. The other option is to use page array::
-
-    $table->addColumn('name', new \atk4\ui\TableColumn\Link(['details', 'id'=>'{$id}', 'status'=>'{$status}']));
-
-Money
------
-
-.. php:class:: TableColumn\Money
-
-Helps decorating monetary values. Will align value to the right and if value is less than zero will also
-use red text (td class "negative" for semantic ui). The money cells are not wrapped.
-
-For the actual number formatting, see :ref:`ui_persistence`
-
-Status
-------
-
-.. php:class:: TableColumn\Status
-
-Allow you to set highlight class and icon based on column value. This is most suitable for columns that
-contain pre-defined values.
-
-If your column "status" can be one of the following "pending", "declined", "archived" and "paid" and you would like
-to use different icons and colors to emphasise status::
-
-
-    $states = [ 'positive'=>['paid', 'archived'], 'negative'=>['declined'] ];
-
-    $table->addColumn('status', new \atk4\ui\TableColumn\Status($states));
-
-Current list of states supported:
-
- - positive (icon checkmark)
- - negative (icon close)
- - and the default/unspecified state (icon question)
-
-(list of states may be expanded furteher)
-
-Template
---------
-
-.. php:class:: TableColumn\Template
-
-This column is suitable if you wish to have custom cell formatting but do not wish to go through
-the trouble of setting up your own class.
-
-If you wish to display movie rating "4 out of 10" based around the column "rating", you can use::
-
-    $table->addColumn('rating', new \atk4\ui\TableColumn\Template('{$rating} out of 10'));
-
-Template may incorporate values from multiple fields in a data row, but current implementation
-will only work if you asign it to a primary column (by passing 1st argument to addColumn).
-
-(In the future it may be optional with the ability to specify caption).
-
-CheckBox
---------
-
-.. php:class:: TableColumn\CheckBox
-
-.. php:method:: jsChecked()
-
-Adding this column will render checkbox for each row. This column must not be used on a field.
-CheckBox column provides you with a handy jsChecked() method, which you can use to reference
-current item selection. The next code will allow you to select the checkboxes, and when you
-click on the button, it will reload $segment component while passing all the id's::
-
-    $box = $table->addColumn(new \atk4\ui\TableColumn\CheckBox());
-
-    $button->on('click', new jsReload($segment, ['ids'=>$box->jsChecked()]));
-
-jsChecked expression represents a JavaScript string which you can place inside a form field,
-use as argument etc.
-
-Actions
--------
-
-.. php:class:: TableColumn\Actions
-
-This column can have number of buttons (or similar views) inside a column. This would allow you
-to interract with each row directly.
-
-The basic usage format is::
-
-    $act = $table->addColumn(new \atk4\ui\TableColumn\Actions());
 

--- a/docs/table.rst
+++ b/docs/table.rst
@@ -541,17 +541,29 @@ Multiformat
 Sometimes your formatting may change depending on value. For example you may want to place link
 only on certain rows. For this you can use a 'Multiformat' decorator::
 
-    $table->addColumn('amount', ['Multiformat', 'callback'=>function($a, $b) {
+    $table->addColumn('amount', ['Multiformat', function($a, $b) {
 
         if($a['is_invoiced'] > 0) {
-            return ['Link', 'invoice', ['invoice_id'=>'id']];
+            return ['Money', ['Link', 'invoice', ['invoice_id'=>'id']]];
         } elseif (abs($a['is_refunded']) < 50) {
-            return ['Template', 'Amount was <b>refunded</b>'];
+            return [['Template', 'Amount was <b>refunded</b>']];
         }
 
-        return ['Money'];
+        return 'Money';
     }]);
 
+You supply a callback to the Multiformat decorator, which will then be used to determine
+the actual set of decorators to be used on a given row. The example above will look at various
+fields of your models and will conditionally add Link on top of Money formatting.
+
+Your callback can return things in varous ways:
+
+ - return array of seeds: [['Link'], 'Money'];
+ - if string or object is returned it is wrapped inside array automatically
+
+Multiple decorators will be created and merged.
+
+.. note:: If you are operating with large tables, code your own decorator, which would be more CPU-efficient.
 
 Advanced Usage
 ==============

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -86,7 +86,7 @@ class Grid extends View
     {
         parent::init();
 
-        $this->container = $this->add(['View', 'ui'=>'', 'template' => new Template('<div id="{$_id}"><div class="ui table atk-overflow-auto">{$Table}</div>{$Paginator}</div>')]);
+        $this->container = $this->add(['View', 'ui'=>'', 'template' => new Template('<div id="{$_id}"><div class="ui table atk-overflow-auto">{$Table}{$Content}</div>{$Paginator}</div>')]);
 
         if ($this->menu !== false) {
             $this->menu = $this->add($this->factory(['Menu', 'activate_on_click' => false], $this->menu), 'Menu');

--- a/src/TableColumn/Multiformat.php
+++ b/src/TableColumn/Multiformat.php
@@ -13,6 +13,10 @@ class Multiformat extends Generic
         return '{$c_'.$this->short_name.'}';
     }
 
+    public function __construct($callback) {
+        $this->callback = $callback;
+    }
+
     public function getHTMLTags($row, $field)
     {
         if (!$this->callback) {

--- a/src/TableColumn/Multiformat.php
+++ b/src/TableColumn/Multiformat.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace atk4\ui\TableColumn;
+
+/**
+ * Swaps out column decorators based on logic
+ */
+class Multiformat extends Generic
+{
+    public $callback = null;
+    public function getDataCellHTML(\atk4\data\Field $f = null)
+    {
+        return '{$c_'.$this->short_name.'}';
+    }
+
+    public function getHTMLTags($row, $field)
+    {
+        if (!$this->callback) {
+            throw new \atk4\ui\Exception(['Must specify a callback for column', 'column'=>$this]);
+        }
+
+        $decorators = call_user_func($this->callback, $row, $field);
+        if (is_string($decorators)) {
+            $decorators = [[$decorators]];
+        }
+
+        if (is_object($decorators)) {
+            $decorators = [$decorators];
+        }
+
+        // we need to smartly wrap things up
+        $name = $field->short_name;
+        $cell = null;
+        $cnt = count($decorators);
+        $td_attr = [];
+        $html_tags = [];
+        foreach ($decorators as $c) {
+
+            if (!is_object($c)) {
+                $c = $this->owner->decoratorFactory($field, $c);
+            }
+
+            if (--$cnt) {
+                $html = $c->getDataCellTemplate($field);
+                $td_attr = $c->getTagAttributes('body', $td_attr);
+            } else {
+                // Last formatter, ask it to give us whole rendering
+                $html = $c->getDataCellHTML($field, $td_attr);
+            }
+
+            if ($cell) {
+                if ($name) {
+                    // if name is set, we can wrap things
+                    $cell = str_replace('{$'.$name.'}', $cell, $html);
+                } else {
+                    $cell = $cell.' '.$html;
+                }
+            } else {
+                $cell = $html;
+            }
+            if (!method_exists($c, 'getHTMLTags')) {
+                continue;
+            }
+            $html_tags = array_merge($c->getHTMLTags($row, $field), $html_tags);
+        }
+
+
+        $template = $this->owner->add(['Template', $cell]);
+        $template->set($row);
+        $template->setHTML($html_tags);
+
+
+        $val = $template->render();
+
+        return ['c_'.$this->short_name => $val];
+    }
+
+}

--- a/src/TableColumn/Multiformat.php
+++ b/src/TableColumn/Multiformat.php
@@ -14,7 +14,8 @@ class Multiformat extends Generic
         return '{$c_'.$this->short_name.'}';
     }
 
-    public function __construct($callback) {
+    public function __construct($callback)
+    {
         $this->callback = $callback;
     }
 

--- a/src/TableColumn/Multiformat.php
+++ b/src/TableColumn/Multiformat.php
@@ -7,6 +7,9 @@ namespace atk4\ui\TableColumn;
  */
 class Multiformat extends Generic
 {
+    /**
+     * @var callable Method to execute which will return array of seeds for decorators
+     */
     public $callback = null;
 
     public function getDataCellHTML(\atk4\data\Field $f = null, $extra_tags = [])

--- a/src/TableColumn/Multiformat.php
+++ b/src/TableColumn/Multiformat.php
@@ -8,7 +8,7 @@ namespace atk4\ui\TableColumn;
 class Multiformat extends Generic
 {
     public $callback = null;
-    public function getDataCellHTML(\atk4\data\Field $f = null)
+    public function getDataCellHTML(\atk4\data\Field $f = null, $extra_tags = [])
     {
         return '{$c_'.$this->short_name.'}';
     }

--- a/src/Template.php
+++ b/src/Template.php
@@ -328,6 +328,10 @@ class Template implements \ArrayAccess
             return $this;
         }
 
+        if (is_object($value)) {
+            throw new Exception(['Value should not be an object', 'value'=>$value]);
+        }
+
         if ($encode) {
             $value = htmlspecialchars($value, ENT_NOQUOTES, 'UTF-8');
         }

--- a/tests/DemoTest.php
+++ b/tests/DemoTest.php
@@ -84,6 +84,7 @@ class DemoTest extends \atk4\core\PHPUnit_AgileTestCase
   sse.php
   sticky.php
   table.php
+  table2.php
   tabs.php
   view.php
   virtual.php


### PR DESCRIPTION
Implementation of Multiformat column for the table. It allows to use different formatters depending on cell value. Simple use:

``` php
    $table->addColumn('amount', ['Multiformat', 'callback'=>function($a, $b) {

        if($a['is_invoiced'] > 0) {
            return ['Link', 'invoice', ['invoice_id'=>'id']];
        } elseif (abs($a['is_refunded']) < 50) {
            return ['Template', 'Amount was <b>refunded</b>'];
        }

        return ['Money'];
    }]);
```

Screenshot does not really correspond to example above, but demonstrates 3 different decorators for a same column, including Link+Money, Money and Template.

<img width="191" alt="screen shot 2018-03-21 at 17 00 16" src="https://user-images.githubusercontent.com/453929/37724758-62559a9a-2d29-11e8-8d1f-0f2f79fadbce.png">

 - Documentation: docs/table.rst
 - Demo: demos/table2.php

