### PR TITLE
Implements FormField->onChange method

### DIFF
--- a/demos/database.php
+++ b/demos/database.php
@@ -5,7 +5,7 @@ try {
     if (file_exists('db.php')) {
         include 'db.php';
     } else {
-        $db = new \atk4\data\Persistence_SQL('mysql:dbname=atk4;host=localhost', 'root', 'root');
+        $db = new \atk4\data\Persistence_SQL('mysql:dbname=atk4;host=localhost', 'root', '');
     }
 } catch (PDOException $e) {
     throw new \atk4\ui\Exception([

--- a/demos/database.php
+++ b/demos/database.php
@@ -5,7 +5,7 @@ try {
     if (file_exists('db.php')) {
         include 'db.php';
     } else {
-        $db = new \atk4\data\Persistence_SQL('mysql:dbname=atk4;host=localhost', 'root', '');
+        $db = new \atk4\data\Persistence_SQL('mysql:dbname=atk4;host=localhost', 'root', 'root');
     }
 } catch (PDOException $e) {
     throw new \atk4\ui\Exception([

--- a/demos/field2.php
+++ b/demos/field2.php
@@ -4,6 +4,8 @@
  */
 require 'init.php';
 
+
+
 $app->add(['Header', 'Stand Alone Line']);
 // you can pass values to button
 $field = $app->add(new \atk4\ui\FormField\Line());
@@ -12,6 +14,8 @@ $field->set('hello world');
 
 $button = $field->addAction('check value');
 $button->on('click', new \atk4\ui\jsExpression('alert("field value is: "+[])', [$field->jsInput()->val()]));
+
+
 
 $app->add(['Header', 'Line in a Form']);
 $form = $app->add('Form');
@@ -31,6 +35,8 @@ $form->onSubmit(function ($f) {
     return $f->model['name'];
 });
 
+
+
 $app->add(['Header', 'Multiple Form Layouts']);
 
 $form = $app->add('Form');
@@ -46,3 +52,33 @@ $form_page->addField('age', new \atk4\ui\FormField\Line());
 $form->onSubmit(function ($f) {
     return $f->model['name'].' has age '.$f->model['age'];
 });
+
+
+
+$app->add(['Header', 'onChange event', 'subHeader'=>'see in browser console']);
+
+$form = $app->add('Form');
+
+$c1 = $form->addField('c1', new \atk4\ui\FormField\Calendar(['type'=>'date']));
+$c2 = $form->addField('c2', new \atk4\ui\FormField\Calendar(['type'=>'date']));
+$c3 = $form->addField('c3', new \atk4\ui\FormField\Calendar(['type'=>'date']));
+
+$f1 = $form->addField('f1');
+$f2 = $form->addField('f2');
+$f3 = $form->addField('f3');
+$f4 = $form->addField('f4');
+
+$c1->onChange('console.log("c1 changed: "+date+","+text+","+mode)');
+$c2->onChange(new \atk4\ui\jsExpression('console.log("c2 changed: "+date+","+text+","+mode)'));
+$c3->onChange([
+    new \atk4\ui\jsExpression('console.log("c3 changed: "+date+","+text+","+mode)'),
+    new \atk4\ui\jsExpression('console.log("c3 really changed: "+date+","+text+","+mode)'),
+]);
+
+$f1->onChange('console.log("f1 changed")');
+$f2->onChange(new \atk4\ui\jsExpression('console.log("f2 changed")'));
+$f3->onChange([
+    new \atk4\ui\jsExpression('console.log("f3 changed")'),
+    new \atk4\ui\jsExpression('console.log("f3 really changed")'),
+]);
+$f4->onChange(function(){return new \atk4\ui\jsExpression('console.log("f4 changed")');});

--- a/demos/field2.php
+++ b/demos/field2.php
@@ -4,8 +4,6 @@
  */
 require 'init.php';
 
-
-
 $app->add(['Header', 'Stand Alone Line']);
 // you can pass values to button
 $field = $app->add(new \atk4\ui\FormField\Line());
@@ -14,8 +12,6 @@ $field->set('hello world');
 
 $button = $field->addAction('check value');
 $button->on('click', new \atk4\ui\jsExpression('alert("field value is: "+[])', [$field->jsInput()->val()]));
-
-
 
 $app->add(['Header', 'Line in a Form']);
 $form = $app->add('Form');
@@ -35,8 +31,6 @@ $form->onSubmit(function ($f) {
     return $f->model['name'];
 });
 
-
-
 $app->add(['Header', 'Multiple Form Layouts']);
 
 $form = $app->add('Form');
@@ -52,8 +46,6 @@ $form_page->addField('age', new \atk4\ui\FormField\Line());
 $form->onSubmit(function ($f) {
     return $f->model['name'].' has age '.$f->model['age'];
 });
-
-
 
 $app->add(['Header', 'onChange event', 'subHeader'=>'see in browser console']);
 
@@ -81,4 +73,6 @@ $f3->onChange([
     new \atk4\ui\jsExpression('console.log("f3 changed")'),
     new \atk4\ui\jsExpression('console.log("f3 really changed")'),
 ]);
-$f4->onChange(function(){return new \atk4\ui\jsExpression('console.log("f4 changed")');});
+$f4->onChange(function () {
+    return new \atk4\ui\jsExpression('console.log("f4 changed")');
+});

--- a/demos/init.php
+++ b/demos/init.php
@@ -26,6 +26,7 @@ if (isset($layout->leftMenu)) {
 
     $form = $layout->leftMenu->addGroup(['Form', 'icon' => 'edit']);
     $form->addItem('Basics and Layouting', ['form']);
+    $form->addItem('Input Fields', ['field2']);
     $form->addItem('Input Field Decoration', ['field']);
     $form->addItem(['File Uploading'], ['upload']);
     $form->addItem(['Checkboxes'], ['checkbox']);

--- a/docs/field.rst
+++ b/docs/field.rst
@@ -272,6 +272,29 @@ that it would target the INPUT element rather then the whole field::
 
     $field->jsInput(true)->val(123);
 
+onChange event
+--------------
+
+.. php:method:: onChange($expression)
+
+It's prefferable to use this short-hand version of on('change', 'input', $expression) method.
+$expression argument can be string, jsExpression, array of jsExpressions or even PHP callback function.
+
+    // simple string
+    $f1 = $f->addField('f1');
+    $f1->onChange('console.log("f1 changed")');
+
+    // callback
+    $f2 = $f->addField('f2');
+    $f2->onChange(function(){return new \atk4\ui\jsExpression('console.log("f2 changed")');});
+
+    // Calendar field - wraps in function call with arguments date, text and mode
+    $c1 = $f->addField('c1', new \atk4\ui\FormField\Calendar(['type'=>'date']));
+    $c1->onChange('console.log("c1 changed: "+date+","+text+","+mode)');
+
+
+
+
 
 DropDown
 ========

--- a/src/FormField/Calendar.php
+++ b/src/FormField/Calendar.php
@@ -70,4 +70,30 @@ class Calendar extends Input
 
         parent::renderView();
     }
+
+    /**
+     * Shorthand method for on('change') event.
+     * Some input fields, like Calendar, could call this differently.
+     *
+     * If $expr is string or jsExpression, then it will execute it instantly.
+     *
+     * Examples:
+     * $field->onChange('console.log(date, text, mode)');
+     * $field->onChange(new \atk4\ui\jsExpression('console.log(date, text, mode)'));
+     * $field->onChange('$(this).parents(".form").form("submit")');
+     *
+     * @param string|jsExpression|array $expr
+     */
+     public function onChange($expr)
+     {
+        if (is_string($expr)) {
+            $expr = new \atk4\ui\jsExpression($expr);
+        }
+        if (!is_array($expr)) {
+            $expr = [$expr];
+        }
+        
+        // Semantic-UI Calendar have different approach for on change event
+        $this->options['onChange'] = new \atk4\ui\jsFunction(['date', 'text', 'mode'], $expr);
+     }
 }

--- a/src/FormField/Calendar.php
+++ b/src/FormField/Calendar.php
@@ -84,16 +84,16 @@ class Calendar extends Input
      *
      * @param string|jsExpression|array $expr
      */
-     public function onChange($expr)
-     {
+    public function onChange($expr)
+    {
         if (is_string($expr)) {
             $expr = new \atk4\ui\jsExpression($expr);
         }
         if (!is_array($expr)) {
             $expr = [$expr];
         }
-        
+
         // Semantic-UI Calendar have different approach for on change event
         $this->options['onChange'] = new \atk4\ui\jsFunction(['date', 'text', 'mode'], $expr);
-     }
+    }
 }

--- a/src/FormField/Generic.php
+++ b/src/FormField/Generic.php
@@ -47,6 +47,9 @@ class Generic extends View
      */
     public $hint = null;
 
+    /**
+     * Initialization.
+     */
     public function init()
     {
         parent::init();
@@ -93,4 +96,26 @@ class Generic extends View
 
         parent::renderView();
     }
+    
+    /**
+     * Shorthand method for on('change') event.
+     * Some input fields, like Calendar, could call this differently.
+     *
+     * If $expr is string or jsExpression, then it will execute it instantly.
+     * If $expr is callback method, then it'll make additional request to webserver.
+     *
+     * Examples:
+     * $field->onChange('console.log("changed")');
+     * $field->onChange(new \atk4\ui\jsExpression('console.log("changed")'));
+     * $field->onChange('$(this).parents(".form").form("submit")');
+     *
+     * @param string|jsExpression|array|callable $expr
+     */
+     public function onChange($expr)
+     {
+        if (is_string($expr)) {
+            $expr = new \atk4\ui\jsExpression($expr);
+        }
+		$this->on('change', '#'.$this->id.'_input', $expr);
+     }
 }

--- a/src/FormField/Generic.php
+++ b/src/FormField/Generic.php
@@ -96,7 +96,7 @@ class Generic extends View
 
         parent::renderView();
     }
-    
+
     /**
      * Shorthand method for on('change') event.
      * Some input fields, like Calendar, could call this differently.
@@ -111,11 +111,11 @@ class Generic extends View
      *
      * @param string|jsExpression|array|callable $expr
      */
-     public function onChange($expr)
-     {
+    public function onChange($expr)
+    {
         if (is_string($expr)) {
             $expr = new \atk4\ui\jsExpression($expr);
         }
-		$this->on('change', '#'.$this->id.'_input', $expr);
-     }
+        $this->on('change', '#'.$this->id.'_input', $expr);
+    }
 }


### PR DESCRIPTION
* implements `FormField->onChange` method
* works around Calendar field issue (#521)
* it's more intuitive and makes developers life easier :)
* includes demo
* includes documentation

It doesn't use `jsInput()` because it's more limited than `on()` method.

It's implemented in Generic field class because not all fields are Input class fields. For example, checkbox.
Not tested for Checkbox and Radio box fields  tough.