### PR TITLE
Make demo for dynamic scroll in container better

### DIFF
--- a/demos/scroll-container.php
+++ b/demos/scroll-container.php
@@ -11,7 +11,9 @@ $app->add(['View', 'ui' => 'ui clearing divider']);
 
 $app->add(['Header', 'Dynamic scroll in Container']);
 
-$scroll_container = $app->add('View')->addClass('ui segment')->addStyle(['max-height' => '400px', 'overflow-y' => 'scroll']);
+$v = $app->add('View')->addClass('ui basic segment atk-scroller');
+
+$scroll_container = $v->add('View')->addClass('ui segment')->addStyle(['max-height' => '400px', 'overflow-y' => 'scroll']);
 
 $lister_template = '<div id="{$_id}">{List}<div id="{$_id}" class="ui segment" style="height: 60px"><i class="{iso}ae{/} flag"></i> {name}andorra{/}</div>{/}{$Content}</div>';
 
@@ -23,4 +25,4 @@ $l = $lister_container->add('Lister', 'List')->addHook('beforeRow', function ($l
 $l->setModel(new Country($db));
 
 //add dynamic scrolling.
-$l->addJsPaginator(20, [], $scroll_container);
+$l->addJsPaginator(20, ['stateContext' => '.atk-scroller'], $scroll_container);

--- a/demos/scroll-grid-container.php
+++ b/demos/scroll-grid-container.php
@@ -9,7 +9,18 @@ $app->add(['View', 'ui' => 'ui clearing divider']);
 
 $app->add(['Header', 'Dynamic scroll in Grid with fixed column headers']);
 
-$g = $app->add(['Grid', 'menu' => false]);
-$m = $g->setModel(new Country($db));
+$c = $app->add('Columns');
 
-$g->addJsPaginatorInContainer(30, 400);
+$c1 = $c->addColumn();
+$g1 = $c1->add(['Grid', 'menu' => false]);
+$m1 = $g1->setModel(new Country($db));
+$g1->addJsPaginatorInContainer(30, 400);
+
+$c2 = $c->addColumn();
+$g2 = $c2->add(['Grid', 'menu' => false]);
+$m2 = $g2->setModel(new Country($db));
+$g2->addJsPaginatorInContainer(20, 200);
+
+$g3 = $c2->add(['Grid', 'menu' => false]);
+$m3 = $g3->setModel(new Country($db));
+$g3->addJsPaginatorInContainer(10, 150);

--- a/js/src/plugins/scroll.js
+++ b/js/src/plugins/scroll.js
@@ -10,6 +10,8 @@ import apiService from "../services/ApiService";
  *  initialPage: 1      The initial page load when calling this plugin.
  *  appendTo: null      The html element where new content should be append to.
  *  allowJsEval: false  Whether or not javascript send in server response should be evaluate.
+ *  stateContext: null  A jQuery selector, where you would like fomantic-ui, to apply the stateContext to during the api call.
+ *                        if null, then a default loader will be apply to the bottom of the $inner element.
  */
 
 export default class scroll extends atkPlugin {
@@ -28,7 +30,8 @@ export default class scroll extends atkPlugin {
       allowJsEval: false ,
       hasFixTableHeader: false,
       tableContainerHeight: 400,
-      tableHeaderColor: '#ffffff'
+      tableHeaderColor: '#ffffff',
+      stateContext: null,
     };
     //set default option if not set.
     this.settings.options = Object.assign({}, defaultSettings, this.settings.options);
@@ -146,14 +149,17 @@ export default class scroll extends atkPlugin {
    * Ask server for more content.
    */
   loadContent() {
+    if (!this.settings.options.stateContext) {
+      this.addLoader();
+    }
+
     this.isWaiting = true;
-    this.addLoader();
     this.$inner.api({
       on: 'now',
       url: this.settings.uri,
       data: Object.assign({}, this.settings.uri_options, {page: this.nextPage}),
       method: 'GET',
-      stateContext: this.settings.options.hasFixTableHeader ? this.$el : this.$inner,
+      stateContext: this.settings.options.stateContext,
       onComplete: this.onComplete.bind(this),
     });
   }

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -251,6 +251,8 @@ class Grid extends View
           'hasFixTableHeader'    => true,
           'tableContainerHeight' => $containerHeight,
         ]);
+        //adding a state context to js scroll plugin.
+        $options = array_merge(['stateContext' => '#'.$this->container->name], $options);
 
         return $this->addJsPaginator($ipp, $options, $container, $scrollRegion);
     }


### PR DESCRIPTION
See `demos/scroll-grid-container.php`

@ibelar Is it possible to fix load spinner? It should show up in the middle of container like it is doing when you sort grid by some column. Otherwise it's messing up page structure and flickering.