### PR TITLE
fix/Readonly state for Lookup and Autocomplete

### DIFF
--- a/src/FormField/AutoComplete.php
+++ b/src/FormField/AutoComplete.php
@@ -243,6 +243,8 @@ class AutoComplete extends Input
         if ($this->readonly) {
             $this->settings['showOnFocus'] = false;
             $this->settings['allowTab'] = false;
+            $this->settings['apiSettings'] = null;
+            $this->settings['onShow'] = new jsFunction([new jsExpression('return false')]);
             $this->template->set('readonly', 'readonly');
         }
 

--- a/src/FormField/Lookup.php
+++ b/src/FormField/Lookup.php
@@ -465,6 +465,8 @@ class Lookup extends Input
         if ($this->readonly) {
             $this->settings['showOnFocus'] = false;
             $this->settings['allowTab'] = false;
+            $this->settings['apiSettings'] = null;
+            $this->settings['onShow'] = new jsFunction([new jsExpression('return false')]);
             $this->template->set('readonly', 'readonly');
         }
 


### PR DESCRIPTION
Prior to this fix, it was still possible to change readonly state for Lookup or Autocomplete
