### PR TITLE
fix/exception using wizard

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -229,13 +229,12 @@ class App
     {
         $ajax = false;
 
-        if(!empty($_SERVER['HTTP_X_REQUESTED_WITH'])
-           && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest')
-        {
+        if (!empty($_SERVER['HTTP_X_REQUESTED_WITH'])
+           && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest') {
             $ajax = true;
         }
 
-        return ($ajax && !isset($_GET['__atk_tab']));
+        return $ajax && !isset($_GET['__atk_tab']);
     }
 
     /**

--- a/src/App.php
+++ b/src/App.php
@@ -207,7 +207,7 @@ class App
         }
         $l->layout->template->tryDel('Header');
 
-        if ($this->isJsonExceptionRequired()) {
+        if ($this->isJsonRequest()) {
             echo json_encode(['success'   => false,
                                 'message' => $l->layout->getHtml(),
                              ]);
@@ -225,7 +225,7 @@ class App
      *
      * @return bool
      */
-    protected function isJsonExceptionRequired()
+    protected function isJsonRequest()
     {
         $ajax = false;
 

--- a/src/App.php
+++ b/src/App.php
@@ -207,8 +207,7 @@ class App
         }
         $l->layout->template->tryDel('Header');
 
-        //send json for callback error.
-        if (isset($_GET['__atk_callback']) && !isset($_GET['__atk_tab'])) {
+        if ($this->isJsonExceptionRequired()) {
             echo json_encode(['success'   => false,
                                 'message' => $l->layout->getHtml(),
                              ]);
@@ -218,6 +217,25 @@ class App
             $this->run_called = true;
         }
         exit;
+    }
+
+    /**
+     * Most of the ajax request will require sending exception in json
+     * instead of html, except for tab.
+     *
+     * @return bool
+     */
+    private function isJsonExceptionRequired()
+    {
+        $ajax = false;
+
+        if(!empty($_SERVER['HTTP_X_REQUESTED_WITH'])
+           && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest')
+        {
+            $ajax = true;
+        }
+
+        return ($ajax && !isset($_GET['__atk_tab']));
     }
 
     /**

--- a/src/App.php
+++ b/src/App.php
@@ -225,7 +225,7 @@ class App
      *
      * @return bool
      */
-    private function isJsonExceptionRequired()
+    protected function isJsonExceptionRequired()
     {
         $ajax = false;
 


### PR DESCRIPTION
Refactor caughtException

Problem was that Wizard use __atk_callback request too but required exception to be send in html, because not using ajax request.

This will first look for ajax request instead of __atk_callback parameter in request. 
Will send exception in json for all ajax request except for tab because  even if tab use ajax, it require an html output.