### PR TITLE
Feature/Table Column Menu

### DIFF
--- a/demos/init.php
+++ b/demos/init.php
@@ -27,18 +27,19 @@ if (isset($layout->leftMenu)) {
     $form = $layout->leftMenu->addGroup(['Form', 'icon' => 'edit']);
     $form->addItem('Basics and Layouting', ['form']);
     $form->addItem('Input Field Decoration', ['field']);
-    $form->addItem(['File Uploading', 'icon'=>'yellow star'], ['upload']);
-    $form->addItem(['Checkboxes', 'icon'=>'yellow star'], ['checkbox']);
+    $form->addItem(['File Uploading'], ['upload']);
+    $form->addItem(['Checkboxes'], ['checkbox']);
     $form->addItem('Data Integration', ['form2']);
     $form->addItem('Form Multi-column layout', ['form3']);
-    $form->addItem(['Integration with Columns', 'icon'=>'yellow star'], ['form5']);
-    $form->addItem(['AutoComplete Field', 'icon'=>'yellow star'], ['autocomplete']);
-    $form->addItem(['Value Selectors', 'icon'=>'yellow star'], ['form6']);
+    $form->addItem(['Integration with Columns'], ['form5']);
+    $form->addItem(['AutoComplete Field'], ['autocomplete']);
+    $form->addItem(['Value Selectors'], ['form6']);
 
     $form = $layout->leftMenu->addGroup(['Grid and Table', 'icon' => 'table']);
     $form->addItem('Data table with formatted columns', ['table']);
     $form->addItem('Advanced table examples', ['table2']);
     $form->addItem('Table interractions', ['multitable']);
+    $form->addItem(['Column Menus', 'icon'=>'yellow star'], ['tablecolumnmenu']);
     $form->addItem('Grid - Table+Bar+Search+Paginator', ['grid']);
     $form->addItem('CRUD - Full editing solution', ['crud']);
 
@@ -52,19 +53,20 @@ if (isset($layout->leftMenu)) {
     $basic->addItem('Menu', ['menu']);
     $basic->addItem('BreadCrumb', ['breadcrumb']);
     $basic->addItem('Tabs', ['tabs']);
-    $basic->addItem(['Columns', 'icon'=>'yellow star'], ['columns']);
+    $basic->addItem(['Columns'], ['columns']);
     $basic->addItem('Paginator', ['paginator']);
 
     $basic = $layout->leftMenu->addGroup(['Interactivity', 'icon' => 'talk']);
-    $basic->addItem(['Wizard', 'icon'=>'yellow star'], ['wizard']);
+    $basic->addItem(['Wizard'], ['wizard']);
     $basic->addItem('JavaScript Events', ['js']);
     $basic->addItem('Element Reloading', ['reloading']);
-    $basic->addItem(['Background PHP Jobs (SSE)', 'icon'=>'yellow star'], ['sse']);
-    $basic->addItem(['Progress Bar', 'icon'=>'yellow star'], ['progress']);
-    $basic->addItem(['Loader', 'icon'=>'yellow star'], ['loader']);
-    $basic->addItem(['Console', 'icon'=>'yellow star'], ['console']);
+    $basic->addItem(['Background PHP Jobs (SSE)'], ['sse']);
+    $basic->addItem(['Progress Bar'], ['progress']);
+    $basic->addItem(['Loader'], ['loader']);
+    $basic->addItem(['Console'], ['console']);
     $basic->addItem('Notifier', ['notify']);
-    $basic->addItem(['Modal View', 'icon'=>'yellow star'], ['modal2']);
+    $basic->addItem(['Pop-up', 'icon'=>'yellow star'], ['popup']);
+    $basic->addItem(['Modal View'], ['modal2']);
     $basic->addItem('Dynamic jsModal', ['modal']);
     $basic->addItem('Sticky GET', ['sticky']);
     $basic->addItem('Recursive Views', ['recursive']);

--- a/demos/tablecolumnmenu.php
+++ b/demos/tablecolumnmenu.php
@@ -6,6 +6,19 @@ require 'database.php';
 
 $app->add(['Header', 'Table column may contains popup or dropdown menu.']);
 
+
+    
+    $table = $app->add(['ui'=>'segment'])->add(['Table', 'celled' => true]);
+    $table->setModel(new Country($app->db));
+
+    $name_column = $table->getColumnDecorators('name');
+    $name_column[0]->addPopup()->set(function($p) {
+        $p->add('HelloWorld');
+    });
+
+exit;
+
+
 //For popup positioning to work correctly, table need to be inside a view segment.
 $view = $app->add('View', ['ui' => 'basic segment']);
 

--- a/demos/tablecolumnmenu.php
+++ b/demos/tablecolumnmenu.php
@@ -7,18 +7,6 @@ require 'database.php';
 $app->add(['Header', 'Table column may contains popup or dropdown menu.']);
 
 
-    
-    $table = $app->add(['ui'=>'segment'])->add(['Table', 'celled' => true]);
-    $table->setModel(new Country($app->db));
-
-    $name_column = $table->getColumnDecorators('name');
-    $name_column[0]->addPopup()->set(function($p) {
-        $p->add('HelloWorld');
-    });
-
-exit;
-
-
 //For popup positioning to work correctly, table need to be inside a view segment.
 $view = $app->add('View', ['ui' => 'basic segment']);
 

--- a/demos/tablemenu.php
+++ b/demos/tablemenu.php
@@ -33,7 +33,7 @@ $col_surname->addPopup()->set(function ($pop) {
 });
 
 //Another dropdown menu.
-$col_title->addDropdown('title', ['Change', 'Reorder', 'Update'], function ($item) {
+$col_title->addDropdown(['Change', 'Reorder', 'Update'], function ($item) {
     return 'Title item: '.$item;
 });
 
@@ -48,10 +48,10 @@ $g->setModel(new Country($db));
 $g->ipp = 5;
 
 //Adding a dropdown menu to the column 'name'.
-$g->addHeaderDropdown('name', ['Rename', 'Delete'], function ($item) {
+$g->addDropdown('name', ['Rename', 'Delete'], function ($item) {
     return $item;
 });
 
 //Adding a popup view to the column 'iso'
-$pop = $g->addHeaderPopup('iso');
+$pop = $g->addPopup('iso');
 $pop->add('View')->set('Grid column popup');

--- a/demos/tablemenu.php
+++ b/demos/tablemenu.php
@@ -24,8 +24,8 @@ $col_name->addHeaderPopup($pop);
 //dropdown setup.
 $menu = $col_surname->addHeaderDropdown('surname', [['name'=> 'Customize', 'value' => 'customize'], ['name' => 'Rename', 'value' => 'rename']]);
 
-$menu->onChangeItem(function($menu, $item){
-   return new atk4\ui\jsNotify($menu.' / '.$item);
+$menu->onChangeItem(function ($menu, $item) {
+    return new atk4\ui\jsNotify($menu.' / '.$item);
 });
 
 // testing

--- a/demos/tablemenu.php
+++ b/demos/tablemenu.php
@@ -12,25 +12,18 @@ $col_name = $table->addColumn('name', new \atk4\ui\TableColumn\Link(['details', 
 //will add dropdown menu to this colum.
 $col_surname = $table->addColumn('surname', new \atk4\ui\TableColumn\Template('{$surname}'))->addClass('warning');
 
-$table->addColumn('title');
+$col_title = $table->addColumn('title');
 $table->addColumn('date');
 $table->addColumn('salary', new \atk4\ui\TableColumn\Money());
 
 //popup setup
-$pop = $app->add('Popup')->setHoverable();
-$pop->add('View')->set('Testing popup.');
-$col_name->addHeaderPopup($pop);
+$col_name->addPopup('name')->add('View')->set('Testing popup');
 
-//dropdown setup.
-$menu = $col_surname->addHeaderDropdown('surname', [['name'=> 'Customize', 'value' => 'customize'], ['name' => 'Rename', 'value' => 'rename']]);
-
-$menu->onChangeItem(function ($menu, $item) {
-    return new atk4\ui\jsNotify($menu.' / '.$item);
+//dropdown menu
+$col_surname->addDropdown('surname', ['Customize', 'Rename', 'Update'], function($item){
+    return 'Surname item: '.$item;
 });
 
-// testing
-//$table->js(true, (new atk4\ui\jQuery('.atk-table-dropdown .dropdown'))
-//    ->dropdown([
-//                'action'  => 'hide',
-//                'values'  => [['name'=> 'Customize Field', 'value' => 'customize'], ['name' => 'Rename', 'value' => 'rename']],
-//               ]));
+$col_title->addDropdown('title', ['Change', 'Reorder', 'Update'], function($item){
+    return 'Title item: '.$item;
+});

--- a/demos/tablemenu.php
+++ b/demos/tablemenu.php
@@ -2,28 +2,56 @@
 
 date_default_timezone_set('UTC');
 include 'init.php';
+require 'database.php';
 
-$table = $app->add(['Table', 'celled' => true]);
+$app->add(['Header', 'Table column may contains popup or dropdown menu.']);
+
+//For popup positioning to work correctly, table need to be inside a view segment.
+$view = $app->add('View', ['ui' => 'basic segment']);
+
+$table = $view->add(['Table', 'celled' => true]);
 $table->setModel(new SomeData(), false);
 
 //will add popup to this column.
-$col_name = $table->addColumn('name', new \atk4\ui\TableColumn\Link(['details', 'id' => '{$id}']));
+$col_name = $table->addColumn('name');
 
 //will add dropdown menu to this colum.
-$col_surname = $table->addColumn('surname', new \atk4\ui\TableColumn\Template('{$surname}'))->addClass('warning');
+$col_surname = $table->addColumn('surname');
 
 $col_title = $table->addColumn('title');
+
 $table->addColumn('date');
 $table->addColumn('salary', new \atk4\ui\TableColumn\Money());
 
-//popup setup
-$col_name->addPopup('name')->add('View')->set('Testing popup');
+//regular popup setup
+$col_name->addPopup()->add('View')->set('Name popup');
 
-//dropdown menu
-$col_surname->addDropdown('surname', ['Customize', 'Rename', 'Update'], function ($item) {
-    return 'Surname item: '.$item;
+//dynamic popup setup
+//This popup will add content using the callback function.
+$col_surname->addPopup()->set(function($pop) {
+    $pop->add('View')->set('This popup is load dynamically');
 });
 
+//Another dropdown menu.
 $col_title->addDropdown('title', ['Change', 'Reorder', 'Update'], function ($item) {
     return 'Title item: '.$item;
 });
+
+////////////////////////////////////////////////
+
+$app->add(['Header', 'Grid column may contains popup or dropdown menu.']);
+
+//For popup positioning to work correctly, table need to be inside a view segment.
+$view = $app->add('View', ['ui' => 'basic segment']);
+$g = $view->add(['Grid']);
+$g->setModel(new Country($db));
+$g->ipp = 5;
+
+//Adding a dropdown menu to the column 'name'.
+$g->addHeaderDropdown('name', ['Rename', 'Delete'], function($item){
+   return $item;
+});
+
+//Adding a popup view to the column 'iso'
+$pop = $g->addHeaderPopup('iso');
+$pop->add('View')->set('Grid column popup');

--- a/demos/tablemenu.php
+++ b/demos/tablemenu.php
@@ -28,7 +28,7 @@ $col_name->addPopup()->add('View')->set('Name popup');
 
 //dynamic popup setup
 //This popup will add content using the callback function.
-$col_surname->addPopup()->set(function($pop) {
+$col_surname->addPopup()->set(function ($pop) {
     $pop->add('View')->set('This popup is load dynamically');
 });
 
@@ -48,8 +48,8 @@ $g->setModel(new Country($db));
 $g->ipp = 5;
 
 //Adding a dropdown menu to the column 'name'.
-$g->addHeaderDropdown('name', ['Rename', 'Delete'], function($item){
-   return $item;
+$g->addHeaderDropdown('name', ['Rename', 'Delete'], function ($item) {
+    return $item;
 });
 
 //Adding a popup view to the column 'iso'

--- a/demos/tablemenu.php
+++ b/demos/tablemenu.php
@@ -41,7 +41,7 @@ $col_title->addDropdown('title', ['Change', 'Reorder', 'Update'], function ($ite
 
 $app->add(['Header', 'Grid column may contains popup or dropdown menu.']);
 
-//For popup positioning to work correctly, table need to be inside a view segment.
+//For popup positioning to work correctly, grid need to be inside a view segment.
 $view = $app->add('View', ['ui' => 'basic segment']);
 $g = $view->add(['Grid']);
 $g->setModel(new Country($db));

--- a/demos/tablemenu.php
+++ b/demos/tablemenu.php
@@ -20,10 +20,10 @@ $table->addColumn('salary', new \atk4\ui\TableColumn\Money());
 $col_name->addPopup('name')->add('View')->set('Testing popup');
 
 //dropdown menu
-$col_surname->addDropdown('surname', ['Customize', 'Rename', 'Update'], function($item){
+$col_surname->addDropdown('surname', ['Customize', 'Rename', 'Update'], function ($item) {
     return 'Surname item: '.$item;
 });
 
-$col_title->addDropdown('title', ['Change', 'Reorder', 'Update'], function($item){
+$col_title->addDropdown('title', ['Change', 'Reorder', 'Update'], function ($item) {
     return 'Title item: '.$item;
 });

--- a/demos/tablemenu.php
+++ b/demos/tablemenu.php
@@ -29,7 +29,7 @@ $col_name->addPopup()->add('View')->set('Name popup');
 //dynamic popup setup
 //This popup will add content using the callback function.
 $col_surname->addPopup()->set(function ($pop) {
-    $pop->add('View')->set('This popup is load dynamically');
+    $pop->add('View')->set('This popup is loaded dynamically');
 });
 
 //Another dropdown menu.

--- a/demos/tablemenu.php
+++ b/demos/tablemenu.php
@@ -4,21 +4,33 @@ date_default_timezone_set('UTC');
 include 'init.php';
 
 $table = $app->add(['Table', 'celled' => true]);
-
-//$table->addTableMenu([['name'=> 'Customize Field', 'value' => 'customize']]);
-$table->columMenus = [['name'=> 'Customize Field', 'value' => 'customize'], ['name' => 'Rename', 'value' => 'rename']];
-
 $table->setModel(new SomeData(), false);
 
-$table->addColumn('name', new \atk4\ui\TableColumn\Link(['details', 'id' => '{$id}']));
-$table->addColumn('surname', new \atk4\ui\TableColumn\Template('{$surname}'))->addClass('warning');
-$table->addColumn('title');
+//will add popup to this column.
+$col_name = $table->addColumn('name', new \atk4\ui\TableColumn\Link(['details', 'id' => '{$id}']));
 
+//will add dropdown menu to this colum.
+$col_surname = $table->addColumn('surname', new \atk4\ui\TableColumn\Template('{$surname}'))->addClass('warning');
+
+$table->addColumn('title');
 $table->addColumn('date');
 $table->addColumn('salary', new \atk4\ui\TableColumn\Money());
 
-$table->js(true, (new atk4\ui\jQuery('.atk-table-dropdown .dropdown'))
-    ->dropdown([
-                'action'  => 'hide',
-                'values'  => $table->columMenus,
-               ]));
+//popup setup
+$pop = $app->add('Popup')->setHoverable();
+$pop->add('View')->set('Testing popup.');
+$col_name->addHeaderPopup($pop);
+
+//dropdown setup.
+$menu = $col_surname->addHeaderDropdown('surname', [['name'=> 'Customize', 'value' => 'customize'], ['name' => 'Rename', 'value' => 'rename']]);
+
+$menu->onChangeItem(function($menu, $item){
+   return new atk4\ui\jsNotify($menu.' / '.$item);
+});
+
+// testing
+//$table->js(true, (new atk4\ui\jQuery('.atk-table-dropdown .dropdown'))
+//    ->dropdown([
+//                'action'  => 'hide',
+//                'values'  => [['name'=> 'Customize Field', 'value' => 'customize'], ['name' => 'Rename', 'value' => 'rename']],
+//               ]));

--- a/demos/tablemenu.php
+++ b/demos/tablemenu.php
@@ -1,0 +1,24 @@
+<?php
+
+date_default_timezone_set('UTC');
+include 'init.php';
+
+$table = $app->add(['Table', 'celled' => true]);
+
+//$table->addTableMenu([['name'=> 'Customize Field', 'value' => 'customize']]);
+$table->columMenus = [['name'=> 'Customize Field', 'value' => 'customize'], ['name' => 'Rename', 'value' => 'rename']];
+
+$table->setModel(new SomeData(), false);
+
+$table->addColumn('name', new \atk4\ui\TableColumn\Link(['details', 'id' => '{$id}']));
+$table->addColumn('surname', new \atk4\ui\TableColumn\Template('{$surname}'))->addClass('warning');
+$table->addColumn('title');
+
+$table->addColumn('date');
+$table->addColumn('salary', new \atk4\ui\TableColumn\Money());
+
+$table->js(true, (new atk4\ui\jQuery('.atk-table-dropdown .dropdown'))
+    ->dropdown([
+                'action' => 'hide',
+                'values'  => $table->columMenus
+               ]));

--- a/demos/wizard.php
+++ b/demos/wizard.php
@@ -22,7 +22,7 @@ $t->addStep('Welcome', function ($p) {
 $t->addStep(['Set DSN', 'icon'=>'configure', 'description'=>'Database Connection String'], function ($p) {
     $f = $p->add('Form');
 
-    $f->addField('dsn', 'Connect DSN', ['required'=>true])->placholder = 'mysql://user:pass@db-host.example.com/mydb';
+    $f->addField('dsn', 'Connect DSN', ['required'=>true])->placeholder = 'mysql://user:pass@db-host.example.com/mydb';
     $f->onSubmit(function ($f) use ($p) {
         $p->memorize('dsn', $f->model['dsn']);
 

--- a/docs/components.rst
+++ b/docs/components.rst
@@ -19,6 +19,7 @@ inherited by its descendants.
     table
     field
     fileupload
+    tablecolumn
 
 Simple components
 =================

--- a/docs/grid.rst
+++ b/docs/grid.rst
@@ -83,9 +83,9 @@ You can use $ipp property to specify different number of items per page::
 Actions
 =======
 
-.. php:attr: $actions
+.. php:attr:: actions
 
-.. php:method: addAction($button, $action, $confirm = false)
+.. php:method:: addAction($button, $action, $confirm = false)
 
 :php:class:`Table` supports use of :php:class:`TableColumn\Actions`, which allows to display button for each row.
 Calling addAction() provides a useful short-cut for creating column-based actions.
@@ -98,7 +98,7 @@ Calling this method multiple times will add button into same action column.
 
 See :php:meth:`TableColumn\Actions::addAction`
 
-.. php:method: addModalAction($button, $title, $callback)
+.. php:method:: addModalAction($button, $title, $callback)
 
 Similar to addAction, but when clicking a button, will open a modal dialog and execute $callback
 to populate a content::
@@ -113,7 +113,7 @@ to populate a content::
 
 Calling this method multiple times will add button into same action column.
 
-See :php:meth:`TableColumn\Actions::addModal`
+See :php:meth:`atk4\\ui\\TableColumn\\Actions::addModal`
 
 Selection
 =========

--- a/docs/popup.rst
+++ b/docs/popup.rst
@@ -12,10 +12,19 @@ Popup
 Implements a popup::
 
     $button = $app->add(['Button', 'Click me']);
-    $app->add(['Popup', $button])->add('Text')
-        ->set('hello world from inside a popup');
+    $app->add(['Popup', $button])->add('HelloWorld');
 
-Pop-up should be added into the App, but it remains invisible until it's triggered by $button.
+.. php:method:: set($callback)
+
+Popup can also operate with dynamic content::
+
+    $button = $app->add(['Button', 'Click me']);
+    $app->add(['Popup', $button])
+        ->set('hello world with rand='.rand(1,100));
+
+Pop-up should be added into a viewport which will define boundaries of a pop-up, but it will
+be positioned relative to the $button. Popup remains invisible until it's triggered by event of $button.
+
 If second argument in the :ref:`seed` is of class :php:class:`Button`, :php:class:`Menu`, 
 :php:class:`Item` or :php:class:`DropDown` (note - NOT FormField!), pop-up will also bind itself
 to that element. The above example will automatically bind "click" event of a button to open a pop-up.

--- a/docs/table.rst
+++ b/docs/table.rst
@@ -9,6 +9,9 @@ Table
 
 .. php:class:: Table
 
+.. important:: For columns, see :php:class:`TableColumn\\Generic`. For DIV-based lists, see :php:class:`Lister`. For an
+    interractive features see :php:class:`Grid` and :php:class:`CRUD`.
+
 Table is the simplest way to output multiple records of structured, static data. For Un-structure output
 please see :php:class:`Lister`
 
@@ -426,144 +429,6 @@ If you are defining your own column, you may want to re-define getDataCellTempla
 getDataCellHTML can be left as-is and will be handled correctly. If you have overriden
 getDataCellHTML only, then your column will still work OK provided that it's used as a
 last decorator.
-
-Standard Decorators
-===================
-
-In addition to :php:class:`TableColumn\Generic`, Agile UI includes several column implementations.
-
-Link
-----
-
-.. php:class:: TableColumn\Link
-
-Put `<a href..` link over the value of the cell. The page property can be specified to constructor. There
-are two usage patterns. With the first you can specify full URL as a string::
-
-    $table->addColumn('name', ['Link', 'http://google.com/?q={$name}']);
-
-The URL may also be specified as an array. It will be passed to App::url() which will encode arguments::
-
-    $table->addColumn('name', ['Link', ['details', 'id'=>123, 'q'=>$anything]]);
-    
-In this case even if `$anything = '{$name}'` the substitution will not take place for safety reasons. To
-pass on some values from your model, use second argument to constructor::
-    
-    $table->addColumn('name', ['Link', ['details', 'id'=>123], ['q'=>'name']]);
-
-
-Money
------
-
-.. php:class:: TableColumn\Money
-
-Helps decorating monetary values. Will align value to the right and if value is less than zero will also
-use red text (td class "negative" for semantic ui). The money cells are not wrapped.
-
-For the actual number formatting, see :ref:`ui_persistence`
-
-Status
-------
-
-.. php:class:: TableColumn\Status
-
-Allow you to set highlight class and icon based on column value. This is most suitable for columns that
-contain pre-defined values.
-
-If your column "status" can be one of the following "pending", "declined", "archived" and "paid" and you would like
-to use different icons and colors to emphasise status::
-
-
-    $states = [ 'positive'=>['paid', 'archived'], 'negative'=>['declined'] ];
-
-    $table->addColumn('status', new \atk4\ui\TableColumn\Status($states));
-
-Current list of states supported:
-
- - positive (icon checkmark)
- - negative (icon close)
- - and the default/unspecified state (icon question)
-
-(list of states may be expanded furteher)
-
-Template
---------
-
-.. php:class:: TableColumn\Template
-
-This column is suitable if you wish to have custom cell formatting but do not wish to go through
-the trouble of setting up your own class.
-
-If you wish to display movie rating "4 out of 10" based around the column "rating", you can use::
-
-    $table->addColumn('rating', new \atk4\ui\TableColumn\Template('{$rating} out of 10'));
-
-Template may incorporate values from multiple fields in a data row, but current implementation
-will only work if you asign it to a primary column (by passing 1st argument to addColumn).
-
-(In the future it may be optional with the ability to specify caption).
-
-CheckBox
---------
-
-.. php:class:: TableColumn\CheckBox
-
-.. php:method:: jsChecked()
-
-Adding this column will render checkbox for each row. This column must not be used on a field.
-CheckBox column provides you with a handy jsChecked() method, which you can use to reference
-current item selection. The next code will allow you to select the checkboxes, and when you
-click on the button, it will reload $segment component while passing all the id's::
-
-    $box = $table->addColumn(new \atk4\ui\TableColumn\CheckBox());
-
-    $button->on('click', new jsReload($segment, ['ids'=>$box->jsChecked()]));
-
-jsChecked expression represents a JavaScript string which you can place inside a form field,
-use as argument etc.
-
-Actions
--------
-
-.. php:class:: TableColumn\Actions
-
-This column can have number of buttons (or similar views) inside a column. This would allow you
-to interract with each row directly.
-
-The basic usage format is::
-
-    $act = $table->addColumn(new \atk4\ui\TableColumn\Actions());
-
-
-Multiformat
------------
-
-Sometimes your formatting may change depending on value. For example you may want to place link
-only on certain rows. For this you can use a 'Multiformat' decorator::
-
-    $table->addColumn('amount', ['Multiformat', function($a, $b) {
-
-        if($a['is_invoiced'] > 0) {
-            return ['Money', ['Link', 'invoice', ['invoice_id'=>'id']]];
-        } elseif (abs($a['is_refunded']) < 50) {
-            return [['Template', 'Amount was <b>refunded</b>']];
-        }
-
-        return 'Money';
-    }]);
-
-You supply a callback to the Multiformat decorator, which will then be used to determine
-the actual set of decorators to be used on a given row. The example above will look at various
-fields of your models and will conditionally add Link on top of Money formatting.
-
-Your callback can return things in varous ways:
-
- - return array of seeds: [['Link'], 'Money'];
- - if string or object is returned it is wrapped inside array automatically
-
-Multiple decorators will be created and merged.
-
-.. note:: If you are operating with large tables, code your own decorator, which would be more CPU-efficient.
 
 Advanced Usage
 ==============

--- a/docs/tablecolumn.rst
+++ b/docs/tablecolumn.rst
@@ -257,7 +257,35 @@ Column Menus and Popups
 =======================
 
 Table column may have a menu as seen in http://ui.agiletoolkit.org/demos/tablecolumnmenu.php. Menu is added
-into table column and can be linked with Popup or Menu::
+into table column and can be linked with Popup or Menu.
+
+Basic Use
+---------
+
+The simplest way to use Menus and Popups is through a wrappers: :php:meth:`Table::addDropdown` and :php:meth:`Table::addPopup`::
+
+    $grid->addPopup('iso')
+        ->add('View')
+        ->set('Grid column popup text');
+
+    // OR
+
+    $grid->addDropdown('name', ['Sort A-Z', 'Sort by Relevance'], function ($item) {
+        return $item;
+    });
+
+Those wrappers will invoke methods :php:meth:`TableColumn::addDropdown` and :php:meth:`TableColmun::addPopup` for
+a specified column, which are documented below.
+
+
+Popups
+------
+
+.. php:method:: addPopup()
+
+To create a popup, you need to get the column decorator object. This must be the first decorator, which
+is responsible for rendering of the TH box. If you are adding column manually, :php:meth:`Table::addColumn()`
+will return it. When using model, use :php:meth:`Table::getColumnDecorators`::
 
     
     $table = $app->add(['ui'=>'segment'])->add(['Table', 'celled' => true]);
@@ -270,4 +298,25 @@ into table column and can be linked with Popup or Menu::
 
 .. important:: If content of a pop-up is too large, it may not be possible to display it on-screen. Watch for warning.
 
-You may also use :php:meth:`atk4\\ui\\Popup::set` method to dynamically load the content.
+You may also use :php:meth:`atk4\\ui\\Popup::set` method to dynamically load the content::
+
+
+    $table = $app->add(['ui'=>'segment'])->add(['Table', 'celled' => true]);
+    $table->setModel(new Country($app->db));
+
+    $name_column = $table->getColumnDecorators('name');
+    $name_column[0]->addPopup()->set(function($p) {
+        $p->add('HelloWorld');
+    });
+
+Dropdown Menus
+--------------
+
+.. php:method:: addDropdown()
+
+Menus will show item selection and will trigger a callback when user selects one of them::
+
+    $some_column->addDropdown(['Change', 'Reorder', 'Update'], function ($item) {
+        return 'Title item: '.$item;
+    });
+

--- a/docs/view.rst
+++ b/docs/view.rst
@@ -9,7 +9,8 @@ Views
 Agile UI is a component framework, which follows a software patterns known as
 `Render Tree` and `Two pass HTML rendering`.
 
-.. php:namespace: atk4\\ui
+.. php:namespace:: atk4\ui
+
 .. php:class:: View
 
     A View is a most fundamental object that can take part in the Render tree. All

--- a/public/agileui.less
+++ b/public/agileui.less
@@ -60,6 +60,17 @@ footer.atk-footer {
   }
 }
 
+// table dropdown menu
+.atk-table-dropdown {
+  display: inline;
+  float: right;
+}
+
+.atk-table-dropdown i {
+  opacity: 0.3;
+  vertical-align: bottom;
+}
+
 
 // Components
 

--- a/src/App.php
+++ b/src/App.php
@@ -715,7 +715,16 @@ class App
             $result = [];
             foreach ($value as $v) {
                 if (is_array($v)) {
-                    $result[] = $this->getTag(...$v);
+                    $arg = [];
+                    foreach ($v as $key => $value) {
+                        if (is_numeric($key)) {
+                            $arg[] = $value;
+                        } else {
+                            $arg[] = [$key => $value];
+                        }
+                    }
+                    $result[] = $this->getTag(...$arg);
+                    //$result[] = $this->getTag(...$v);
                 } else {
                     $result[] = $v;
                 }

--- a/src/App.php
+++ b/src/App.php
@@ -715,16 +715,7 @@ class App
             $result = [];
             foreach ($value as $v) {
                 if (is_array($v)) {
-                    $arg = [];
-                    foreach ($v as $key => $value) {
-                        if (is_numeric($key)) {
-                            $arg[] = $value;
-                        } else {
-                            $arg[] = [$key => $value];
-                        }
-                    }
-                    $result[] = $this->getTag(...$arg);
-                    //$result[] = $this->getTag(...$v);
+                    $result[] = $this->getTag(...$v);
                 } else {
                     $result[] = $v;
                 }

--- a/src/CallbackLater.php
+++ b/src/CallbackLater.php
@@ -14,7 +14,7 @@ class CallbackLater extends Callback
      * Executes user-specified action before rendering or if App is
      * already in rendering state, then before output.
      *
-     * @param callback $callback
+     * @param callable $callback
      * @param array    $args
      *
      * @return mixed|null

--- a/src/Console.php
+++ b/src/Console.php
@@ -68,7 +68,7 @@ class Console extends View implements \Psr\Log\LoggerInterface
      *
      * While inside a callback you may execute runCommand or setModel multiple times.
      *
-     * @param callback    $callback callback which will be executed while displaying output inside console
+     * @param callable    $callback callback which will be executed while displaying output inside console
      * @param bool|string $event    "true" would mean to execute on page load, string would indicate
      *                              js event. See first argument for View::js()
      *

--- a/src/FormField/AutoComplete.php
+++ b/src/FormField/AutoComplete.php
@@ -12,7 +12,7 @@ class AutoComplete extends Input
     /**
      * Object used to capture requests from the browser.
      *
-     * @var Callback
+     * @var callable
      */
     public $callback;
 

--- a/src/FormField/DropDown.php
+++ b/src/FormField/DropDown.php
@@ -18,7 +18,17 @@ class DropDown extends Input
     public function init()
     {
         parent::init();
-        $this->jsInput(true)->dropdown();
+        //See https://github.com/atk4/ui/issues/418
+        //if field is required, disable empty selection once a value is
+        //selected. Currently standard behaviour of sematic ui dropdown
+        if(isset($this->field) && $this->field->required) {
+            $this->jsInput(true)->dropdown();
+        }
+        //add any (does not have to be $this->empty) placeholder to allow
+        //empty selection even after a value was selected
+        else {
+            $this->jsInput(true)->dropdown(['placeholder' => $this->empty]);
+        }
     }
 
     /**
@@ -62,8 +72,14 @@ class DropDown extends Input
             'placeholder' => $this->placeholder,
             'id'          => $this->id.'_input',
         ], [[$options]]
-        //
-        );
+       //
+    );
         //return '<input name="'.$this->short_name.'" type="'.$this->inputType.'" placeholder="'.$this->placeholder.'" id="'.$this->id.'_input"/>';
+    }
+
+    public function renderView()
+    {
+        $this->jsInput(true)->dropdown($this->options);
+        parent::renderView();
     }
 }

--- a/src/FormField/DropDown.php
+++ b/src/FormField/DropDown.php
@@ -18,17 +18,7 @@ class DropDown extends Input
     public function init()
     {
         parent::init();
-        //See https://github.com/atk4/ui/issues/418
-        //if field is required, disable empty selection once a value is
-        //selected. Currently standard behaviour of sematic ui dropdown
-        if (isset($this->field) && $this->field->required) {
-            $this->jsInput(true)->dropdown();
-        }
-        //add any (does not have to be $this->empty) placeholder to allow
-        //empty selection even after a value was selected
-        else {
-            $this->jsInput(true)->dropdown(['placeholder' => $this->empty]);
-        }
+        $this->jsInput(true)->dropdown();
     }
 
     /**
@@ -72,14 +62,8 @@ class DropDown extends Input
             'placeholder' => $this->placeholder,
             'id'          => $this->id.'_input',
         ], [[$options]]
-       //
-    );
+        //
+        );
         //return '<input name="'.$this->short_name.'" type="'.$this->inputType.'" placeholder="'.$this->placeholder.'" id="'.$this->id.'_input"/>';
-    }
-
-    public function renderView()
-    {
-        $this->jsInput(true)->dropdown($this->options);
-        parent::renderView();
     }
 }

--- a/src/FormField/DropDown.php
+++ b/src/FormField/DropDown.php
@@ -18,17 +18,7 @@ class DropDown extends Input
     public function init()
     {
         parent::init();
-        //See https://github.com/atk4/ui/issues/418
-        //if field is required, disable empty selection once a value is
-        //selected. Currently standard behaviour of sematic ui dropdown
-        if(isset($this->field) && $this->field->required) {
-            $this->jsInput(true)->dropdown();
-        }
-        //add any (does not have to be $this->empty) placeholder to allow
-        //empty selection even after a value was selected
-        else {
-            $this->jsInput(true)->dropdown(['placeholder' => $this->empty]);
-        }
+        $this->jsInput(true)->dropdown();
     }
 
     /**
@@ -72,14 +62,8 @@ class DropDown extends Input
             'placeholder' => $this->placeholder,
             'id'          => $this->id.'_input',
         ], [[$options]]
-       //
-    );
+        //
+        );
         //return '<input name="'.$this->short_name.'" type="'.$this->inputType.'" placeholder="'.$this->placeholder.'" id="'.$this->id.'_input"/>';
-    }
-
-    public function renderView()
-    {
-        $this->jsInput(true)->dropdown($this->options);
-        parent::renderView();
     }
 }

--- a/src/FormField/DropDown.php
+++ b/src/FormField/DropDown.php
@@ -18,7 +18,17 @@ class DropDown extends Input
     public function init()
     {
         parent::init();
-        $this->jsInput(true)->dropdown();
+        //See https://github.com/atk4/ui/issues/418
+        //if field is required, disable empty selection once a value is
+        //selected. Currently standard behaviour of sematic ui dropdown
+        if(isset($this->field) && $this->field->required) {
+            $this->jsInput(true)->dropdown();
+        }
+        //add any (does not have to be $this->empty) placeholder to allow
+        //empty selection even after a value was selected
+        else {
+            $this->jsInput(true)->dropdown(['placeholder' => $this->empty]);
+        }
     }
 
     /**
@@ -65,5 +75,11 @@ class DropDown extends Input
        //
     );
         //return '<input name="'.$this->short_name.'" type="'.$this->inputType.'" placeholder="'.$this->placeholder.'" id="'.$this->id.'_input"/>';
+    }
+
+    public function renderView()
+    {
+        $this->jsInput(true)->dropdown($this->options);
+        parent::renderView();
     }
 }

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -205,7 +205,7 @@ class Grid extends View
             throw new Exception('The column where you want to add dropdown does not exist: '.$columnName);
         }
 
-        $column->addDropdown($columnName, $items, function($item) use ($fx) {
+        $column->addDropdown($columnName, $items, function ($item) use ($fx) {
             return call_user_func($fx, [$item]);
         }, $icon);
     }
@@ -216,8 +216,9 @@ class Grid extends View
      * @param string $columnName The name of column where to add popup.
      * @param string $icon       The icon.
      *
-     * @return mixed
      * @throws Exception
+     *
+     * @return mixed
      */
     public function addHeaderPopup($columnName, $icon = 'caret square down')
     {

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -227,12 +227,7 @@ class Grid extends View
             throw new Exception('The column where you want to add popup does not exist: '.$columnName);
         }
 
-        $popup = $column->addPopup($icon);
-        if ($this->name === @$_GET['__atk_reload']) {
-            $this->js(true, $popup->jsPopup());
-        }
-
-        return $popup;
+        return $column->addPopup($icon);
     }
 
     /**

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -231,6 +231,7 @@ class Grid extends View
         if ($this->name === @$_GET['__atk_reload']) {
             $this->js(true, $popup->jsPopup());
         }
+
         return $popup;
     }
 

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -227,7 +227,11 @@ class Grid extends View
             throw new Exception('The column where you want to add popup does not exist: '.$columnName);
         }
 
-        return $column->addPopup($icon);
+        $popup = $column->addPopup($icon);
+        if ($this->name === @$_GET['__atk_reload']) {
+            $this->js(true, $popup->jsPopup());
+        }
+        return $popup;
     }
 
     /**

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -189,6 +189,47 @@ class Grid extends View
     }
 
     /**
+     * Add a dropdown menu to header column.
+     *
+     * @param string   $columnName The name of column where to add dropdown.
+     * @param array    $items      The menu items to add.
+     * @param callable $fx         The callback function to execute when an item is selected.
+     * @param string   $icon       The icon.
+     *
+     * @throws Exception
+     */
+    public function addHeaderDropdown($columnName, $items, $fx, $icon = 'caret square down')
+    {
+        $column = $this->table->columns[$columnName];
+        if (!isset($column)) {
+            throw new Exception('The column where you want to add dropdown does not exist: '.$columnName);
+        }
+
+        $column->addDropdown($columnName, $items, function($item) use ($fx) {
+            return call_user_func($fx, [$item]);
+        }, $icon);
+    }
+
+    /**
+     * Add a popup to header column.
+     *
+     * @param string $columnName The name of column where to add popup.
+     * @param string $icon       The icon.
+     *
+     * @return mixed
+     * @throws Exception
+     */
+    public function addHeaderPopup($columnName, $icon = 'caret square down')
+    {
+        $column = $this->table->columns[$columnName];
+        if (!isset($column)) {
+            throw new Exception('The column where you want to add popup does not exist: '.$columnName);
+        }
+
+        return $column->addPopup($icon);
+    }
+
+    /**
      * Similar to addAction but when button is clicked, modal is displayed
      * with the $title and $callback is executed through VirtualPage.
      *

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -195,39 +195,44 @@ class Grid extends View
      * @param array    $items      The menu items to add.
      * @param callable $fx         The callback function to execute when an item is selected.
      * @param string   $icon       The icon.
+     * @param string   $menuId     The menu id return by callback.
      *
      * @throws Exception
      */
-    public function addHeaderDropdown($columnName, $items, $fx, $icon = 'caret square down')
+    public function addDropdown($columnName, $items, $fx, $icon = 'caret square down', $menuId = null)
     {
         $column = $this->table->columns[$columnName];
         if (!isset($column)) {
             throw new Exception('The column where you want to add dropdown does not exist: '.$columnName);
         }
+        if (!$menuId) {
+            $menuId = $columnName;
+        }
 
-        $column->addDropdown($columnName, $items, function ($item) use ($fx) {
+        $column->addDropdown($items, function ($item) use ($fx) {
             return call_user_func($fx, [$item]);
-        }, $icon);
+        }, $icon, $menuId);
     }
 
     /**
      * Add a popup to header column.
      *
      * @param string $columnName The name of column where to add popup.
+     * @param Popup  $popup      Popup view.
      * @param string $icon       The icon.
      *
      * @throws Exception
      *
      * @return mixed
      */
-    public function addHeaderPopup($columnName, $icon = 'caret square down')
+    public function addPopup($columnName, $popup = null, $icon = 'caret square down')
     {
         $column = $this->table->columns[$columnName];
         if (!isset($column)) {
             throw new Exception('The column where you want to add popup does not exist: '.$columnName);
         }
 
-        return $column->addPopup($icon);
+        return $column->addPopup($popup, $icon);
     }
 
     /**

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -31,7 +31,7 @@ class Loader extends View
 
     public $ui = 'ui segment';
 
-    /** @var Callback for triggering */
+    /** @var callable for triggering */
     protected $cb;
 
     public function init()

--- a/src/Popup.php
+++ b/src/Popup.php
@@ -94,6 +94,18 @@ class Popup extends View
      */
     public $minHeight = null; //'60px';
 
+    /**
+     * Whether or not the click event triggering popup
+     * should stop event propagation.
+     *
+     * Ex: when Popup is located inside a sortable grid header.
+     * Set this options to true in order to activate just the popup
+     * and stop sort action.
+     *
+     * @var bool
+     */
+    public $stopClickEvent = false;
+
     public function __construct($triggerBy = null)
     {
         if (is_object($triggerBy)) {
@@ -263,6 +275,9 @@ class Popup extends View
             }
             $chain = new jQuery($name);
             $chain->popup($this->popOptions);
+            if ($this->stopClickEvent) {
+                $chain->on('click', new jsExpression('function(e){e.stopPropagation();}'));
+            }
             $this->js(true, $chain);
         }
 

--- a/src/Popup.php
+++ b/src/Popup.php
@@ -263,22 +263,35 @@ class Popup extends View
         return $this;
     }
 
+    /**
+     * Return js action need to display popup.
+     * When a grid is reloading, this method can be call
+     * in order to display the popup once again.
+     *
+     * @return jQuery
+     */
+    public function jsPopup()
+    {
+        $name = $this->triggerBy;
+        if (!is_string($this->triggerBy)) {
+            $name = '#'.$this->triggerBy->name;
+            if ($this->triggerBy instanceof FormField\Generic) {
+                $name = '#'.$this->triggerBy->name.'_input';
+            }
+        }
+        $chain = new jQuery($name);
+        $chain->popup($this->popOptions);
+        if ($this->stopClickEvent) {
+            $chain->on('click', new jsExpression('function(e){e.stopPropagation();}'));
+        }
+
+        return $chain;
+    }
+
     public function renderView()
     {
         if ($this->triggerBy) {
-            $name = $this->triggerBy;
-            if (!is_string($this->triggerBy)) {
-                $name = '#'.$this->triggerBy->name;
-                if ($this->triggerBy instanceof FormField\Generic) {
-                    $name = '#'.$this->triggerBy->name.'_input';
-                }
-            }
-            $chain = new jQuery($name);
-            $chain->popup($this->popOptions);
-            if ($this->stopClickEvent) {
-                $chain->on('click', new jsExpression('function(e){e.stopPropagation();}'));
-            }
-            $this->js(true, $chain);
+            $this->js(true, $this->jsPopup());
         }
 
         if ($this->cb) {

--- a/src/Popup.php
+++ b/src/Popup.php
@@ -57,7 +57,7 @@ class Popup extends View
     /**
      * The callback use to generate dynamic content.
      *
-     * @var Callback|null
+     * @var callable|null
      */
     public $cb = null;
 

--- a/src/SSE.php
+++ b/src/SSE.php
@@ -47,7 +47,7 @@ class SSE
     /**
      * Executes user-specified action when call-back is triggered.
      *
-     * @param callback $callback
+     * @param callable $callback
      * @param array    $args
      *
      * @return mixed|null

--- a/src/Table.php
+++ b/src/Table.php
@@ -36,6 +36,8 @@ class Table extends Lister
      */
     public $columns = [];
 
+    public $columMenus = [];
+
     /**
      * Allows you to inject HTML into table using getHTMLTags hook and column call-backs.
      * Switch this feature off to increase performance at expense of some row-specific HTML.

--- a/src/Table.php
+++ b/src/Table.php
@@ -36,8 +36,6 @@ class Table extends Lister
      */
     public $columns = [];
 
-    public $columMenus = [];
-
     /**
      * Allows you to inject HTML into table using getHTMLTags hook and column call-backs.
      * Switch this feature off to increase performance at expense of some row-specific HTML.

--- a/src/TableColumn/Generic.php
+++ b/src/TableColumn/Generic.php
@@ -45,6 +45,8 @@ class Generic
      */
     public $hasHeaderAction = false;
 
+    public $headerAction = null;
+
     /**
      * The tag value required for getTag when using an header action.
      *

--- a/src/TableColumn/Generic.php
+++ b/src/TableColumn/Generic.php
@@ -62,15 +62,15 @@ class Generic
         $this->setDefaults($defaults);
     }
 
-
     /**
      * Add popup to header.
      *
      * @param string $id
      * @param string $icon
      *
-     * @return mixed
      * @throws Exception
+     *
+     * @return mixed
      */
     public function addPopup($id, $icon = 'caret square down')
     {
@@ -117,7 +117,6 @@ class Generic
         foreach ($items as $key => $item) {
             if (is_int($key)) {
                 $menuITems[] = ['name' => $item, 'value' => $item];
-
             } else {
                 $menuITems[] = ['name' => $key, 'value' => $item];
             }
@@ -125,8 +124,8 @@ class Generic
 
         $cb = $this->addHeaderDropdown($id, $menuITems, $icon);
 
-        $cb->onChangeItem(function($menu, $item) use ($fx) {
-           return call_user_func($fx, $item);
+        $cb->onChangeItem(function ($menu, $item) use ($fx) {
+            return call_user_func($fx, $item);
         });
     }
 

--- a/src/TableColumn/Generic.php
+++ b/src/TableColumn/Generic.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace atk4\ui\TableColumn;
+
 use atk4\ui\DropDown;
 use atk4\ui\Exception;
 use atk4\ui\jQuery;
@@ -68,16 +69,16 @@ class Generic
      * @param Popup $popup
      * @param $icon
      */
-    public function addHeaderPopup($popup,  $icon = 'caret square down')
+    public function addHeaderPopup($popup, $icon = 'caret square down')
     {
         $this->headerAction = true;
         $this->headerActionTag = ['div',  ['class'=>'atk-table-dropdown'],
             [
                 ['i', ['id' => $this->name.'_ac', 'class' => $icon.' icon']],
-            ]
+            ],
         ];
         $popup->triggerBy = '#'.$this->name.'_ac';
-        $popup->popOptions = array_merge($popup->popOptions, ['on' =>'click', 'position' => 'bottom left', /*'movePopup' => false,*//* 'target' => '#'.$this->name.'_th'*/]);
+        $popup->popOptions = array_merge($popup->popOptions, ['on' =>'click', 'position' => 'bottom left'/*'movePopup' => false,*//* 'target' => '#'.$this->name.'_th'*/]);
     }
 
     /**
@@ -88,10 +89,11 @@ class Generic
      * @param $items
      * @param string $icon
      *
-     * @return \atk4\ui\jsCallback
      * @throws Exception
+     *
+     * @return \atk4\ui\jsCallback
      */
-    public function addHeaderDropdown($name, $items,  $icon = 'caret square down')
+    public function addHeaderDropdown($name, $items, $icon = 'caret square down')
     {
         $this->headerAction = true;
         $this->headerActionTag = ['div',  ['class'=>'atk-table-dropdown'],
@@ -100,7 +102,7 @@ class Generic
                     'div', ['id' => $this->name.'_ac', 'class'=>'ui top right pointing dropdown', 'data-menu-id' => $name],
                     [['i', ['class' => $icon.' icon']]],
                 ],
-            ]
+            ],
         ];
 
         $cb = $this->table->add(new jsHeader());
@@ -120,7 +122,7 @@ class Generic
         $chain->dropdown([
                              'action'   => 'hide',
                              'values'   => $items,
-                             'onChange' => new jsExpression($function)
+                             'onChange' => new jsExpression($function),
                          ]);
 
         $this->table->js(true, $chain);
@@ -239,7 +241,7 @@ class Generic
             $tag = $this->getTag(
                 'head',
                 [$f->getCaption(),
-                    $this->headerActionTag
+                    $this->headerActionTag,
                 ],
                 $attr
             );

--- a/src/TableColumn/Generic.php
+++ b/src/TableColumn/Generic.php
@@ -2,7 +2,6 @@
 
 namespace atk4\ui\TableColumn;
 
-use atk4\ui\DropDown;
 use atk4\ui\Exception;
 use atk4\ui\jQuery;
 use atk4\ui\jsExpression;
@@ -63,22 +62,72 @@ class Generic
         $this->setDefaults($defaults);
     }
 
+
+    /**
+     * Add popup to header.
+     *
+     * @param string $id
+     * @param string $icon
+     *
+     * @return mixed
+     * @throws Exception
+     */
+    public function addPopup($id, $icon = 'caret square down')
+    {
+        if (!$this->app) {
+            throw new Exception('Columns\'s popup need to have a layout.');
+        }
+        $popup = $this->app->add('Popup')->setHoverable();
+        $this->addHeaderPopup($id, $popup, $icon);
+
+        return $popup;
+    }
+
     /**
      * Setup popup header action.
      *
      * @param Popup $popup
      * @param $icon
      */
-    public function addHeaderPopup($popup, $icon = 'caret square down')
+    public function addHeaderPopup($id, $popup, $icon = 'caret square down')
     {
         $this->headerAction = true;
         $this->headerActionTag = ['div',  ['class'=>'atk-table-dropdown'],
             [
-                ['i', ['id' => $this->name.'_ac', 'class' => $icon.' icon']],
+                ['i', ['id' => 'atk-popup-cln-ac-'.$id, 'class' => $icon.' icon']],
             ],
         ];
-        $popup->triggerBy = '#'.$this->name.'_ac';
+        $popup->triggerBy = '#atk-popup-cln-ac-'.$id;
         $popup->popOptions = array_merge($popup->popOptions, ['on' =>'click', 'position' => 'bottom left'/*'movePopup' => false,*//* 'target' => '#'.$this->name.'_th'*/]);
+    }
+
+    /**
+     * Add a dropdown header menu.
+     *
+     * @param string   $id
+     * @param array    $items
+     * @param callable $fx
+     * @param string   $icon
+     *
+     * @throws Exception
+     */
+    public function addDropdown($id, $items, $fx, $icon = 'caret square down')
+    {
+        $menuITems = [];
+        foreach ($items as $key => $item) {
+            if (is_int($key)) {
+                $menuITems[] = ['name' => $item, 'value' => $item];
+
+            } else {
+                $menuITems[] = ['name' => $key, 'value' => $item];
+            }
+        }
+
+        $cb = $this->addHeaderDropdown($id, $menuITems, $icon);
+
+        $cb->onChangeItem(function($menu, $item) use ($fx) {
+           return call_user_func($fx, $item);
+        });
     }
 
     /**
@@ -93,13 +142,13 @@ class Generic
      *
      * @return \atk4\ui\jsCallback
      */
-    public function addHeaderDropdown($name, $items, $icon = 'caret square down')
+    public function addHeaderDropdown($id, $items, $icon = 'caret square down')
     {
         $this->headerAction = true;
         $this->headerActionTag = ['div',  ['class'=>'atk-table-dropdown'],
             [
                 [
-                    'div', ['id' => $this->name.'_ac', 'class'=>'ui top right pointing dropdown', 'data-menu-id' => $name],
+                    'div', ['id' => 'atk-dropdown-cln-ac-'.$id, 'class'=>'ui top right pointing dropdown', 'data-menu-id' => $id],
                     [['i', ['class' => $icon.' icon']]],
                 ],
             ],
@@ -118,7 +167,7 @@ class Generic
                             );
                      }";
 
-        $chain = new jQuery('#'.$this->name.'_ac');
+        $chain = new jQuery('#atk-dropdown-cln-ac-'.$id);
         $chain->dropdown([
                              'action'   => 'hide',
                              'values'   => $items,

--- a/src/TableColumn/Generic.php
+++ b/src/TableColumn/Generic.php
@@ -137,7 +137,7 @@ class Generic
         $cb = $this->setHeaderDropdown($menuITems, $icon, $menuId);
 
         $cb->onSelectItem(function ($menu, $item) use ($fx) {
-            return call_user_func($fx, [$item, $menu]);
+            return call_user_func($fx, $item, $menu);
         });
     }
 

--- a/src/TableColumn/Generic.php
+++ b/src/TableColumn/Generic.php
@@ -72,13 +72,13 @@ class Generic
      *
      * @return mixed
      */
-    public function addPopup($id, $icon = 'caret square down')
+    public function addPopup($icon = 'caret square down')
     {
         if (!$this->app) {
             throw new Exception('Columns\'s popup need to have a layout.');
         }
         $popup = $this->app->add('Popup')->setHoverable();
-        $this->addHeaderPopup($id, $popup, $icon);
+        $this->addHeaderPopup($popup, $icon);
 
         return $popup;
     }
@@ -89,16 +89,19 @@ class Generic
      * @param Popup $popup
      * @param $icon
      */
-    public function addHeaderPopup($id, $popup, $icon = 'caret square down')
+    public function addHeaderPopup($popup, $icon = 'caret square down')
     {
         $this->headerAction = true;
+        $id = $this->name.'_ac';
+
         $this->headerActionTag = ['div',  ['class'=>'atk-table-dropdown'],
             [
-                ['i', ['id' => 'atk-popup-cln-ac-'.$id, 'class' => $icon.' icon']],
+                ['i', ['id' => $id, 'class' => $icon.' icon']],
             ],
         ];
-        $popup->triggerBy = '#atk-popup-cln-ac-'.$id;
-        $popup->popOptions = array_merge($popup->popOptions, ['on' =>'click', 'position' => 'bottom left'/*'movePopup' => false,*//* 'target' => '#'.$this->name.'_th'*/]);
+        $popup->triggerBy = '#'.$id;
+        $popup->popOptions = array_merge($popup->popOptions, ['on' =>'click', 'position' => 'bottom right', 'movePopup' => false]);
+        $popup->stopClickEvent = true;
     }
 
     /**
@@ -111,7 +114,7 @@ class Generic
      *
      * @throws Exception
      */
-    public function addDropdown($id, $items, $fx, $icon = 'caret square down')
+    public function addDropdown($menuId, $items, $fx, $icon = 'caret square down')
     {
         $menuITems = [];
         foreach ($items as $key => $item) {
@@ -122,9 +125,9 @@ class Generic
             }
         }
 
-        $cb = $this->addHeaderDropdown($id, $menuITems, $icon);
+        $cb = $this->addHeaderDropdown($menuId, $menuITems, $icon);
 
-        $cb->onChangeItem(function ($menu, $item) use ($fx) {
+        $cb->onSelectItem(function ($menu, $item) use ($fx) {
             return call_user_func($fx, $item);
         });
     }
@@ -141,13 +144,14 @@ class Generic
      *
      * @return \atk4\ui\jsCallback
      */
-    public function addHeaderDropdown($id, $items, $icon = 'caret square down')
+    public function addHeaderDropdown($menuId, $items, $icon = 'caret square down')
     {
         $this->headerAction = true;
+        $id = $this->name.'_ac';
         $this->headerActionTag = ['div',  ['class'=>'atk-table-dropdown'],
             [
                 [
-                    'div', ['id' => 'atk-dropdown-cln-ac-'.$id, 'class'=>'ui top right pointing dropdown', 'data-menu-id' => $id],
+                    'div', ['id' => $id, 'class'=>'ui top right pointing dropdown', 'data-menu-id' => $menuId],
                     [['i', ['class' => $icon.' icon']]],
                 ],
             ],
@@ -166,12 +170,15 @@ class Generic
                             );
                      }";
 
-        $chain = new jQuery('#atk-dropdown-cln-ac-'.$id);
+        $chain = new jQuery('#'.$id);
         $chain->dropdown([
                              'action'   => 'hide',
                              'values'   => $items,
                              'onChange' => new jsExpression($function),
                          ]);
+
+        //will stop grid column from being sorted.
+        $chain->on('click', new jsExpression('function(e){e.stopPropagation();}'));
 
         $this->table->js(true, $chain);
 

--- a/src/TableColumn/Generic.php
+++ b/src/TableColumn/Generic.php
@@ -149,11 +149,30 @@ class Generic
             }
         }
 
-        return $this->getTag(
-            'head',
-            $f->getCaption(),
-            $attr
-        );
+        if (!empty($this->table->columMenus)) {
+            $tag =  $this->getTag(
+                'head',
+                [ $f->getCaption(),
+                    ['div',  ['class'=>'atk-table-dropdown'],
+                        [
+                            [
+                                'div', ['class'=>'ui top right pointing dropdown'],
+                                [['i', ['class' => 'caret square down icon']]]
+                            ]
+                        ]
+                    ],
+                ],
+                $attr
+            );
+        } else {
+            $tag = $this->getTag(
+                'head',
+                $f->getCaption(),
+                $attr
+            );
+        }
+
+        return $tag;
     }
 
     /**

--- a/src/TableColumn/Generic.php
+++ b/src/TableColumn/Generic.php
@@ -65,6 +65,7 @@ class Generic
     /**
      * Add popup to header.
      *
+     * @param Popup  $popup
      * @param string $id
      * @param string $icon
      *
@@ -72,13 +73,16 @@ class Generic
      *
      * @return mixed
      */
-    public function addPopup($icon = 'caret square down')
+    public function addPopup($popup = null, $icon = 'caret square down')
     {
         if (!$this->app) {
             throw new Exception('Columns\'s popup need to have a layout.');
         }
-        $popup = $this->app->add('Popup')->setHoverable();
-        $this->addHeaderPopup($popup, $icon);
+        if (!$popup) {
+            $popup = $this->app->add('Popup')->setHoverable();
+        }
+
+        $this->setHeaderPopup($popup, $icon);
 
         return $popup;
     }
@@ -89,7 +93,7 @@ class Generic
      * @param Popup $popup
      * @param $icon
      */
-    public function addHeaderPopup($popup, $icon = 'caret square down')
+    public function setHeaderPopup($popup, $icon = 'caret square down')
     {
         $this->headerAction = true;
         $id = $this->name.'_ac';
@@ -112,14 +116,14 @@ class Generic
     /**
      * Add a dropdown header menu.
      *
-     * @param string   $id
-     * @param array    $items
-     * @param callable $fx
-     * @param string   $icon
+     * @param array       $items
+     * @param callable    $fx
+     * @param string      $icon
+     * @param string|null $menuId     The menu name.
      *
      * @throws Exception
      */
-    public function addDropdown($menuId, $items, $fx, $icon = 'caret square down')
+    public function addDropdown($items, $fx, $icon = 'caret square down', $menuId = null)
     {
         $menuITems = [];
         foreach ($items as $key => $item) {
@@ -130,10 +134,10 @@ class Generic
             }
         }
 
-        $cb = $this->addHeaderDropdown($menuId, $menuITems, $icon);
+        $cb = $this->setHeaderDropdown($menuITems, $icon, $menuId);
 
         $cb->onSelectItem(function ($menu, $item) use ($fx) {
-            return call_user_func($fx, $item);
+            return call_user_func($fx, [$item, $menu]);
         });
     }
 
@@ -142,14 +146,15 @@ class Generic
      * This method return a callback where you can detect
      * menu item change via $cb->onMenuItem($item) function.
      *
-     * @param $items
-     * @param string $icon
+     * @param             $items
+     * @param string      $icon
+     * @param string|null $menuId The id of the menu.
      *
      * @throws Exception
      *
      * @return \atk4\ui\jsCallback
      */
-    public function addHeaderDropdown($menuId, $items, $icon = 'caret square down')
+    public function setHeaderDropdown($items, $icon = 'caret square down', $menuId = null)
     {
         $this->headerAction = true;
         $id = $this->name.'_ac';

--- a/src/TableColumn/Generic.php
+++ b/src/TableColumn/Generic.php
@@ -102,6 +102,11 @@ class Generic
         $popup->triggerBy = '#'.$id;
         $popup->popOptions = array_merge($popup->popOptions, ['on' =>'click', 'position' => 'bottom right', 'movePopup' => false]);
         $popup->stopClickEvent = true;
+
+        if (@$_GET['__atk_reload']) {
+            //This is part of a reload, need to reactivate popup.
+            $this->table->js(true, $popup->jsPopup());
+        }
     }
 
     /**

--- a/src/TableColumn/Generic.php
+++ b/src/TableColumn/Generic.php
@@ -119,7 +119,7 @@ class Generic
      * @param array       $items
      * @param callable    $fx
      * @param string      $icon
-     * @param string|null $menuId     The menu name.
+     * @param string|null $menuId The menu name.
      *
      * @throws Exception
      */

--- a/src/TableColumn/jsHeader.php
+++ b/src/TableColumn/jsHeader.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace atk4\ui\TableColumn;
+
+use atk4\ui\jsCallback;
+
+/**
+ * Implement a callback for a header dropdown menu.
+ */
+class jsHeader extends jsCallback
+{
+    /**
+     * Function to call when header menu has change.
+     *
+     * @param callable $fx
+     */
+    public function onChangeItem($fx)
+    {
+        if (is_callable($fx)) {
+            if ($this->triggered()) {
+                $param = [$_GET['id'],  @$_GET['item']];
+                $this->set(function () use ($fx, $param) {
+                    return call_user_func_array($fx, $param);
+                });
+            }
+        }
+    }
+}

--- a/src/TableColumn/jsHeader.php
+++ b/src/TableColumn/jsHeader.php
@@ -5,16 +5,16 @@ namespace atk4\ui\TableColumn;
 use atk4\ui\jsCallback;
 
 /**
- * Implement a callback for a header dropdown menu.
+ * Implement a callback for a column header dropdown menu.
  */
 class jsHeader extends jsCallback
 {
     /**
-     * Function to call when header menu has change.
+     * Function to call when header menu item is select.
      *
      * @param callable $fx
      */
-    public function onChangeItem($fx)
+    public function onSelectItem($fx)
     {
         if (is_callable($fx)) {
             if ($this->triggered()) {

--- a/src/VirtualPage.php
+++ b/src/VirtualPage.php
@@ -13,7 +13,7 @@ namespace atk4\ui;
  */
 class VirtualPage extends View
 {
-    /** @var Callback */
+    /** @var callable */
     public $cb = null;
 
     /** @var callable Optional callback function of virtual page */

--- a/tests/DemoTest.php
+++ b/tests/DemoTest.php
@@ -86,6 +86,7 @@ class DemoTest extends \atk4\core\PHPUnit_AgileTestCase
   sticky.php
   table.php
   table2.php
+  tablecolumnmenu.php
   tabs.php
   view.php
   virtual.php


### PR DESCRIPTION
Implements ability to interact with "Columns" of a grid by clicking on icon in the header. This is NOT same as sorting.

Column can be used to implement "column-specific filter" or "hide column" option or any other column-specific interraction through a pop-up.

<img width="673" alt="screen shot 2018-04-12 at 18 38 35" src="https://user-images.githubusercontent.com/453929/38694127-bd4ba314-3e80-11e8-9e37-b5d8565fb94a.png">


Usage:

``` php
$column = $table->addColumn('test');

$column->addPopup('test')->add('LoremIpsum');
```

You can also add menus to the column using a callback:

``` php
$column->addDropdown('name', ['one', 'two', 'three'], function($menuItem) {
    return 'Selected '.$menuItem;
});
```

The callback is called when user select an item in the menu.

Support grid column too:

```
//Adding a dropdown menu to the column 'name'.
$g->addHeaderDropdown('name', ['Rename', 'Delete'], function($item){
   return $item;
});

//Adding a popup view to the column 'iso'
$pop = $g->addHeaderPopup('iso');
$pop->add('View')->set('Grid column popup');
```
