### PR TITLE
console->set() captures executon info/output.

### DIFF
--- a/src/Console.php
+++ b/src/Console.php
@@ -88,6 +88,11 @@ class Console extends View implements \Psr\Log\LoggerInterface
         $this->sse->set(function () use ($callback) {
             $this->sseInProgress = true;
 
+            if (isset($this->app)) {
+                $old_logger = $this->app->logger;
+                $this->app->logger = $this;
+            }
+
             try {
                 ob_start(function ($content) {
                     if ($this->_output_bypass) {
@@ -116,6 +121,11 @@ class Console extends View implements \Psr\Log\LoggerInterface
             } catch (\Exception $e) {
                 $this->output('Exception: '.$e->getMessage());
             }
+
+            if (isset($this->app)) {
+                $this->app->logger = $old_logger;
+            }
+
             $this->sseInProgress = false;
         });
 


### PR DESCRIPTION
Minor enhancement adding output to console even if you use set().

Currently runMethod() will substitute app->logger to the console itself and will capture all the info() and warning() raised by objects. If you are using set() no such thing is done.

This PR makes set() work similar to runMethod():


<img width="474" alt="screen shot 2018-08-22 at 14 24 32" src="https://user-images.githubusercontent.com/453929/44460782-1d401e00-a617-11e8-90c4-a5401f4f0042.png">
