### PR TITLE
Feature/dynamic scroll crud

### DIFF
--- a/demos/scroll-grid-container.php
+++ b/demos/scroll-grid-container.php
@@ -3,7 +3,7 @@
 require 'init.php';
 require 'database.php';
 
-$app->add(['Button', 'Dynamic scroll in Grid', 'small left floated basic blue', 'icon' => 'left arrow'])
+$app->add(['Button', 'Dynamic scroll in CRUD and Grid', 'small left floated basic blue', 'icon' => 'left arrow'])
     ->link(['scroll-grid']);
 $app->add(['View', 'ui' => 'ui clearing divider']);
 
@@ -12,9 +12,9 @@ $app->add(['Header', 'Dynamic scroll in Grid with fixed column headers']);
 $c = $app->add('Columns');
 
 $c1 = $c->addColumn();
-$g1 = $c1->add(['Grid', 'menu' => false]);
-$m1 = $g1->setModel(new Country($db));
-$g1->addJsPaginatorInContainer(30, 400);
+$g1 = $c1->add(['CRUD']);
+$m1 = $g1->setModel(new Country($db), ['name','iso']);
+$g1->addJsPaginatorInContainer(30, 350);
 
 $c2 = $c->addColumn();
 $g2 = $c2->add(['Grid', 'menu' => false]);

--- a/demos/scroll-grid-container.php
+++ b/demos/scroll-grid-container.php
@@ -13,7 +13,7 @@ $c = $app->add('Columns');
 
 $c1 = $c->addColumn();
 $g1 = $c1->add(['CRUD']);
-$m1 = $g1->setModel(new Country($db), ['name','iso']);
+$m1 = $g1->setModel(new Country($db), ['name', 'iso']);
 $g1->addJsPaginatorInContainer(30, 350);
 
 $c2 = $c->addColumn();

--- a/js/src/plugins/scroll.js
+++ b/js/src/plugins/scroll.js
@@ -78,7 +78,8 @@ export default class scroll extends atkPlugin {
       $tableCopy.css({
         'position':'absolute',
         'background-color' : this.settings.options.tableHeaderColor,
-        'border' : this.$el.find('th').eq(1).css('border-left')
+        'border' : this.$el.find('th').eq(1).css('border-left'),
+        'z-index': 1
       });
       this.$scroll.prepend($tableCopy);
       this.$el.find('thead').hide();

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -247,6 +247,7 @@ class Grid extends View
      */
     public function addJsPaginatorInContainer($ipp, $containerHeight, $options = [], $container = null, $scrollRegion = 'Body')
     {
+        $this->table->hasCollapsingCssActionColumn = false;
         $options = array_merge($options, [
           'hasFixTableHeader'    => true,
           'tableContainerHeight' => $containerHeight,

--- a/src/Table.php
+++ b/src/Table.php
@@ -119,6 +119,16 @@ class Table extends Lister
     public $sort_order = null;
 
     /**
+     * Make action columns in table use
+     * the collapsing css class.
+     * An action cell that is collapsing will
+     * only uses as much space as required.
+     *
+     * @var bool
+     */
+    public $hasCollapsingCssActionColumn = true;
+
+    /**
      * Constructor.
      *
      * @param null|string $class CSS class to add

--- a/src/TableColumn/Actions.php
+++ b/src/TableColumn/Actions.php
@@ -12,7 +12,7 @@ class Actions extends Generic
     public function init()
     {
         parent::init();
-        $this->addClass('right aligned collapsing');
+        $this->addClass('right aligned');
     }
 
     /**
@@ -55,6 +55,18 @@ class Actions extends Generic
         });
 
         return $this->addAction($button, $modal->show([$this->name=>$this->owner->jsRow()->data('id')]));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTag($position, $value, $attr = [])
+    {
+        if ($this->table->hasCollapsingCssActionColumn && $position === 'body') {
+            $attr['class'][] = 'collapsing';
+        }
+
+        return parent::getTag($position, $value, $attr);
     }
 
     public function getDataCellTemplate(\atk4\data\Field $f = null)


### PR DESCRIPTION
Dynamic scroll in Table and Grid works fine, but in CRUD:
1. data table column width doesn't match table header widths.
2. edit, delete buttons move to right and are not visible.

![screenshot](https://user-images.githubusercontent.com/1969119/49646201-1357f480-fa27-11e8-9324-417050b32019.png)


Solution which works - remove `collapsing` CSS class from table cells with buttons.
But maybe that way we break something else.