### PR TITLE
Allow PHP 7.2+ to check method signatures

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -345,7 +345,7 @@ class App
     }
 
     /**
-     * Add a new object into the app. You will need to have Layout first
+     * Add a new object into the app. You will need to have Layout first.
      *
      * @param mixed  $seed   New object to add
      * @param string $region

--- a/src/App.php
+++ b/src/App.php
@@ -148,7 +148,14 @@ class App
         }
 
         if ($this->fix_incompatible) {
-            if (PHP_MAJOR_VERSION >= 7) {
+            // PHP 7.0 introduces strict checks for method patterns. But only 7.2 introduced parameter type widening
+            //
+            // https://en.wikipedia.org/wiki/Covariance_and_contravariance_(computer_science)#Contravariant_method_argument_type
+            // https://wiki.php.net/rfc/parameter-no-type-variance
+            //
+            // We wish to start using type-hinting more in our classes, but it would break any extends in 3rd party code unless
+            // they are on 7.2.
+            if (version_compare(PHP_VERSION, '7.0.0') >= 0 && version_compare(PHP_VERSION, '7.2.0') < 0) {
                 set_error_handler(function ($errno, $errstr) {
                     return strpos($errstr, 'Declaration of') === 0;
                 }, E_WARNING);
@@ -338,25 +345,20 @@ class App
     }
 
     /**
-     * Create object and associate it with this app.
+     * Add a new object into the app. You will need to have Layout first
+     *
+     * @param mixed  $seed   New object to add
+     * @param string $region
      *
      * @return object
      */
-    public function add()
+    public function add($seed, $region = null)
     {
-        if ($this->layout) {
-            return call_user_func_array([$this->layout, 'add'], func_get_args());
-        } else {
-            list($obj) = func_get_args();
-
-            if (!is_object($obj)) {
-                throw new Exception(['Incorrect use of App::add. First parameter should be object.']);
-            }
-
-            $obj->app = $this;
-
-            return $obj;
+        if (!$this->layout) {
+            throw new Exception(['If you use $app->add() you should first call $app->setLayout()']);
         }
+
+        return $this->layout->add($seed, $region);
     }
 
     /**


### PR DESCRIPTION
Problem: ATK UI currently disables method signature checking, because PHP 7.0/7.1 does not implement parameter widening correctly.

This has been fixed in 7.2 and by hiding errors we prompt our users to write bad code. 

Read up:
https://wiki.php.net/rfc/parameter-no-type-variance
https://en.wikipedia.org/wiki/Covariance_and_contravariance_(computer_science)#Contravariant_method_argument_type

## Scenario 1

Your code:

``` php
class MyView extends \atk4\ui\View {
 public function setModel($m) {
   parent::setModel($m);
 }
}
```

This code will work OK on 7.2 (because you use type widening), but will fail on 7.0 and 7.1. Which is why we leave warning suppression for those versions. 

## Scenario 2

Your code:

``` php
class MyView extends \atk4\ui\View {
 public function setModel(MyUser $m) {
   parent::setModel($m);
 }
}
```


This is a BAD code. It currently is allowed but after merging PR it will display warning. You should instead use this:

``` php
 public function setUser(MyUser $m) {
   parent::setModel($m);
 }
```

## Scenario 3

Your code:

``` php
class MyView extends \atk4\ui\View {
 public function jsReload($args = []) {
    parent::jsReload($args = []);
  }
}
```

IF next version of ATK UI would want to enforce array type argument for View::jsReload by replacing 
https://github.com/atk4/ui/blob/develop/src/View.php#L859 with:

``` php
    public function jsReload(array $args = [])
```

your code will generate warning on 7.0 and 7.1. Suppression would probably hide the error though. If you are on 7.2 the code is still valid.
