### PR TITLE
afterRow is good to render sub lines related to any line

### DIFF
--- a/src/Table.php
+++ b/src/Table.php
@@ -511,11 +511,11 @@ class Table extends Lister
 
             $this->renderRow();
             
+            $this->_rendered_rows_count++;
+            
             if ($this->hook('afterRow') === false) {
                 continue;
             }
-
-            $this->_rendered_rows_count++;
         }
 
         // Add totals rows or empty message

--- a/src/Table.php
+++ b/src/Table.php
@@ -510,6 +510,10 @@ class Table extends Lister
             }
 
             $this->renderRow();
+            
+            if ($this->hook('afterRow') === false) {
+                continue;
+            }
 
             $this->_rendered_rows_count++;
         }


### PR DESCRIPTION
Implementation of `afterRow` hook

Required in cases where a few more lines are required to be inserted based on the current line after the current row
