### PR TITLE
add top and bottom padding to centered layout

### DIFF
--- a/template/semantic-ui/layout/centered.html
+++ b/template/semantic-ui/layout/centered.html
@@ -1,7 +1,8 @@
 
-<div class="ui middle aligned grid container" style="min-height: 100%">
+<div class="ui middle aligned grid container" style="min-height:100%; padding:2rem 0;">
   <div class="column">{Header}
-    <h1 class="ui center aligned header"><img class="ui image" src="https://github.com/atk4/ui/raw/07208a0af84109f0d6e3553e242720d8aeedb784/public/logo.png"/>
+    <h1 class="ui center aligned header">
+      <img class="ui image" src="https://github.com/atk4/ui/raw/07208a0af84109f0d6e3553e242720d8aeedb784/public/logo.png"/>
       <div class="content">{$title}</div>
     </h1>{/}
     <div class="ui piled segment">{$Content}</div>


### PR DESCRIPTION
Centered layout didnt have any top and bottom padding/margin. On pages that exceeded browsers inner height, that looked quite crappy.

Maybe theres a nicer way using some predefined FUI class?