### PR TITLE
fix/caughtException in tab

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -208,7 +208,7 @@ class App
         $l->layout->template->tryDel('Header');
 
         //send json for callback error.
-        if (isset($_GET['__atk_callback'])) {
+        if (isset($_GET['__atk_callback']) && !isset($_GET['__atk_tab'])) {
             echo json_encode(['success'   => false,
                                 'message' => $l->layout->getHtml(),
                              ]);

--- a/src/Tab.php
+++ b/src/Tab.php
@@ -36,7 +36,7 @@ class Tab extends Item
     {
         if ($this->path) {
             $this->js(true)->tab(
-                ['cache' => false, 'auto' => true, 'path' => $this->path]
+                ['cache' => false, 'auto' => true, 'path' => $this->path, 'apiSettings' => ['data' => ['__atk_tab' => 1]]]
             );
         } else {
             $this->js(true)->tab();


### PR DESCRIPTION
This will allow to properly display exception when in dynamic tabs.

Dynamic tab is using semantic-ui api request internally and the internal request type is set to receive html only. 
When Exception occur in dynamic tab, then html should be return, not json, as it is for regular callback. 