### PR TITLE
fix/Persisitence-ui-for-reference-field

### DIFF
--- a/src/Persistence/UI.php
+++ b/src/Persistence/UI.php
@@ -114,7 +114,7 @@ class UI extends \atk4\data\Persistence
         }
 
         if (isset($f->reference)) {
-            if ($value === '') {
+            if (empty($value)) {
                 $value = null;
             }
         }


### PR DESCRIPTION
Will set null to all empty possible value:

- ‘’ (an empty string)
- 0 (0 as integer)
- 0.0 (0 as float)
- ‘0’ (0 as string)
- null
- false
- array (an empty array)