### PR TITLE
Set view as not rendered if there is exception

### DIFF
--- a/src/View.php
+++ b/src/View.php
@@ -729,6 +729,7 @@ class View implements jsExpressionable
                                 'html'    => $this->template->render(),
                                 'id'      => $this->name, ]);
         } catch (\Exception $exception) {
+            $this->_rendered = false;
             $l = $this->add(new self());
             if ($exception instanceof \atk4\core\Exception) {
                 $l->template->setHTML('Content', $exception->getHTML());


### PR DESCRIPTION
If View is already rendered, but throws exception in json_encode, then you can't add more elements in View so need to set it as not rendered here.
