### PR TITLE
Only show action <div> if there are actions

### DIFF
--- a/src/Modal.php
+++ b/src/Modal.php
@@ -46,6 +46,14 @@ class Modal extends View
     //now only supported json type response.
     public $type = 'json';
 
+    /*
+     * if true, the <div class="actions"> at the bottom of the modal is
+     * shown. Automatically set to true if any actions are added
+     *
+     * @var bool
+     */
+    public $showActions = false;
+
     /**
      * Set callback function for this modal.
      *
@@ -262,7 +270,7 @@ class Modal extends View
     public function addButtonAction($button)
     {
         $this->add($button, 'actions');
-
+        $this->showActions = true;
         return $this;
     }
 
@@ -290,6 +298,10 @@ class Modal extends View
 
         if (!empty($this->fx)) {
             $data['uri'] = $this->cb->getJSURL();
+        }
+
+        if (!$this->showActions) {
+            $this->template->del('ActionContainer');
         }
 
         // call modal creation first

--- a/template/semantic-ui/modal.html
+++ b/template/semantic-ui/modal.html
@@ -1,6 +1,9 @@
 <{_element}div{/} id="{$_id}" class="{_ui}ui {/} {$class} {_class}{/}" style="{$style}" {$attributes}><i class="{$close}"></i>
 <div class="{$headerCss}">{$title}</div>
 <div class="img content atk-dialog-content">{$Content}</div>
+{ActionContainer}
 <div class="actions">
   <div>{$actions}</div>
-</div></{_element}div{/}>
+</div>
+{/ActionContainer}
+</{_element}div{/}>

--- a/template/semantic-ui/modal.pug
+++ b/template/semantic-ui/modal.pug
@@ -1,6 +1,8 @@
 <{_element}div{/} id="{$_id}" class="{_ui}ui {/} {$class} {_class}{/}" style="{$style}" {$attributes}><i class="{$close}"></i>
     div(class="{$headerCss}") {$title}
     div(class="img content atk-dialog-content") {$Content}
+    {ActionContainer}
     .actions
         div {$actions}
+    {/ActionContainer}
 </{_element}div{/}>


### PR DESCRIPTION
Fixes #583 
Added property showActions which is set to true by addButtonAction.
Only if showActions is true the ```<div class="action">``` is shown.

Edit: I am too stupid to work with Github, the template file is missing in this pull request, and I cant get in in here.
```
<{_element}div{/} id="{$_id}" class="{_ui}ui {/} {$class} {_class}{/}" style="{$style}" {$attributes}><i class="{$close}"></i>
<div class="{$headerCss}">{$title}</div>
<div class="img content atk-dialog-content">{$Content}</div>
{ActionContainer}
<div class="actions">
  <div>{$actions}</div>
</div>
{/ActionContainer}
</{_element}div{/}>
```