### PR TITLE
Allow $field->ui['placeholder'] to affect form fields' placeholder directly.

### DIFF
--- a/demos/form2.php
+++ b/demos/form2.php
@@ -72,7 +72,7 @@ $form->onSubmit(function ($f) {
         {
             parent::init();
             $this->addField('name', ['required' => true]);
-            $this->addField('surname');
+            $this->addField('surname', ['ui'=>['placeholder'=>'e.g. Smith']]);
             $this->addField('gender', ['enum' => ['M', 'F']]);
         }
 

--- a/src/Form.php
+++ b/src/Form.php
@@ -370,6 +370,10 @@ class Form extends View //implements \ArrayAccess - temporarily so that our buil
             $fallback_seed['hint'] = $f->ui['hint'];
         }
 
+        if (isset($f->ui['placeholder'])) {
+            $fallback_seed['placeholder'] = $f->ui['placeholder'];
+        }
+
         $seed = $this->mergeSeeds(
             $seed,
             isset($f->ui['form']) ? $f->ui['form'] : null,


### PR DESCRIPTION
There is a perfectly working solution to set a Field's placeholder value:

``` php
$this->addField('surname', ['ui'=>['Form'=>['placeholder'=>'e.g. Smith']]]);
```

However, it appears that defining this value directly in 'ui' is desired by users:

``` php
$this->addField('surname', ['ui'=>['placeholder'=>'e.g. Smith']]);
```

This PR implements a short-hand method:

<img width="392" alt="screen shot 2018-06-04 at 10 23 12" src="https://user-images.githubusercontent.com/453929/40909377-4fa29a4a-67e1-11e8-9ecd-47b28ce1d762.png">

