### PR TITLE
fix/FormSerializer option

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -97,6 +97,12 @@ This command will output the atkjs-ui.min.js file, also in /public folder.
 
 ## Release note
 
+### version 1.3.8
+
+  - allow jQuery FormSerializer to accept _ char at beginning of input name. ex: _e-mail
+  - Check for FormSerializer to be present before extending it. 
+
+
 ### version 1.3.7
 
   - allow jQuery FormSerializer to accept dash char in input name. ex: e-mail. 

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atkjs-ui",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Agile Toolkit Javascript library.",
   "main": "lib/atkjs-ui.js",
   "scripts": {

--- a/js/src/atk-semantic-ui.js
+++ b/js/src/atk-semantic-ui.js
@@ -14,7 +14,7 @@ popupService.setPopups($.fn.popup.settings);
 if (typeof FormSerializer != "undefined") {
   //setup jQuery FormSerializer to accept in input name with dash char (-)
   $.extend(FormSerializer.patterns, {
-    validate: /^[_a-z][a-z0-9_-]*(?:\[(?:\d*|[a-z0-9_-]+)\])*$/i,
+    validate: /^[a-z_][a-z0-9_-]*(?:\[(?:\d*|[a-z0-9_-]+)\])*$/i,
     key:      /[a-z0-9_-]+|(?=\[\])/gi,
     named:    /^[a-z0-9_-]+$/i
   });

--- a/js/src/atk-semantic-ui.js
+++ b/js/src/atk-semantic-ui.js
@@ -11,12 +11,14 @@ modalService.setModals($.fn.modal.settings);
 formService.setService($.fn.form.settings);
 popupService.setPopups($.fn.popup.settings);
 
-//setup jQuery FormSerializer to accept in input name with dash char (-)
-$.extend(FormSerializer.patterns, {
-  validate: /^[a-z][a-z0-9_-]*(?:\[(?:\d*|[a-z0-9_-]+)\])*$/i,
-  key:      /[a-z0-9_-]+|(?=\[\])/gi,
-  named:    /^[a-z0-9_-]+$/i
-});
+if (typeof FormSerializer != "undefined") {
+  //setup jQuery FormSerializer to accept in input name with dash char (-)
+  $.extend(FormSerializer.patterns, {
+    validate: /^[_a-z][a-z0-9_-]*(?:\[(?:\d*|[a-z0-9_-]+)\])*$/i,
+    key:      /[a-z0-9_-]+|(?=\[\])/gi,
+    named:    /^[a-z0-9_-]+$/i
+  });
+}
 
 let atkSemantic = {
   uploadService: uploadService,


### PR DESCRIPTION
Allow FormSerializer to use _ as the first char in input name.

For better safety, will now check for the presence of jQuery Serialize object plugin prior to set option.