### PR TITLE
fix/#487-Modal Behaviour

### DIFF
--- a/demos/modal2.php
+++ b/demos/modal2.php
@@ -23,7 +23,7 @@ $b->on('click', $modal_simple->show());
 
 /********** DYNAMIC ******************/
 
-$app->add(['Header', 'Modal loading dynamic content via callback']);
+$app->add(['Header', 'Three levels of Modal loading dynamic content via callback']);
 
 //modal_vp1 will be render into page but hide until $modal_vp1->show() is activate.
 $modal_vp1 = $app->add(['Modal', 'title' => 'Lorem Ipsum load dynamically']);
@@ -31,21 +31,29 @@ $modal_vp1 = $app->add(['Modal', 'title' => 'Lorem Ipsum load dynamically']);
 //modal_vp2 will be render into page but hide until $modal_vp1->show() is activate.
 $modal_vp2 = $app->add(['Modal', 'title' => 'Text message load dynamically'])->addClass('small');
 
+$modal_vp3 = $app->add(['Modal', 'title' => 'Third level modal'])->addClass('small');
+$modal_vp3->set(function($modal){
+    $modal->add(['Text'])->set('This is yet another modal');
+    //$modal->add(['LoremIpsum', 'size' => 2]);
+
+});
+
 //When $modal_vp1->show() is activate, it will dynamically add this content to it.
 $modal_vp1->set(function ($modal) use ($modal_vp2) {
     $modal->add(new \atk4\ui\tests\ViewTester());
     $modal->add(['LoremIpsum', 'size' => 2]);
     $form = $modal->add('Form');
-    $form->addField('color', null, ['enum' => ['red', 'green', 'blue']]);
+    $form->addField('color', null, ['enum' => ['red', 'green', 'blue'], 'default' => 'green']);
     $form->onSubmit(function ($form) use ($modal_vp2) {
         return $modal_vp2->show(['color' => $form->model['color']]);
     });
 });
 
 //When $modal_vp2->show() is activate, it will dynamically add this content to it.
-$modal_vp2->set(function ($modal) {
+$modal_vp2->set(function ($modal) use ($modal_vp3) {
     //$modal->add(new \atk4\ui\tests\ViewTester());
     $modal->add(['Message', 'Message', @$_GET['color']])->text->addParagraph('This text is loaded using a second modal.');
+    $modal->add('Button')->set('Third modal')->on('click', $modal_vp3->show());
 });
 
 $bar = $app->add(['View', 'ui' => 'buttons']);
@@ -123,16 +131,17 @@ $modal_step->addButtonAction($action);
 
 //Set modal functionality. Will changes content according to page being displayed.
 $modal_step->set(function ($modal) use ($modal_step, $session, $prev_action, $next_action) {
-    $page = $session->recall('page', 1);
-    $success = $session->recall('success', false);
-    if (isset($_GET['move'])) {
-        if ($_GET['move'] === 'next' && $success) {
-            $page++;
+    $page    = $session->recall( 'page', 1 );
+    $success = $session->recall( 'success', false );
+    if ( isset( $_GET['move'] ) ) {
+        if ( $_GET['move'] === 'next' && $success ) {
+            $page ++;
         }
-        if ($_GET['move'] === 'prev' && $page > 1) {
-            $page--;
+        if ( $_GET['move'] === 'prev' && $page > 1 ) {
+            $page --;
         }
-        $session->memorize('success', false);
+        $session->memorize( 'success', false );
+    } elseif ($page === 2) {
     } else {
         $page = 1;
     }

--- a/demos/modal2.php
+++ b/demos/modal2.php
@@ -32,10 +32,9 @@ $modal_vp1 = $app->add(['Modal', 'title' => 'Lorem Ipsum load dynamically']);
 $modal_vp2 = $app->add(['Modal', 'title' => 'Text message load dynamically'])->addClass('small');
 
 $modal_vp3 = $app->add(['Modal', 'title' => 'Third level modal'])->addClass('small');
-$modal_vp3->set(function($modal){
+$modal_vp3->set(function ($modal) {
     $modal->add(['Text'])->set('This is yet another modal');
     //$modal->add(['LoremIpsum', 'size' => 2]);
-
 });
 
 //When $modal_vp1->show() is activate, it will dynamically add this content to it.
@@ -131,16 +130,16 @@ $modal_step->addButtonAction($action);
 
 //Set modal functionality. Will changes content according to page being displayed.
 $modal_step->set(function ($modal) use ($modal_step, $session, $prev_action, $next_action) {
-    $page    = $session->recall( 'page', 1 );
-    $success = $session->recall( 'success', false );
-    if ( isset( $_GET['move'] ) ) {
-        if ( $_GET['move'] === 'next' && $success ) {
-            $page ++;
+    $page = $session->recall('page', 1);
+    $success = $session->recall('success', false);
+    if (isset($_GET['move'])) {
+        if ($_GET['move'] === 'next' && $success) {
+            $page++;
         }
-        if ( $_GET['move'] === 'prev' && $page > 1 ) {
-            $page --;
+        if ($_GET['move'] === 'prev' && $page > 1) {
+            $page--;
         }
-        $session->memorize( 'success', false );
+        $session->memorize('success', false);
     } elseif ($page === 2) {
     } else {
         $page = 1;

--- a/js/README.md
+++ b/js/README.md
@@ -97,6 +97,16 @@ This command will output the atkjs-ui.min.js file, also in /public folder.
 
 ## Release note
 
+### version 1.3.5
+
+#### Changes in ModalService
+  - Set top modal position value to 'absolute'
+    - this fix semantic.ui 2.3.2 modal positioning problem.
+  - Add esc key handler to document while modal are in service.
+    - this allow to close all open modal window using esc key one after the others.  
+#### Changes in createModal
+  - Allow to pass a string icon value for closing icon.  
+
 ### version 1.3.4
 
   - Allow jsSearch to load using already set input value.

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atkjs-ui",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Agile Toolkit Javascript library.",
   "main": "lib/atkjs-ui.js",
   "scripts": {

--- a/js/src/plugins/createModal.js
+++ b/js/src/plugins/createModal.js
@@ -22,7 +22,7 @@ export default class createModal extends atkPlugin {
   }
 
   getDialogHtml(title) {
-    return `<i class="close icon"></i>
+    return `<i class="${this.settings.icon} icon close"></i>
           <div class="header">${title}</div>
           <div class="image content atk-dialog-content">
             </div>
@@ -34,6 +34,7 @@ createModal.DEFAULTS = {
   title: '',
   uri: null,
   uri_options: {},
+  icon: '',
   label: 'Loading...',
   modal: {
       duration: 100

--- a/js/src/services/ModalService.js
+++ b/js/src/services/ModalService.js
@@ -31,11 +31,11 @@ class ModalService {
     }
 
     onHidden() {
-        modalService.removeModal($(this));
+      modalService.removeModal($(this));
     }
 
     onVisible() {
-        let args = {}, data;
+      let args = {}, data;
         // const service = apiService;
         const $modal = $(this);
         const $content = $(this).find('.atk-dialog-content');
@@ -81,19 +81,41 @@ class ModalService {
                 }
             });
         }
-        modalService.addModal($modal);
     }
 
-    onShow() {}
+    onShow() {
+        const $modal = $(this);
+        modalService.addModal($modal);
+    }
 
     onHide() {
         return $(this).data('isClosable');
     }
 
     addModal(modal) {
+        const that = this;
         this.modals.push(modal);
+
         this.setCloseTriggerEventInModals();
         this.hideShowCloseIcon();
+
+        // temp fix while semantic modal positioning is not fixed.
+        // hide other modals.
+        if (this.modals.length > 1 ) {
+           modal.css('position', 'absolute');
+           this.modals[this.modals.length - 2].css('opacity', 0);
+        }
+
+        // add modal esc handler.
+        if (this.modals.length === 1) {
+            $(document).on('keyup.atk.modalService', function (e) {
+              if (e.keyCode === 27) {
+                  if (that.modals.length > 0) {
+                      that.modals[that.modals.length -1].modal('hide');
+                  }
+              }
+            });
+        }
     }
 
     removeModal(modal) {
@@ -104,6 +126,17 @@ class ModalService {
         this.modals.pop();
         this.setCloseTriggerEventInModals();
         this.hideShowCloseIcon();
+
+        // temp fix while semantic modal positioning is not fixed.
+        // show last modals.
+        if (this.modals.length > 0 ) {
+           modal.css('position', '');
+           this.modals[this.modals.length - 1].css('opacity', '');
+        }
+
+        if (this.modals.length === 0 ) {
+            $(document).off('atk.modalService');
+        }
     }
 
     doAutoFocus(modal) {

--- a/template/semantic-ui/modal.html
+++ b/template/semantic-ui/modal.html
@@ -1,4 +1,4 @@
-<{_element}div{/} id="{$_id}" class="{_ui}ui {/} {$class} {_class}{/}" style="{$style}" {$attributes}><i class="{$close}"></i><i class="icon close"></i>
+<{_element}div{/} id="{$_id}" class="{_ui}ui {/} {$class} {_class}{/}" style="{$style}" {$attributes}><i class="{$close}"></i>
 <div class="header">{$title}</div>
 <div class="img content atk-dialog-content">{$Content}</div>
 <div class="actions">

--- a/template/semantic-ui/modal.pug
+++ b/template/semantic-ui/modal.pug
@@ -1,5 +1,4 @@
 <{_element}div{/} id="{$_id}" class="{_ui}ui {/} {$class} {_class}{/}" style="{$style}" {$attributes}><i class="{$close}"></i>
-    i.icon.close
     .header {$title}
     div(class="img content atk-dialog-content") {$Content}
     .actions


### PR DESCRIPTION
Fix multiple modal positioning when using multiple modal;

- Modals under top modal opacity are set to 0, they look hidden but they are still available.
  - this is need for modalServices to work properly. 
  - We can set the opacity value to an higher number if the intent is still be able to see under modals.
 - Proper positioning is done by setting position value to absolute. 
-  Fix the esc key behaviour. Simply adding our own esc event in modal service.

Update modal2.php demos files in order to show modal at three level deep.

## Note
atkjs-ui need to be rebuild.