### PR TITLE
don't show never_persist fields as changed - that's confusing

### DIFF
--- a/demos/form3.php
+++ b/demos/form3.php
@@ -31,12 +31,10 @@ $form->setModel(
 $form->onSubmit(function ($form) {
     $errors = [];
     foreach ($form->model->dirty as $field => $value) {
-        /*
-        if (!$form->model->getElement($field)->isEditable()) {
-            continue;
+        // we should care only about editable fields
+        if ($form->model->getElement($field)->isEditable()) {
+            $errors[] = $form->error($field, 'Value was changed, '.json_encode($value).' to '.json_encode($form->model[$field]));
         }
-        */
-        $errors[] = $form->error($field, 'Value was changed, '.json_encode($value).' to '.json_encode($form->model[$field]));
     }
 
     return $errors ?: 'No fields were changed';


### PR DESCRIPTION
never_persist fields are still set in Model->dirty array.
Because of that this demo was confusing because it shows that field value was changed, but user didn't and couldn't change it.