### PR TITLE
Fixes #618: Process fields with integer value 0 correctly

### DIFF
--- a/src/FormField/DropDown.php
+++ b/src/FormField/DropDown.php
@@ -105,7 +105,13 @@ class DropDown extends Input
      */
     public function getInput()
     {
-        $value = isset($this->field) ? $this->app->ui_persistence->typecastSaveField($this->field, $this->field->get()) : $this->content ?: '';
+        //fix for https://github.com/atk4/ui/issues/618
+        if(isset($this->field)) {
+            $value = $this->app->ui_persistence->typecastSaveField($this->field, $this->field->get());
+        }
+        else {
+            $value = $this->content ?: '';
+        }
 
         return $this->app->getTag('input', [
             'name'        => $this->short_name,

--- a/src/FormField/DropDown.php
+++ b/src/FormField/DropDown.php
@@ -106,10 +106,9 @@ class DropDown extends Input
     public function getInput()
     {
         //fix for https://github.com/atk4/ui/issues/618
-        if(isset($this->field)) {
+        if (isset($this->field)) {
             $value = $this->app->ui_persistence->typecastSaveField($this->field, $this->field->get());
-        }
-        else {
+        } else {
             $value = $this->content ?: '';
         }
 


### PR DESCRIPTION
The stacked ternary operator led to a wrong processing of integer 0 values, this fixes it and the value of the dropdown's hidden input is set correctly to 0 instead of an empty string.

Fixes #618 