### PR TITLE
Adding virtualpage into Form makes sure we inherit stickyGet

### DIFF
--- a/demos/autocomplete.php
+++ b/demos/autocomplete.php
@@ -33,11 +33,11 @@ $form->addField('country3', [
 //$acc = $form->getField('country_id');
 //$acc->actionRight = ['Button', 'Hello htere'];
 
-$form->onSubmit(function ($f) {
-    return $f->model->ref('country_id')['name'];
+$form->onSubmit(function ($f) use ($db) {
+    return $f->model->ref('country1')['name'].' / '.$f->model->ref('country2')['name'].' / '.(new Country($db))->load($f->model['country3'])->get('name');
 });
 
-$layout->add(new \atk4\ui\FormField\AutoComplete(['placeholder' => 'Search users', 'left' => true, 'icon' => 'users']));
+//$layout->add(new \atk4\ui\FormField\AutoComplete(['placeholder' => 'Search users', /*'left' => true,*/ 'icon' => 'users']));
 
 $layout->add(new \atk4\ui\Header(['Labels', 'size' => 2]));
 

--- a/src/FormField/AutoComplete.php
+++ b/src/FormField/AutoComplete.php
@@ -89,7 +89,12 @@ class AutoComplete extends Input
             $this->action = $this->factory(['Button', is_string($this->plus) ? $this->plus : 'Add new']);
         }
         //var_Dump($this->model->get());
-        $vp = $this->form->add('VirtualPage');
+        if ($this->form) {
+            $vp = $this->form->add('VirtualPage');
+        } else {
+            $vp = $this->owner->add('VirtualPage');
+        }
+
         $vp->set(function ($p) {
             $f = $p->add('Form');
             $f->setModel($this->model);

--- a/src/FormField/AutoComplete.php
+++ b/src/FormField/AutoComplete.php
@@ -89,7 +89,7 @@ class AutoComplete extends Input
             $this->action = $this->factory(['Button', is_string($this->plus) ? $this->plus : 'Add new']);
         }
         //var_Dump($this->model->get());
-        $vp = $this->app->add('VirtualPage');
+        $vp = $this->form->add('VirtualPage');
         $vp->set(function ($p) {
             $f = $p->add('Form');
             $f->setModel($this->model);


### PR DESCRIPTION
Currently using "plus" inside crud pop-up does not work due to 2 reasons:

 - virtual page is added into app, therefore loosing some stickyGet set on the modal
 - semanticUI pop-up looks messed up appears not on top of existing popup but below it.

