### PR TITLE
Fix/modal callback in modal callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,5 @@ docs/build
 /build
 .DS_Store
 *.codekit3
-
+yarn.lock
 run_local.sh

--- a/src/Modal.php
+++ b/src/Modal.php
@@ -75,6 +75,7 @@ class Modal extends View
     public function enableCallback()
     {
         $this->cb_view = $this->add('View');
+        $this->cb_view->stickyGet('__atk_m', $this->name);
         $this->cb = $this->cb_view->add('CallbackLater');
 
         $this->cb->set(function () {
@@ -282,7 +283,6 @@ class Modal extends View
         $data['label'] = $this->loading_label;
 
         if (!empty($this->fx)) {
-            $this->cb_view->stickyGet('__atk_m', $this->name);
             $data['uri'] = $this->cb->getJSURL();
         }
 

--- a/src/Modal.php
+++ b/src/Modal.php
@@ -81,7 +81,10 @@ class Modal extends View
             if ($this->cb->triggered() && $this->fx) {
                 $this->fx[0]($this->cb_view);
             }
-            $this->app->terminate($this->cb_view->renderJSON());
+            $modalName = isset($_GET['__atk_m']) ? $_GET['__atk_m'] : null;
+            if ($modalName === $this->name) {
+                $this->app->terminate($this->cb_view->renderJSON());
+            }
         });
     }
 
@@ -279,6 +282,7 @@ class Modal extends View
         $data['label'] = $this->loading_label;
 
         if (!empty($this->fx)) {
+            $this->cb_view->stickyGet('__atk_m', $this->name);
             $data['uri'] = $this->cb->getJSURL();
         }
 


### PR DESCRIPTION
This will properly allow to use modal callback inside another modal callback.

For example, allow to display a table in a modal using an action column edit that open another modal using a form.

```
$t = $app->add('Table');
$m = $t->setModel($m);

$t->addColumn(null, 'Actions')->addModal('btn', 'Title', function ($modal, $id) use ($m, $app) {
    // get this app.
    $m->load($id);

    $modal->add(['Header', $mUserApps['name'], 'size' => 4]);

    $table = $modal->add('Table');
    $table->setModel(new Model());

    $table->addColumn(null, 'Actions')->addModal('Edit Item', 'Editing item', function($editModal, $id) use ($m) {
        $f = $editModal->add('Form');
        $f->setModel($m)->load($id));
        $f->onSubmit(function($f) use ($modal, $editModal, $tablePerm) {
           $f->model->save();
           return [$editModal->owner->hide(), new jsReload($table)];
        });
    });
});
```