### PR TITLE
Critical bug fix: always convert Dropdown/Autocomplete/Lookup values to string

### DIFF
--- a/src/FormField/AutoComplete.php
+++ b/src/FormField/AutoComplete.php
@@ -170,11 +170,15 @@ class AutoComplete extends Input
 
         $data = [];
         foreach ($this->model as $junk) {
-            $data[] = ['id' => $this->model[$id_field], 'name' => $this->model[$title_field]];
+            // IMPORTANT: always convert data to string, otherwise numbers can be rounded by JS
+            $data[] = [
+                'id'   => (string) $this->model[$id_field],
+                'name' => (string) $this->model[$title_field],
+            ];
         }
 
         if ($this->empty) {
-            array_unshift($data, ['id' => 0, 'name' => $this->empty]);
+            array_unshift($data, ['id' => '0', 'name' => (string) $this->empty]);
         }
 
         $this->app->terminate(json_encode([
@@ -263,7 +267,9 @@ class AutoComplete extends Input
             if (!$this->model->loaded()) {
                 $this->field->set(null);
             } else {
-                $chain->dropdown('set value', $this->model[$id_field])->dropdown('set text', $this->model[$title_field]);
+                // IMPORTANT: always convert data to string, otherwise numbers can be rounded by JS
+                $chain->dropdown('set value', (string) $this->model[$id_field])
+                        ->dropdown('set text', (string) $this->model[$title_field]);
                 $this->js(true, $chain);
             }
         }

--- a/src/FormField/DropDown.php
+++ b/src/FormField/DropDown.php
@@ -175,13 +175,13 @@ class DropDown extends Input
 
         $options = [];
         if (!$this->isValueRequired && !$this->isMultiple) {
-            $options[] = ['div',  'class' => 'item', 'data-value' => '', $this->empty || is_numeric($this->empty) ? [$this->empty] : []];
+            $options[] = ['div',  'class' => 'item', 'data-value' => '', $this->empty || is_numeric($this->empty) ? [(string) $this->empty] : []];
         }
 
         if (isset($this->model)) {
             foreach ($this->model as $key => $row) {
                 $title = $row->getTitle();
-                $item = ['div', 'class' => 'item', 'data-value' => (string) $key, $title || is_numeric($title) ? [$title] : []];
+                $item = ['div', 'class' => 'item', 'data-value' => (string) $key, $title || is_numeric($title) ? [(string) $title] : []];
                 $options[] = $item;
             }
         } else {
@@ -191,7 +191,7 @@ class DropDown extends Input
                         $val = "<i class='{$val['icon']}'></i>{$val[0]}";
                     }
                 }
-                $item = ['div', 'class' => 'item', 'data-value' => (string) $key, $val || is_numeric($val) ? [$val] : []];
+                $item = ['div', 'class' => 'item', 'data-value' => (string) $key, $val || is_numeric($val) ? [(string) $val] : []];
                 $options[] = $item;
             }
         }

--- a/src/FormField/Lookup.php
+++ b/src/FormField/Lookup.php
@@ -200,11 +200,15 @@ class Lookup extends Input
 
         $data = [];
         foreach ($this->model as $junk) {
-            $data[] = ['id' => $this->model[$id_field], 'name' => $this->model[$title_field]];
+            // IMPORTANT: always convert data to string, otherwise numbers can be rounded by JS
+            $data[] = [
+                'id'   => (string) $this->model[$id_field],
+                'name' => (string) $this->model[$title_field],
+            ];
         }
 
         if ($this->empty) {
-            array_unshift($data, ['id' => 0, 'name' => $this->empty]);
+            array_unshift($data, ['id' => '0', 'name' => (string) $this->empty]);
         }
 
         $this->app->terminate(json_encode([
@@ -513,7 +517,9 @@ class Lookup extends Input
                 $this->field->set(null);
             } else {
                 $chain = new jQuery('#'.$this->name.'-ac');
-                $chain->dropdown('set value', $this->model[$id_field])->dropdown('set text', $this->model[$title_field]);
+                // IMPORTANT: always convert data to string, otherwise numbers can be rounded by JS
+                $chain->dropdown('set value', (string) $this->model[$id_field])
+                        ->dropdown('set text', (string) $this->model[$title_field]);
                 $this->js(true, $chain);
             }
         }


### PR DESCRIPTION
To prevent rounding numbers (typically IDs) in JS

The rounding issue has been identified as least in the Semnatic UI Dropdown `set value` and `set  text` APIs.