### PR TITLE
Allow to override url setting

### DIFF
--- a/src/FormField/AutoComplete.php
+++ b/src/FormField/AutoComplete.php
@@ -198,7 +198,7 @@ class AutoComplete extends Input
     {
         $settings = array_merge([
             'fields'      => ['name' => 'name', 'value' => 'id'/*, 'text' => 'description'*/],
-            'apiSettings' => array_merge($this->apiConfig, ['url' => $this->getCallbackURL().'&q={query}']),
+            'apiSettings' => array_merge(['url' => $this->getCallbackURL().'&q={query}'], $this->apiConfig),
         ], $this->settings);
 
         $chain->dropdown($settings);


### PR DESCRIPTION
Hi there,
I switched the parameter order of array_merge to make overwriting the url setting possible.
Now, something like this works:
```
$ac->setApiConfig([
        'url'              => 'my_custom_url',
        'allowReselection' => true,
        'selectOnKeydown'  => false,
    ]);
```

Before, the custom URL setting was overwritten by the standard callback URL.
