### PR TITLE
Fix #629, also add new Callback for custom HTML

### DIFF
--- a/demos/dropdown-plus.php
+++ b/demos/dropdown-plus.php
@@ -1,8 +1,45 @@
 <?php
 
 require 'init.php';
+require 'database.php';
 
 $form = $app->add('Form');
+
+//standard with model: use id_field as Value, title_field as Title for each DropDown option
+$form->addField('withModel',
+                ['DropDown',
+                    'caption' => 'DropDown with data from Model',
+                    'model'   => new Country($db),
+                ]);
+
+//custom callback: alter title
+$form->addField('withModel2',
+                ['DropDown',
+                    'caption' => 'DropDown with data from Model',
+                    'model'   => new Country($db),
+                    'renderRowFunction' => function($row) {
+                        return [
+                          'value' => $row->id,
+                          'title' => $row->getTitle().' ('.$row->get('iso3').')',
+                        ];
+                    }
+                ]);
+
+//custom callback: add icon
+$form->addField('withModel2',
+                ['DropDown',
+                    'caption' => 'DropDown with data from Model',
+                    'model'   => new File($db),
+                    'renderRowFunction' => function($row) {
+                        return [
+                          'value' => $row->id,
+                          'title' => $row->getTitle(),,
+                          'icon'  => $row->get('is_folder') ? 'folder' : 'file',
+                        ];
+                    }
+                ]);
+
+
 
 $form->addField('enum',
                 ['DropDown',

--- a/demos/dropdown-plus.php
+++ b/demos/dropdown-plus.php
@@ -33,7 +33,7 @@ $form->addField('withModel2',
                     'renderRowFunction' => function($row) {
                         return [
                           'value' => $row->id,
-                          'title' => $row->getTitle(),,
+                          'title' => $row->getTitle(),
                           'icon'  => $row->get('is_folder') ? 'folder' : 'file',
                         ];
                     }

--- a/demos/dropdown-plus.php
+++ b/demos/dropdown-plus.php
@@ -26,7 +26,7 @@ $form->addField('withModel2',
                 ]);
 
 //custom callback: add icon
-$form->addField('withModel2',
+$form->addField('withModel3',
                 ['DropDown',
                     'caption' => 'DropDown with data from Model',
                     'model'   => new File($db),

--- a/demos/init.php
+++ b/demos/init.php
@@ -41,6 +41,7 @@ if (isset($layout->leftMenu)) {
     $form->addItem('Form Multi-column layout', ['form3']);
     $form->addItem(['Integration with Columns'], ['form5']);
     $form->addItem(['AutoComplete Field', 'icon'=>'yellow star'], ['autocomplete']);
+    $form->addItem(['DropDown Field'], ['dropdown-plus']);
     $form->addItem(['Value Selectors'], ['form6']);
     $form->addItem(['Conditional Fields'], ['jscondform']);
 

--- a/template/semantic-ui/formfield/dropdown.html
+++ b/template/semantic-ui/formfield/dropdown.html
@@ -5,7 +5,11 @@
 {Input}<input type="{input_type}text{/}" {$input_attributes}/>{/}
 <i class="{DropIcon}dropdown icon{/}"></i>
 <div class="default text">{DefaultText}...{/}</div>
-{$Items}
+<div class="menu">
+{Item}
+<div class="item" data-value="{$value}">{Icon}<i class="{$icon}"></i>{/Icon}{$title}</div>
+{/Item}
+</div>
 {$AfterInput}
 {$AfterAfterInput}
 </div>


### PR DESCRIPTION
Adds property renderRowFunction, which can be used to pass custom html options to renderView for each option.
If not defined, only needed title_field and id_field are used. (and system fields, they are also loaded when using only_fields()).