### PR TITLE
Feature/js search auto query

### DIFF
--- a/demos/grid.php
+++ b/demos/grid.php
@@ -5,7 +5,9 @@ require 'database.php';
 
 $g = $app->add(['Grid']);
 $g->setModel(new Country($db));
-$g->addQuickSearch();
+
+//Adding Quicksearch on Name field using auto query.
+$g->addQuickSearch(['name'], true);
 
 $g->menu->addItem(['Add Country', 'icon' => 'add square'], new \atk4\ui\jsExpression('alert(123)'));
 $g->menu->addItem(['Re-Import', 'icon' => 'power'], new \atk4\ui\jsReload($g));

--- a/docs/grid.rst
+++ b/docs/grid.rst
@@ -54,7 +54,7 @@ Adding Quick Search
 
 .. php:attr: $quickSearch
 
-.. php:method: addQuickSearch($fields = [])
+.. php:method: addQuickSearch($fields = [], $hasAutoQuery = false)
 
 After you have associated grid with a model using :php:class:`View::setModel()` you can
 include quick-search component::
@@ -63,6 +63,11 @@ include quick-search component::
 
 If you don't specify argument, then search will be done by a models title field.
 (http://agile-data.readthedocs.io/en/develop/model.html#title-field)
+
+By default, quick search input field will query server when user press the Enter key. However, it is possible to make it
+querying the server automatically, i.e. after the user has finished typing, by setting the auto query parameter::
+
+    $grid->addQuickSearch(['name', 'surname'], true);
 
 Paginator
 =========

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -199,13 +199,16 @@ class Grid extends View
 
     /**
      * Add Search input field using js action.
+     * By default, will query server when using Enter key on input search field.
+     * You can change it to query server on each keystroke by passing $autoQuery true,
      *
-     * @param array $fields
+     * @param array   $fields        The list of fields to search for.
+     * @param boolean $hasAutoQuery  Will query server on each key pressed.
      *
      * @throws Exception
      * @throws \atk4\data\Exception
      */
-    public function addQuickSearch($fields = [])
+    public function addQuickSearch($fields = [], $hasAutoQuery = false)
     {
         if (!$fields) {
             $fields = [$this->model->title_field];
@@ -219,7 +222,7 @@ class Grid extends View
             ->addMenuRight()->addItem()->setElement('div')
             ->add('View');
 
-        $this->quickSearch = $view->add(['jsSearch', 'reload' => $this->container]);
+        $this->quickSearch = $view->add(['jsSearch', 'reload' => $this->container, 'autoQuery' => $hasAutoQuery]);
 
         if ($q = $this->stickyGet('_q')) {
             $cond = [];

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -200,10 +200,10 @@ class Grid extends View
     /**
      * Add Search input field using js action.
      * By default, will query server when using Enter key on input search field.
-     * You can change it to query server on each keystroke by passing $autoQuery true,
+     * You can change it to query server on each keystroke by passing $autoQuery true,.
      *
-     * @param array   $fields        The list of fields to search for.
-     * @param boolean $hasAutoQuery  Will query server on each key pressed.
+     * @param array $fields       The list of fields to search for.
+     * @param bool  $hasAutoQuery Will query server on each key pressed.
      *
      * @throws Exception
      * @throws \atk4\data\Exception

--- a/src/jsSearch.php
+++ b/src/jsSearch.php
@@ -16,6 +16,15 @@ class jsSearch extends View
     public $reload = null;
 
     public $args = [];
+
+    /**
+     * Whether or not jsSearch will query server on each keystroke.
+     * Default is with using Enter key.
+     *
+     * @var bool
+     */
+    public $autoQuery = false;
+
     /**
      * The input field.
      *
@@ -54,7 +63,11 @@ class jsSearch extends View
         $this->template->set('BtnSearchIcon', $this->btnSearchIcon);
         $this->template->set('BtnRemoveIcon', $this->btnRemoveIcon);
 
-        $this->js(true)->atkJsSearch(['uri' => $this->reload->jsURL(), 'uri_options' => array_merge(['__atk_reload'=>$this->reload->name], $this->args)]);
+        $this->js(true)->atkJsSearch([
+                'uri'         => $this->reload->jsURL(),
+                'uri_options' => array_merge(['__atk_reload'=>$this->reload->name], $this->args),
+                'autoQuery'   => $this->autoQuery,
+            ]);
 
         parent::renderView();
     }


### PR DESCRIPTION
jsSearch  now offer the option to send server query on each keystroke instead of default Enter key.

Setup the feature using the autoQuery option directly in jsSearch or using Grid::addQuickSearch method.

```
$g = $app->add(['Grid']);
$g->setModel(new Country($db));

//setting AutoQuery using second parameter of addQuickSearch
$g->addQuickSearch([], true);
```

