### PR TITLE
Fix/Crud Draghandler Position

### DIFF
--- a/src/Grid.php
+++ b/src/Grid.php
@@ -281,10 +281,8 @@ class Grid extends View
     public function addDragHandler()
     {
         $handler = $this->table->addColumn(null, 'DragHandler');
-
-        // Move element to the beginning
-        $k = array_search($this->selection, $this->table->columns);
-        $this->table->columns = [$k => $this->table->columns[$k]] + $this->table->columns;
+        // Move last column to the beginning in table column array.
+        array_unshift($this->table->columns, array_pop($this->table->columns));
 
         return $handler;
     }


### PR DESCRIPTION
This fix will make sure the draghandler column is set to first column when using drag handler in CRUD with action button.

Otherwise, draghandler column is set after edit / delete button.