### PR TITLE
Make View->on(event, [jsAction1, jsAction2]) work

### DIFF
--- a/src/View.php
+++ b/src/View.php
@@ -955,7 +955,11 @@ class View implements jsExpressionable
 
             $actions[] = $cb;
         //$thisAction->api(['on'=>'now', 'url'=>$cb->getJSURL(), 'urlData'=>$urlData, 'obj'=>new jsExpression('this')]);
-        } elseif ($action) {
+        }
+        elseif(is_array($action)) {
+            $actions = array_merge($actions, $action);
+        }
+        elseif ($action) {
             // otherwise include
             $actions[] = $action;
         }


### PR DESCRIPTION
If an array containing only JS actions was used as second parameter of View->on, it failed and threw the error message:
atk4\ui\Exception: You cannot add anything into the view after it was rendered

Now JS actions are merged into $actions array and it works as intended.

Simple test code:
        $v_test= $app->add(['Button']);
        $v_test->on('click', [$v_test->js()->html('sdfsf'), $v_test->js()->html('ddddd')]);