### PR TITLE
View::on now takes callback and JS actions

### DIFF
--- a/src/View.php
+++ b/src/View.php
@@ -925,14 +925,8 @@ class View implements jsExpressionable
         }
 
         $actions = [];
-        $actions['preventDefault'] = true;
-        $actions['stopPropagation'] = true;
-        if (isset($defaults['preventDefault'])) {
-            $actions['preventDefault'] = $defaults['preventDefault'];
-        }
-        if (isset($defaults['stopPropagation'])) {
-            $actions['stopPropagation'] = $defaults['stopPropagation'];
-        }
+        $actions['preventDefault'] = isset($defaults['preventDefault']) ? $defaults['preventDefault'] : true;
+        $actions['stopPropagation'] = isset($defaults['stopPropagation']) ? $defaults['stopPropagation'] : true;
 
         if (is_callable($action) || (is_array($action) && isset($action[0]) && is_callable($action[0]))) {
             // if callable $action is passed, then execute ajaxec()

--- a/src/View.php
+++ b/src/View.php
@@ -940,7 +940,7 @@ class View implements jsExpressionable
             if (is_array($action)) {
                 $urlData = $action;
                 unset($urlData[0]);
-                foreach($urlData as $a) {
+                foreach ($urlData as $a) {
                     $actions[] = $a;
                 }
                 $action = $action[0];

--- a/src/View.php
+++ b/src/View.php
@@ -940,6 +940,9 @@ class View implements jsExpressionable
             if (is_array($action)) {
                 $urlData = $action;
                 unset($urlData[0]);
+                foreach($urlData as $a) {
+                    $actions[] = $a;
+                }
                 $action = $action[0];
             } else {
                 $urlData = [];


### PR DESCRIPTION
This enables usage of View::on to pass a PHP callback function as well as several JS actions, e.g.:
```
 $this->on(
            'click',
            '.somecssclass',
            [
                function($e) {
                    //PHP Callback
                },
                (new \atk4\ui\jQuery('#eooSaveButton'))->addClass('loading'),
                //someotherJSaction
            ]
        );
```
