### PR TITLE
Add "confirm" option support for js->on() case

### DIFF
--- a/src/View.php
+++ b/src/View.php
@@ -997,6 +997,12 @@ class View implements jsExpressionable
         $chain = new jQuery();
         $actions[] = $chain;
 
+        if (isset($defaults['confirm'])) {
+            array_unshift($actions,
+                new jsExpression('if(!confirm([])){return;}', [$defaults['confirm']])
+            );
+        }
+
         $action = new jsFunction($actions);
 
         if ($selector) {


### PR DESCRIPTION
Now will support 'confirm' option also in this case not only when you use callback.

```
$btn->on(
    'click',
    [
        new jsReload($installer, ['start' => 1], null, ['stateContext' => '#'.$btn->name]),
        $btn->js()->addClass('disabled'),
    ],
    ['confirm' => 'Are you sure you want to install this add-on?']
);
```
