### PR TITLE
Feature/fix add column

### DIFF
--- a/src/FormLayout/_Abstract.php
+++ b/src/FormLayout/_Abstract.php
@@ -20,7 +20,7 @@ abstract class _Abstract extends \atk4\ui\View
      * Places field inside a layout somewhere. Should be called
      * through $form->addField().
      *
-     * @param string|null              $name
+     * @param string                   $name
      * @param array|string|object|null $decorator
      * @param array|string|object|null $field
      *

--- a/src/Table.php
+++ b/src/Table.php
@@ -252,20 +252,24 @@ class Table extends Lister
     /**
      * Add column Decorator.
      *
-     * @param string                     $name      Column name
-     * @param string|TableColumn/Generic $decorator
+     * @param string $name Column name
+     * @param mixed  $seed Defaults to pass to factory() when decorator is initialized
+     *
+     * @return TableColumn\Generic
      */
-    public function addDecorator($name, $decorator)
+    public function addDecorator($name, $seed)
     {
         if (!$this->columns[$name]) {
             throw new Exception(['No such column, cannot decorate', 'name' => $name]);
         }
-        $decorator = $this->_add($this->factory($decorator, ['table' => $this], 'TableColumn'));
+        $decorator = $this->_add($this->factory($seed, ['table' => $this], 'TableColumn'));
 
         if (!is_array($this->columns[$name])) {
             $this->columns[$name] = [$this->columns[$name]];
         }
         $this->columns[$name][] = $decorator;
+        
+        return $decorator;
     }
 
     /**
@@ -287,7 +291,7 @@ class Table extends Lister
      * By default will use default column.
      *
      * @param \atk4\data\Field $f    Data model field
-     * @param array            $seed Defaults to pass to factory() when decorator is initialized
+     * @param mixed            $seed Defaults to pass to factory() when decorator is initialized
      *
      * @return TableColumn\Generic
      */

--- a/src/Table.php
+++ b/src/Table.php
@@ -191,7 +191,7 @@ class Table extends Lister
 
         if ($field === null) {
             // column is not associated with any model field
-            $columnDecorator =  $this->_add($this->factory($columnDecorator, ['table' => $this], 'TableColumn'));
+            $columnDecorator = $this->_add($this->factory($columnDecorator, ['table' => $this], 'TableColumn'));
         } elseif (is_array($columnDecorator) || is_string($columnDecorator)) {
             $columnDecorator = $this->decoratorFactory($field, $columnDecorator);
         } elseif (!$columnDecorator) {
@@ -276,7 +276,7 @@ class Table extends Lister
             $this->columns[$name] = [$this->columns[$name]];
         }
         $this->columns[$name][] = $decorator;
-        
+
         return $decorator;
     }
 

--- a/src/Table.php
+++ b/src/Table.php
@@ -201,8 +201,6 @@ class Table extends Lister
         if (is_null($name)) {
             $this->columns[] = $columnDecorator;
         } elseif (!is_string($name)) {
-            echo 'about to throw exception.....';
-
             throw new Exception(['Name must be a string', 'name' => $name]);
         } elseif (isset($this->columns[$name])) {
             throw new Exception(['Table already has column with $name. Try using addDecorator()', 'name' => $name]);
@@ -280,11 +278,8 @@ class Table extends Lister
     public function getColumnDecorators($name)
     {
         $dec = $this->columns[$name];
-        if (!is_array($dec)) {
-            $dec = [$dec];
-        }
 
-        return $dec;
+        return is_array($dec) ? $dec : [$dec];
     }
 
     /**


### PR DESCRIPTION
`addColumn` now properly support `$name===null` case.

That's when we want to add column in table, but don't want to create or link it with any model field.
That approach is used in CRUD addAction, but because of this wrong implementation of addColumn we actually added new field called 'field_sql' in data model and it even show up in forms.
This PR fixes that.