### PR TITLE
fix/ grid table overflow

### DIFF
--- a/public/agileui.less
+++ b/public/agileui.less
@@ -81,11 +81,14 @@ footer.atk-footer {
 
 // Components
 
-.ui.table.atk-overflow-auto {
+.atk-overflow-auto {
   overflow: auto;
-  >.ui.table {
-    border: none;
+  border: 1px solid rgba(34, 36, 38, 0.15);
+  margin-bottom: 1em;
+  > .ui.table {
+    margin-top: 0em;
   }
+
 }
 .atk-cell-expanded {
   min-width: 320px;


### PR DESCRIPTION
This css fix will allow table inside grid to overflow horizontally.

Css change is due because  table css class in container for table in grid was remove in PR for column resizer.