### PR TITLE
Feature/Calendar-input-using-ui-persistence

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -97,6 +97,11 @@ This command will output the atkjs-ui.min.js file, also in /public folder.
 
 ## Release note
 
+### version 1.3.6
+
+  - Add locutus library dependency for outputing js date using php format.
+    - use in Calendar.js formatter. 
+
 ### version 1.3.5
 
 #### Changes in ModalService

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atkjs-ui",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Agile Toolkit Javascript library.",
   "main": "lib/atkjs-ui.js",
   "scripts": {
@@ -46,6 +46,7 @@
   "dependencies": {
     "debounce": "^1.1.0",
     "jquery": "^3.1.1",
+    "locutus": "^2.0.9",
     "semantic-ui-modal": "^2.2.10"
   }
 }

--- a/js/src/agile-toolkit-ui.js
+++ b/js/src/agile-toolkit-ui.js
@@ -1,6 +1,7 @@
 import atk from 'atk-semantic-ui';
 import 'helpers/addParams';
 import {plugin, createAtkplugins} from "./plugin";
+import date from 'locutus/php/datetime/date';
 
 // Create atk plugins.
 createAtkplugins();
@@ -8,6 +9,8 @@ createAtkplugins();
 atk.version = function(){return _ATKVERSION_};
 //Allow to register a plugin with jQuery;
 atk.registerPlugin = plugin;
+
+atk.phpDate = date;
 
 
 /**

--- a/src/FormField/Calendar.php
+++ b/src/FormField/Calendar.php
@@ -3,9 +3,17 @@
 namespace atk4\ui\FormField;
 
 use atk4\ui\Form;
+use atk4\ui\jsExpression;
+use atk4\ui\jsFunction;
 
 /**
  * Input element for a form field.
+ *
+ * 2018-06-25 : Add Locutus js library for formatting date as per php format.
+ * http://locutus.io/php/datetime/
+ *
+ * Locutus date function are available under atk.phpDate function.
+ * ex: atk.phpDate('m.d.Y', new Date());
  */
 class Calendar extends Input
 {
@@ -21,6 +29,17 @@ class Calendar extends Input
      */
     public $options = [];
 
+    /**
+     * Allow to set Calendar.js function.
+     *
+     * @param $name
+     * @param $value
+     */
+    public function setOption($name, $value)
+    {
+        $this->options[$name] = $value;
+    }
+
     public function renderView()
     {
         if (!$this->icon) {
@@ -29,9 +48,20 @@ class Calendar extends Input
             }
         }
 
-        if ($this->type) {
-            $this->options['type'] = $this->type;
+        if (!$this->type) {
+             $this->type = 'datetime';
         }
+
+        $typeFormat = $this->type.'_format';
+        if ($format = $this->app->ui_persistence->$typeFormat) {
+            $formatter = "function(date, settings){
+                            if (!date) return;
+                            return atk.phpDate('${format}', date);
+                        }";
+            $this->options['formatter'][$this->type] = new jsExpression($formatter);
+        }
+
+        $this->options['type'] = $this->type;
 
         $this->js(true)->calendar($this->options);
 

--- a/src/FormField/Calendar.php
+++ b/src/FormField/Calendar.php
@@ -53,10 +53,10 @@ class Calendar extends Input
 
         $typeFormat = $this->type.'_format';
         if ($format = $this->app->ui_persistence->$typeFormat) {
-            $formatter = "function(date, settings){
+            $formatter = 'function(date, settings){
                             if (!date) return;
                             return atk.phpDate([format], date);
-                        }";
+                        }';
             $this->options['formatter'][$this->type] = new jsExpression($formatter, ['format' => $format]);
         }
 

--- a/src/FormField/Calendar.php
+++ b/src/FormField/Calendar.php
@@ -56,12 +56,16 @@ class Calendar extends Input
         if ($format = $this->app->ui_persistence->$typeFormat) {
             $formatter = "function(date, settings){
                             if (!date) return;
-                            return atk.phpDate('${format}', date);
+                            return atk.phpDate([format], date);
                         }";
-            $this->options['formatter'][$this->type] = new jsExpression($formatter);
+            $this->options['formatter'][$this->type] = new jsExpression($formatter, ['format' => $format]);
         }
 
         $this->options['type'] = $this->type;
+
+        if ($dayOfWeek = $this->app->ui_persistence->firstDayOfWeek) {
+            $this->options['firstDayOfWeek'] = $dayOfWeek;
+        }
 
         $this->js(true)->calendar($this->options);
 

--- a/src/Persistence/UI.php
+++ b/src/Persistence/UI.php
@@ -26,7 +26,7 @@ class UI extends \atk4\data\Persistence
 
     /**
      * Calendar input first day of week.
-     *  0 = sunday;
+     *  0 = sunday;.
      *
      * @var int
      */

--- a/src/Persistence/UI.php
+++ b/src/Persistence/UI.php
@@ -24,6 +24,14 @@ class UI extends \atk4\data\Persistence
     public $datetime_format = 'M d, Y H:i:s';
     // 'D, d M Y H:i:s O';
 
+    /**
+     * Calendar input first day of week.
+     *  0 = sunday;
+     *
+     * @var int
+     */
+    public $firstDayOfWeek = 0;
+
     public $currency = '€';
 
     /**


### PR DESCRIPTION
Let calendar input field use format from ui persistence.

This is a fix for #507 

This will now work:
```
$app->ui_persistence->date_format = 'd.m.Y';
$app->ui_persistence->time_format = 'H:i';
$app->ui_persistence->datetime_format = 'd.m.Y H:i';

$c = $app->add(['CRUD', 'ipp' => 10]);
$c->setModel($m);
```

## Note 

atkjs-ui need to be rebuild.

