### PR TITLE
Feature/Table Column Resizable

### DIFF
--- a/demos/table2.php
+++ b/demos/table2.php
@@ -70,3 +70,10 @@ $table->addColumn('amount_copy', ['Multiformat', function ($a, $b) {
     // Short way is to simply return seed
     return 'Money';
 }, 'attr'=>['all'=>['class'=>['right aligned singel line']]]]);
+
+$app->add(['Header', 'Table with resizable columns', 'subHeader'=>'Just drag column header to resize', 'icon'=>'table']);
+
+
+$table = $app->add('Table');
+$table->setModel($m);
+$table->addClass('celled')->resizableColumn();

--- a/demos/table2.php
+++ b/demos/table2.php
@@ -73,7 +73,6 @@ $table->addColumn('amount_copy', ['Multiformat', function ($a, $b) {
 
 $app->add(['Header', 'Table with resizable columns', 'subHeader'=>'Just drag column header to resize', 'icon'=>'table']);
 
-
 $table = $app->add('Table');
 $table->setModel($m);
 $table->addClass('celled')->resizableColumn();

--- a/js/README.md
+++ b/js/README.md
@@ -97,6 +97,11 @@ This command will output the atkjs-ui.min.js file, also in /public folder.
 
 ## Release note
 
+### version 1.4.0
+
+ - add new plugin atkColumnresizer. This new jQuery plugin allow to resize table column using drag n drop,
+ - fix padding setting in apiService error modal.
+
 ### version 1.3.9
 
   - Add option for creating modal in createModal plugin.

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atkjs-ui",
-  "version": "1.3.9",
+  "version": "1.4.0",
   "description": "Agile Toolkit Javascript library.",
   "main": "lib/atkjs-ui.js",
   "scripts": {
@@ -44,6 +44,7 @@
   },
   "homepage": "http://www.agiletoolkit.org/",
   "dependencies": {
+    "column-resizer": "^1.1.2",
     "debounce": "^1.1.0",
     "jquery": "^3.1.1",
     "locutus": "^2.0.9",

--- a/js/src/plugin.js
+++ b/js/src/plugin.js
@@ -9,6 +9,7 @@ import fileUpload from "./plugins/fileUpload";
 import jsSearch from "./plugins/jsSearch";
 import jsSortable from "./plugins/jsSortable";
 import conditionalForm from "./plugins/conditionalForm";
+import columnResizer from "./plugins/columnResizer";
 
 /**
  * Generate a jQuery plugin
@@ -88,6 +89,7 @@ function createAtkplugins() {
     {name: 'JsSearch', plugin: jsSearch, sh: false},
     {name: 'JsSortable', plugin: jsSortable, sh: false},
     {name: 'ConditionalForm', plugin: conditionalForm, sh: true},
+    {name: 'ColumnResizer', plugin: columnResizer, sh: false},
   ];
 
   atkJqPlugins.forEach((atkJqPlugin) => {

--- a/js/src/plugins/columnResizer.js
+++ b/js/src/plugins/columnResizer.js
@@ -1,0 +1,65 @@
+import $ from "jquery";
+import atkPlugin from 'plugins/atkPlugin';
+import Resizer from 'column-resizer';
+
+/**
+ * Enable table column to be resizable using drag.
+ */
+export default class columnResizer extends atkPlugin {
+
+  main() {
+
+    // add on resize callback if url is supply.
+    if (this.settings.uri) {
+      this.settings.onResize = this.onResize.bind(this);
+    }
+    this.resizable = new Resizer(this.$el[0], Object.assign({}, this.settings.atkDefaults, this.settings));
+
+    //reset padding class.
+    this.$el.removeClass('grip-padding');
+  }
+
+  /**
+   * Send widths to server via callback uri.
+   *
+   * @param widths an Array of objects, each containing the column name and their size in pixels [{column: 'name', size: '135px'}]
+   */
+  sendWidths(widths) {
+    this.$el.api({
+      on: 'now',
+      url: this.settings.uri,
+      method: 'POST',
+      data: {widths: JSON.stringify(widths)},
+    });
+  }
+
+  /**
+   * On resize callback when user finish dragging column for resizing.
+   * Calling this method via callback need to bind "this" set to this plugin.
+   *
+   * @param e  the event.
+   */
+  onResize(e) {
+    const table = this.$el;
+
+    const columns = this.$el.find('th');
+
+    let widths = [];
+    columns.each(function(idx, item){
+      widths.push({column : $(item).data('column'), size: $(item).css('width')});
+    });
+
+    this.sendWidths(widths);
+  }
+}
+
+columnResizer.DEFAULTS = {
+  atkDefaults: {
+    liveDrag: true,
+    resizeMode: 'overflow',
+    draggingClass: 'atk-column-dragging',
+    minWidth:8,
+    //onResize: function(e) {e.path.filter(function(item){return item.querySelector('table')});}
+  },
+  uri: null,
+};

--- a/js/src/services/ApiService.js
+++ b/js/src/services/ApiService.js
@@ -199,7 +199,6 @@ class ApiService {
       .css({
         'padding':'8px',
         'background-color': 'rgba(0, 0, 0, 0.5)',
-        'padding':'4px',
         'margin': 'auto',
         'width': '100%',
         'height': '100%',

--- a/src/Table.php
+++ b/src/Table.php
@@ -316,30 +316,30 @@ class Table extends Lister
     ];
 
     /**
-     *
      * Make columns resizable by dragging column header.
      *
-     * @param null $fx              A callback function with columns widths as parameter.
-     * @param null $widths          An array of widths value, integer only. ex: [100,200,300,100]
-     * @param null $resizerOptions  An array of column-resizer module options. see https://www.npmjs.com/package/column-resizer
+     * @param null $fx             A callback function with columns widths as parameter.
+     * @param null $widths         An array of widths value, integer only. ex: [100,200,300,100]
+     * @param null $resizerOptions An array of column-resizer module options. see https://www.npmjs.com/package/column-resizer
      *
      * @throws Exception
      */
     public function resizableColumn($fx = null, $widths = null, $resizerOptions = null)
     {
         $options = [];
-        if ($fx  && is_callable($fx)) {
+        if ($fx && is_callable($fx)) {
             $cb = $this->add('jsCallBack');
-            $cb->set(function() use ($fx) {
+            $cb->set(function () use ($fx) {
                 $widths = [];
                 if (isset($_POST['widths'])) {
                     //$widths = explode(',', $_GET['widths']);
                     $widths = json_decode($_POST['widths']);
                 }
+
                 return call_user_func($fx, $widths);
             });
             $options['uri'] = $cb->getJSURL();
-        } else if ($fx && is_array($fx)) {
+        } elseif ($fx && is_array($fx)) {
             $widths = $fx;
         }
 

--- a/src/Table.php
+++ b/src/Table.php
@@ -316,6 +316,47 @@ class Table extends Lister
     ];
 
     /**
+     *
+     * Make columns resizable by dragging column header.
+     *
+     * @param null $fx              A callback function with columns widths as parameter.
+     * @param null $widths          An array of widths value, integer only. ex: [100,200,300,100]
+     * @param null $resizerOptions  An array of column-resizer module options. see https://www.npmjs.com/package/column-resizer
+     *
+     * @throws Exception
+     */
+    public function resizableColumn($fx = null, $widths = null, $resizerOptions = null)
+    {
+        $options = [];
+        if ($fx  && is_callable($fx)) {
+            $cb = $this->add('jsCallBack');
+            $cb->set(function() use ($fx) {
+                $widths = [];
+                if (isset($_POST['widths'])) {
+                    //$widths = explode(',', $_GET['widths']);
+                    $widths = json_decode($_POST['widths']);
+                }
+                return call_user_func($fx, $widths);
+            });
+            $options['uri'] = $cb->getJSURL();
+        } else if ($fx && is_array($fx)) {
+            $widths = $fx;
+        }
+
+        if ($widths) {
+            $options['widths'] = $widths;
+        }
+
+        if ($resizerOptions) {
+            $options = array_merge($options, $resizerOptions);
+        }
+
+        $this->js(true, $this->js()->atkColumnResizer($options));
+
+        return $this;
+    }
+
+    /**
      * Override works like this:.
      * [
      *   'name'=>'Totals for {$num} rows:',

--- a/template/semantic-ui/grid.html
+++ b/template/semantic-ui/grid.html
@@ -3,7 +3,7 @@
 {$Content}
 {Container}
 <div class="ui vertical segment" id="{$_id}">
-  <div class="ui table atk-overflow-auto">
+  <div class="ui atk-overflow-auto">
     {$Table}
     {$Content}
   </div>{$Paginator}

--- a/template/semantic-ui/grid.pug
+++ b/template/semantic-ui/grid.pug
@@ -3,7 +3,7 @@
 | {$Content}
 | {Container}
 div(id="{$_id}" class="ui vertical segment")
-    div(class="ui table atk-overflow-auto")
+    div(class="ui atk-overflow-auto")
         |{$Table}
         |{$Content}
     |{$Paginator}


### PR DESCRIPTION
Allow table column to be resizable using drag via new Table method Table::resizableColumn()

 - You can supply callback function that will return new width set via dragging;
-  you can supply an array of column widths when creating the table;

``` php
    /**
     *
     * Make columns resizable by dragging column header.
     *
     * @param null $fx              A callback function with columns widths as parameter.
     * @param null $widths          An array of widths value, integer only. ex: [100,200,300,100]
     * @param null $resizerOptions  An array of column-resizer module options. see https://www.npmjs.com/package/column-resizer
     *
     * @throws Exception
     */
    public function resizableColumn($fx = null, $widths = null, $resizerOptions = null)
    {
        $options = [];
        if ($fx  && is_callable($fx)) {
            $cb = $this->add('jsCallBack');
            $cb->set(function() use ($fx) {
                $widths = [];
                if (isset($_POST['widths'])) {
                    //$widths = explode(',', $_GET['widths']);
                    $widths = json_decode($_POST['widths']);
                }
                return call_user_func($fx, $widths);
            });
            $options['uri'] = $cb->getJSURL();
        } else if ($fx && is_array($fx)) {
            $widths = $fx;
        }

        if ($widths) {
            $options['widths'] = $widths;
        }

        if ($resizerOptions) {
            $options = array_merge($options, $resizerOptions);
        }

        $this->js(true, $this->js()->atkColumnResizer($options));

        return $this;
    }
```

<img width="884" alt="screen shot 2018-09-06 at 11 07 04 am" src="https://user-images.githubusercontent.com/2204478/45166815-dbda7180-b1c5-11e8-9bf8-6ad3fb625b52.png">

## Demo
Available in table2.php file.

## Important 
atkui-js need to be rebuild.