### PR TITLE
Fix problem with multiple callbacks being not executed

### DIFF
--- a/demos/tabs.php
+++ b/demos/tabs.php
@@ -18,6 +18,13 @@ $t->addTab('Dynamic Lorem Ipsum', function ($tab) {
     $tab->add(['LoremIpsum', 'size' => 2]);
 });
 
+// modal tab
+$t->addTab('Modal popup', function ($tab) {
+    $tab->add(['Button', 'Load Lorem'])->on('click', $tab->add('Modal')->set(function($p){
+        $p->add(['LoremIpsum', 'size' => 2]);
+    })->show());
+});
+
 // dynamic tab
 $t->addTab('Dynamic Form', function ($tab) {
     $tab->add(['Message', 'It takes 2 seconds for this tab to load', 'warning']);

--- a/demos/tabs.php
+++ b/demos/tabs.php
@@ -20,7 +20,7 @@ $t->addTab('Dynamic Lorem Ipsum', function ($tab) {
 
 // modal tab
 $t->addTab('Modal popup', function ($tab) {
-    $tab->add(['Button', 'Load Lorem'])->on('click', $tab->add('Modal')->set(function($p){
+    $tab->add(['Button', 'Load Lorem'])->on('click', $tab->add('Modal')->set(function ($p) {
         $p->add(['LoremIpsum', 'size' => 2]);
     })->show());
 });

--- a/src/CallbackLater.php
+++ b/src/CallbackLater.php
@@ -27,11 +27,9 @@ class CallbackLater extends Callback
 
         if ($this->app->is_rendering) {
             return parent::set($callback, $args);
-        } else {
-            $hook = 'beforeRender';
         }
 
-        $this->app->addHook($hook, function (...$args) use ($callback) {
+        $this->app->addHook('beforeRender', function (...$args) use ($callback) {
             array_shift($args); // Hook will have first argument pointing to the app. We don't need that.
             return parent::set($callback, $args);
         }, $args);

--- a/src/CallbackLater.php
+++ b/src/CallbackLater.php
@@ -26,7 +26,7 @@ class CallbackLater extends Callback
         }
 
         if ($this->app->is_rendering) {
-            $hook = 'beforeOutput';
+            return parent::set($callback, $args);
         } else {
             $hook = 'beforeRender';
         }


### PR DESCRIPTION
Various UI element use CallbackLater. It will divert it's execution until later time, but what if it is already a "later time" ? Currently CallbackLater would divert until "more later time" beforeRender / beforeOutput, but that's not a correct approach, because it would fail third time. 

This PR will execute CallbackLater instantly if it's already late.

resolve #500 

IMPORTANT: this fix was reverted in the past due to: https://github.com/atk4/ui/issues/313. I have tried paginator examples and they seem to work fine.