### PR TITLE
Template tags can also contain more symbols, for example, colon

### DIFF
--- a/src/Template.php
+++ b/src/Template.php
@@ -610,7 +610,7 @@ class Template implements \ArrayAccess
         $this->tag_cnt = [];
 
         /* First expand self-closing tags {$tag} -> {tag}{/tag} */
-        $str = preg_replace('/{\$([\w]+)}/', '{\1}{/\1}', $str);
+        $str = preg_replace('/{\$([-_:\w]+)}/', '{\1}{/\1}', $str);
 
         $this->parseTemplate($str);
 
@@ -702,7 +702,7 @@ class Template implements \ArrayAccess
      */
     protected function parseTemplate($str)
     {
-        $tag = '/{([\/$]?[-_\w]*)}/';
+        $tag = '/{([\/$]?[-_:\w]*)}/';
 
         $input = preg_split($tag, $str, -1, PREG_SPLIT_DELIM_CAPTURE);
 


### PR DESCRIPTION
In some cases template tags can also contain some other symbols like colon.

There are persistences which allow field names like "cmis:objectType". Grid picks up this field name and creates template tag {$cmis:objecttype}, but Template class don't recognize this as tag because of colon. This commit fixes that.
