### PR TITLE
Grid will display loader while fetching data

### DIFF
--- a/src/Grid.php
+++ b/src/Grid.php
@@ -86,7 +86,7 @@ class Grid extends View
     {
         parent::init();
 
-        $this->container = $this->add(['View', 'ui'=>'', 'template' => new Template('<div id="{$_id}"><div class="ui table atk-overflow-auto">{$Table}{$Content}</div>{$Paginator}</div>')]);
+        $this->container = $this->add(['View', 'ui'=>'ui basic segment', 'template' => new Template('<div id="{$_id}" class="{$_class} {$class}"><div class="ui table atk-overflow-auto">{$Table}{$Content}</div>{$Paginator}</div>')]);
 
         if ($this->menu !== false) {
             $this->menu = $this->add($this->factory(['Menu', 'activate_on_click' => false], $this->menu), 'Menu');


### PR DESCRIPTION
Add css ‘segment’ class to grid element in order for loader to be display while loading.

resolve #493 