### PR TITLE
Do not warn about runaway callbacks from "default app"

### DIFF
--- a/src/View.php
+++ b/src/View.php
@@ -347,9 +347,9 @@ class View implements jsExpressionable
     protected function initDefaultApp()
     {
         $this->app = new App([
-            'skin' => $this->skin, 
-            'catch_exceptions' => false, 
-            'always_run' => false,
+            'skin'                    => $this->skin,
+            'catch_exceptions'        => false,
+            'always_run'              => false,
             'catch_runaway_callbacks' => false,
         ]);
         $this->app->init();

--- a/src/View.php
+++ b/src/View.php
@@ -346,7 +346,12 @@ class View implements jsExpressionable
      */
     protected function initDefaultApp()
     {
-        $this->app = new App(['skin' => $this->skin, 'catch_exceptions' => false, 'always_run' => false]);
+        $this->app = new App([
+            'skin' => $this->skin, 
+            'catch_exceptions' => false, 
+            'always_run' => false,
+            'catch_runaway_callbacks' => false,
+        ]);
         $this->app->init();
     }
 


### PR DESCRIPTION
Currently default app created by view (if you don't have app) may complain about unhandled callbacks.

``` php
$app = new \atk4\ui\App();
$v = $app->add('View');

$logout = new \atk4\ui\Button('Logout');
$logout->init();

$logout->on('click', function() use($app) {
    $app->auth->logout();
    return new \atk4\ui\jsExpression('document.location.reload()');
});

$v->template->setHTML('Content', $logout->render());
```