### PR TITLE
Allow to set a custom Limit to loaded records

### DIFF
--- a/src/FormField/AutoComplete.php
+++ b/src/FormField/AutoComplete.php
@@ -45,7 +45,7 @@ class AutoComplete extends Input
 
     /**
      * Sets the max. amount of records that are loaded. The default 10
-     * displays nicely in UI,
+     * displays nicely in UI.
      *
      * @var int
      */

--- a/src/FormField/AutoComplete.php
+++ b/src/FormField/AutoComplete.php
@@ -44,6 +44,14 @@ class AutoComplete extends Input
     public $plus = false;
 
     /**
+     * Sets the max. amount of records that are loaded. The default 10
+     * displays nicely in UI,
+     *
+     * @var int
+     */
+    public $limit = 10;
+
+    /**
      * Semantic UI uses cache to remember choices. For dynamic sites this may be dangerous, so
      * it's disabled by default. To switch cache on, set 'cache'=>'local'.
      *
@@ -131,7 +139,7 @@ class AutoComplete extends Input
         if (!$this->model) {
             $this->app->terminate(json_encode([['id' => '-1', 'name' => 'Model must be set for AutoComplete']]));
         }
-        $this->model->setLimit(10);
+        $this->model->setLimit($this->limit);
         if (isset($_GET['q'])) {
             if ($this->search instanceof Closure) {
                 $this->search($this->model, $_GET['q']);


### PR DESCRIPTION
Adds a property `limit` which can be used to set a custom limit of records loaded.
This can be very handy in the following case:
Imagine in total its 50 records for this model, 20 of them are used often, the others hardly. Setting the limit to 20 and the sorting to frequency makes the 20 most used records available without typing anything in the text field.