### PR TITLE
feature/leftMenu option

### DIFF
--- a/docs/app.rst
+++ b/docs/app.rst
@@ -396,15 +396,44 @@ contents. It is a standard html5 doctype template.
 The layout will be selected based on your choice - 'Centered', 'Admin' etc. This will
 not only change the overal page outline, but will also introduce some additional views.
 
-Going with the 'Admin' layout will populate some menu objects. Each layout may come with
-several views that you can populate::
+Each layout, depending on it's content, may come with several views that you can populate.
+
+Admin Layout
+------------
+.. php:namespace:: atk4\ui\Layout
+.. php:class:: Admin
+
+Agile Toolkit comes with a ready to use admin layout for your application. The layout is build
+with top, left and right menu object.
+
+.. php:attr:: menuLeft
+
+Populating the left menu object is simply a matter of adding the right menu items to the layout menu::
 
     $app->initLayout('Admin');
+    $layout = $app->layout;
 
     // Add item into menu
-    $app->layout->menu->addItem('User Admin', 'admin');
-    // or simply which does the same thing
-    $app->menu->addItem('User Admin', 'admin');
+    $layout->menuLeft->addItem(['Welcome Page', 'icon' => 'gift'], ['index']);
+    $layout->menuLeft->addItem(['Layouts', 'icon' => 'object group'], ['layouts']);
+
+    $EditGroup = $layout->menuLeft->addGroup(['Edit', 'icon' => 'edit']);
+    $EditGroup->addItem('Basics', ['edit/basic']);
+
+.. php:attr:: menu
+
+This is the top menu of the admin layout. You can add other item to the top menu using::
+
+    $layout->menu->addItem()->add(['Button', 'View Source', 'teal', 'icon' => 'github'])
+        ->setAttr('target', '_blank')->on('click', new \atk4\ui\jsExpression('document.location=[];', [$url.$f]));
+
+.. php:attr:: menuRight
+
+The top right dropdown menu.
+
+.. php:attr:: isMenuLeftVisible
+
+Whether or not the left menu is open on page load or not. Default is true.
 
 
 Integration with Legacy Apps

--- a/src/App.php
+++ b/src/App.php
@@ -314,7 +314,6 @@ class App
         // Agile UI
         $url = isset($this->cdn['atk']) ? $this->cdn['atk'] : '../public';
         $this->requireJS($url.'/atkjs-ui.min.js');
-        $this->requireJS($url.'/agileui.js');
         $this->requireCSS($url.'/agileui.css');
     }
 

--- a/src/Layout/Admin.php
+++ b/src/Layout/Admin.php
@@ -2,7 +2,9 @@
 
 namespace atk4\ui\Layout;
 
+use atk4\ui\jQuery;
 use atk4\ui\Menu;
+use atk4\ui\Template;
 
 /**
  * Implements a classic 100% width admin layout.
@@ -34,6 +36,11 @@ class Admin extends Generic
 
     public $burger = true;      // burger menu item
 
+    /*
+     * Whether or not left Menu is visible on Page load.
+     */
+    public $isMenuLeftVisible = true;
+
     /**
      * Obsolete, use menuLeft.
      *
@@ -49,7 +56,12 @@ class Admin extends Generic
 
         if ($this->menu === null) {
             $this->menu = $this->add(['Menu', 'atk-topMenu inverted fixed horizontal', 'element' => 'header'], 'TopMenu');
-            $this->burger = $this->menu->addItem(['class' => ['icon atk-leftMenuTrigger']])->add(['Icon', 'content']);
+            $this->burger = $this->menu->addItem(['class' => ['icon atk-leftMenuTrigger']]);
+            $this->burger->on('click', [
+                (new jQuery('.ui.left.sidebar'))->toggleClass('visible'),
+                (new jQuery('body'))->toggleClass('atk-leftMenu-visible'),
+            ]);
+            $this->burger->add(['Icon', 'content']);
         }
 
         if ($this->menuRight === null) {
@@ -58,8 +70,12 @@ class Admin extends Generic
         }
 
         if ($this->menuLeft === null) {
-            $this->menuLeft = $this->add(new Menu('left vertical inverted labeled visible sidebar'), 'LeftMenu');
+            $this->menuLeft = $this->add(new Menu('left vertical inverted labeled sidebar'), 'LeftMenu');
             $this->leftMenu = $this->menuLeft;
+
+            $closeIcon = $this->menuLeft->add(['View', 'template' => new Template('<a id="{$_id}" href="#" onclick="return false;" class="{$class} item atk-leftMenuClose"><i class="close icon"></i></a>')]);
+            $closeIcon->on('click', (new jQuery('body'))->removeClass('atk-leftMenu-visible'));
+
             $this->menuLeft->addHeader($this->app->title);
         }
 
@@ -75,6 +91,9 @@ class Admin extends Generic
             if (count($this->menuLeft->elements) == 1) {
                 // no items were added, so lets add dashboard
                 $this->menuLeft->addItem(['Dashboard', 'icon' => 'dashboard'], 'index');
+            }
+            if ($this->isMenuLeftVisible) {
+                $this->menuLeft->addClass('visible');
             }
             //$this->leftMenu->addItem(['Logout', 'icon'=>'sign out'], ['logout']);
         }


### PR DESCRIPTION
Add option to set left menu as visible or not on page load.

### New Property Admin::isMenuLeftVisible

Setting this property to false will not show the admin left menu on page load. Menu will only appear when clicking on Burger icon.
The default setting is true.

### Usage:

```
$app->initLayout(['Admin', 'isMenuLeftVisible' => false]);
```

### Note
 
This PR also remove dependencies on agileui.js file.
