### PR TITLE
Removed deprecated each functions from template parsing

### DIFF
--- a/src/Template.php
+++ b/src/Template.php
@@ -735,6 +735,10 @@ class Template implements \ArrayAccess
      */
     protected function parseTemplateRecursive(&$input, &$template)
     {
+        if (!is_array($input) || empty($input)) {
+            return;
+        }
+        
         while (true) {
             
             $tag = current($input);next($input);
@@ -776,7 +780,7 @@ class Template implements \ArrayAccess
                     
                     // next would be prefix
                     $prefix = current($input);next($input);
-                    $template[$full_tag] = $prefix ? [$prefix] : [];
+                    $template[$full_tag] = ($prefix===false || $prefix===null) ? [] : [$prefix];
                     
                     $this->tags[$tag][] = &$template[$full_tag];
                     

--- a/src/Template.php
+++ b/src/Template.php
@@ -756,13 +756,12 @@ class Template implements \ArrayAccess
                 case '$':
                     
                     $tag = substr($tag, 1);
+                    
                     $full_tag = $this->regTag($tag);
-                    
                     $template[$full_tag] = '';  // empty value
-                    
                     $this->tags[$tag][] = &$template[$full_tag];
                     
-                    // recurse
+                    // eat next chunk
                     $chunk = current($input);next($input);
                     if ($chunk !== false && $chunk !== null) {
                         $template[] = $chunk;
@@ -776,7 +775,6 @@ class Template implements \ArrayAccess
                     $full_tag = $this->regTag($tag);
                     
                     $prefix = current($input);next($input);
-                    
                     $template[$full_tag] = $prefix ? [$prefix] : [];
                     
                     $this->tags[$tag][] = &$template[$full_tag];

--- a/src/Template.php
+++ b/src/Template.php
@@ -774,6 +774,7 @@ class Template implements \ArrayAccess
                     
                     $full_tag = $this->regTag($tag);
                     
+                    // next would be prefix
                     $prefix = current($input);next($input);
                     $template[$full_tag] = $prefix ? [$prefix] : [];
                     


### PR DESCRIPTION
today while i was playing with error catching and i see that there are a bunch of deprecated each functions and i remove it. I see that are covered by PHPUnit and i run tests with success, need to test more even if the use of each was not so extended.

i don't use foreach, because there are some performance issues with memory/pointers, this function is so heavy used and any minimal change in performance on a big layout will result in a huge latency on TTFB.