### PR TITLE
Feature/jsModal options and Modal option

### DIFF
--- a/demos/modal.php
+++ b/demos/modal.php
@@ -3,13 +3,22 @@
 require 'init.php';
 // Re-usable component implementing counter
 
-$app->add(['Header', 'Dynamic Modal Dialog']);
 
-    $modal = $app->add(['Modal', 'title' => 'Add a name']);
-    $modal->add('LoremIpsum');
-    $modal->add(['Button', 'Hide'])->on('click', $modal->hide());
+$app->add(['Header', 'Static Modal Dialog']);
 
-    $app->add(['Button', 'Show'])->on('click', $modal->show());
+$bar = $app->add(['View', 'ui' => 'buttons']);
+
+$modal = $app->add(['Modal', 'title' => 'Add a name']);
+$modal->add('LoremIpsum');
+$modal->add(['Button', 'Hide'])->on('click', $modal->hide());
+
+$noTitle =  $app->add(['Modal', 'title' => false]);
+$noTitle->add('LoremIpsum');
+$noTitle->add(['Button', 'Hide'])->on('click', $noTitle->hide());
+
+$bar->add(['Button', 'Show'])->on('click', $modal->show());
+$bar->add(['Button', 'No Title'])->on('click', $noTitle->show());
+
 
 if (!class_exists('Counter')) {
     class Counter extends \atk4\ui\FormField\Line
@@ -53,6 +62,11 @@ if (isset($_GET['slow'])) {
     sleep(1);
 }
 
+$bar->add('Button')->set('No title')->on('click', new \atk4\ui\jsModal(null, $vp->getJSURL('cut').'&slow=true' ));
+if (isset($_GET['slow'])) {
+    sleep(1);
+}
+
 $app->add(['Header', 'Modal when you click on table row']);
 $t = $app->add(['Table', 'celled' => true]);
 $t->setModel(new SomeData());
@@ -63,3 +77,6 @@ $frame->set(function ($frame) {
 });
 
 $t->onRowClick(new \atk4\ui\jsModal('Row Clicked', $frame, ['id' => $t->jsRow()->data('id')]));
+
+$app->layout->js(true, new \atk4\ui\jsExpression('serviceInit("blabla")'));
+$app->requireJS('../public/init.js');

--- a/demos/modal.php
+++ b/demos/modal.php
@@ -3,7 +3,6 @@
 require 'init.php';
 // Re-usable component implementing counter
 
-
 $app->add(['Header', 'Static Modal Dialog']);
 
 $bar = $app->add(['View', 'ui' => 'buttons']);
@@ -12,13 +11,12 @@ $modal = $app->add(['Modal', 'title' => 'Add a name']);
 $modal->add('LoremIpsum');
 $modal->add(['Button', 'Hide'])->on('click', $modal->hide());
 
-$noTitle =  $app->add(['Modal', 'title' => false]);
+$noTitle = $app->add(['Modal', 'title' => false]);
 $noTitle->add('LoremIpsum');
 $noTitle->add(['Button', 'Hide'])->on('click', $noTitle->hide());
 
 $bar->add(['Button', 'Show'])->on('click', $modal->show());
 $bar->add(['Button', 'No Title'])->on('click', $noTitle->show());
-
 
 if (!class_exists('Counter')) {
     class Counter extends \atk4\ui\FormField\Line
@@ -62,7 +60,7 @@ if (isset($_GET['slow'])) {
     sleep(1);
 }
 
-$bar->add('Button')->set('No title')->on('click', new \atk4\ui\jsModal(null, $vp->getJSURL('cut').'&slow=true' ));
+$bar->add('Button')->set('No title')->on('click', new \atk4\ui\jsModal(null, $vp->getJSURL('cut').'&slow=true'));
 if (isset($_GET['slow'])) {
     sleep(1);
 }

--- a/js/README.md
+++ b/js/README.md
@@ -97,6 +97,10 @@ This command will output the atkjs-ui.min.js file, also in /public folder.
 
 ## Release note
 
+### version 1.3.9
+
+  - Add option for creating modal in createModal plugin.
+
 ### version 1.3.8
 
   - allow jQuery FormSerializer to accept _ char at beginning of input name. ex: _e-mail

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atkjs-ui",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "Agile Toolkit Javascript library.",
   "main": "lib/atkjs-ui.js",
   "scripts": {

--- a/js/src/plugins/createModal.js
+++ b/js/src/plugins/createModal.js
@@ -22,8 +22,8 @@ export default class createModal extends atkPlugin {
   }
 
   getDialogHtml(title) {
-    return `<i class="${this.settings.icon} icon close"></i>
-          <div class="header">${title}</div>
+    return `<i class="icon close"></i>
+          <div class="${this.settings.headerCss}">${title}</div>
           <div class="image content atk-dialog-content">
             </div>
           </div>`;
@@ -34,7 +34,7 @@ createModal.DEFAULTS = {
   title: '',
   uri: null,
   uri_options: {},
-  icon: '',
+  headerCss: 'header',
   label: 'Loading...',
   modal: {
       duration: 100

--- a/public/agileui.less
+++ b/public/agileui.less
@@ -15,6 +15,10 @@
   padding-left: @leftMenuWidth;
 }
 
+.atk-dialog-content {
+  min-height: 100px;
+}
+
 .atk-layout {
   display: flex;
   min-height: 100vh;

--- a/src/Modal.php
+++ b/src/Modal.php
@@ -30,6 +30,7 @@ class Modal extends View
     public $defaultTemplate = 'modal.html';
     public $title = 'Modal title';
     public $loading_label = 'Loading...';
+    public $headerCss = 'header ui blue';
     public $ui = 'modal';
     public $fx = [];
     public $cb = null;
@@ -281,6 +282,8 @@ class Modal extends View
     {
         $data['type'] = $this->type;
         $data['label'] = $this->loading_label;
+
+        $this->template->trySet('headerCss', $this->headerCss);
 
         if (!empty($this->fx)) {
             $data['uri'] = $this->cb->getJSURL();

--- a/src/Modal.php
+++ b/src/Modal.php
@@ -30,7 +30,7 @@ class Modal extends View
     public $defaultTemplate = 'modal.html';
     public $title = 'Modal title';
     public $loading_label = 'Loading...';
-    public $headerCss = 'header ui blue';
+    public $headerCss = 'header';
     public $ui = 'modal';
     public $fx = [];
     public $cb = null;

--- a/src/Modal.php
+++ b/src/Modal.php
@@ -28,6 +28,12 @@ namespace atk4\ui;
 class Modal extends View
 {
     public $defaultTemplate = 'modal.html';
+
+    /**
+     * Set to empty or false for no header.
+     *
+     * @var string
+     */
     public $title = 'Modal title';
     public $loading_label = 'Loading...';
     public $headerCss = 'header';
@@ -39,12 +45,6 @@ class Modal extends View
 
     //now only supported json type response.
     public $type = 'json';
-
-    public function init()
-    {
-        parent::init();
-        $this->template->trySet('title', $this->title);
-    }
 
     /**
      * Set callback function for this modal.
@@ -283,7 +283,10 @@ class Modal extends View
         $data['type'] = $this->type;
         $data['label'] = $this->loading_label;
 
-        $this->template->trySet('headerCss', $this->headerCss);
+        if (!empty($this->title)) {
+            $this->template->trySet('title', $this->title);
+            $this->template->trySet('headerCss', $this->headerCss);
+        }
 
         if (!empty($this->fx)) {
             $data['uri'] = $this->cb->getJSURL();

--- a/src/jsModal.php
+++ b/src/jsModal.php
@@ -7,7 +7,15 @@ namespace atk4\ui;
  */
 class jsModal extends jsExpression
 {
-    public function __construct($title, $url, $args = [], $mode = 'json', $hasHeader = true)
+    /**
+     * jsModal constructor.
+     *
+     * @param $title       //When empty, header will be remove in modal.
+     * @param $url
+     * @param array $args
+     * @param string $mode
+     */
+    public function __construct($title, $url, $args = [], $mode = 'json')
     {
         if ($url instanceof VirtualPage) {
             $url = $url->getJSURL('cut');
@@ -15,7 +23,7 @@ class jsModal extends jsExpression
 
         parent::__construct('$(this).atkCreateModal([arg])', ['arg' => ['uri' => $url, 'title' => $title, 'mode' => $mode, 'uri_options' => $args]]);
 
-        if (!$hasHeader) {
+        if (empty($title)) {
             $this->removeHeader();
         }
     }

--- a/src/jsModal.php
+++ b/src/jsModal.php
@@ -7,12 +7,61 @@ namespace atk4\ui;
  */
 class jsModal extends jsExpression
 {
-    public function __construct($title, $url, $args = [], $mode = 'json')
+    public function __construct($title, $url, $args = [], $mode = 'json', $hasHeader = true)
     {
         if ($url instanceof VirtualPage) {
             $url = $url->getJSURL('cut');
         }
 
         parent::__construct('$(this).atkCreateModal([arg])', ['arg' => ['uri' => $url, 'title' => $title, 'mode' => $mode, 'uri_options' => $args]]);
+
+        if (!$hasHeader) {
+            $this->removeHeader();
+        }
+    }
+
+    /**
+     * Set additionnal option for this jsModal.
+     *
+     * Valuable option are headerCss and label:
+     *  'headerCss' -> customize css class name for the header.
+     *      ex: changing color text for header
+     *      $jsModal->setOption('headerCss', 'ui blue header');
+     *
+     *  'label' -> set the text loader value.
+     *      ex: changing default 'Loading...' for no text
+     *      $jsModal->setOption('label', '');
+     *
+     * You can set option individually or supply an array.
+     *
+     * @param $options
+     * @param null $value
+     *
+     * @return $this
+     */
+    public function setOption($options, $value = null)
+    {
+        if (is_array($options)) {
+            foreach ($options as $key => $value) {
+                $this->args['arg'][$key] = $value;
+            }
+        } else {
+            $this->args['arg'][$options] = $value;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Clear header class and title.
+     *
+     * @return $this
+     */
+    public function removeHeader()
+    {
+        $this->args['arg']['headerCss'] = '';
+        $this->args['arg']['title'] = '';
+
+        return $this;
     }
 }

--- a/src/jsModal.php
+++ b/src/jsModal.php
@@ -12,7 +12,7 @@ class jsModal extends jsExpression
      *
      * @param $title       //When empty, header will be remove in modal.
      * @param $url
-     * @param array $args
+     * @param array  $args
      * @param string $mode
      */
     public function __construct($title, $url, $args = [], $mode = 'json')

--- a/template/semantic-ui/modal.html
+++ b/template/semantic-ui/modal.html
@@ -1,5 +1,5 @@
 <{_element}div{/} id="{$_id}" class="{_ui}ui {/} {$class} {_class}{/}" style="{$style}" {$attributes}><i class="{$close}"></i>
-<div class="header">{$title}</div>
+<div class="{$headerCss}">{$title}</div>
 <div class="img content atk-dialog-content">{$Content}</div>
 <div class="actions">
   <div>{$actions}</div>

--- a/template/semantic-ui/modal.pug
+++ b/template/semantic-ui/modal.pug
@@ -1,5 +1,5 @@
 <{_element}div{/} id="{$_id}" class="{_ui}ui {/} {$class} {_class}{/}" style="{$style}" {$attributes}><i class="{$close}"></i>
-    .header {$title}
+    div(class="{$headerCss}") {$title}
     div(class="img content atk-dialog-content") {$Content}
     .actions
         div {$actions}


### PR DESCRIPTION
Address issue #538 

 - Option to customize header css class for Modal and jsModal;
 - Option to customize Loading label in jsModal;

### Customizing header css class name for jsModal and Modal:

- using jsModal::setOption($options, $value) 
```
       $jsModal->setOption('headerCss', 'ui blue header')  //will make header color blue.
```
- using Modal::headerCss property for regular modal.

### Removing header in jsModal

 - at creation time passing an empty, null or false value in title parameter;
 - by calling jsModal::removeHeader() method;

### Customizing Loading label in jsModal

- using jsModal::setOption($options, $value) 
```
   $jsModal->setOption('label', '')  //set loading label to an empty string
```