### PR TITLE
Fix #418

### DIFF
--- a/src/FormField/DropDown.php
+++ b/src/FormField/DropDown.php
@@ -18,7 +18,17 @@ class DropDown extends Input
     public function init()
     {
         parent::init();
-        $this->jsInput(true)->dropdown();
+        //See https://github.com/atk4/ui/issues/418
+        //if field is required, disable empty selection once a value is
+        //selected. Currently standard behaviour of sematic ui dropdown
+        if(isset($this->field) && $this->field->required) {
+            $this->jsInput(true)->dropdown();
+        }
+        //add any (does not have to be $this->empty) placeholder to allow
+        //empty selection even after a value was selected
+        else {
+            $this->jsInput(true)->dropdown(['placeholder' => $this->empty]);
+        }
     }
 
     /**


### PR DESCRIPTION
Fix for #418, allows empty selection in a dropdown once a "real" value is selected (was not possible before).
As there is an open bug in Semantic UI for this, this might change with future sematic UI Versions:
https://github.com/Semantic-Org/Semantic-UI/issues/2072
