### PR TITLE
features/MultiLine Form Field

### DIFF
--- a/demos/multiline.php
+++ b/demos/multiline.php
@@ -61,7 +61,8 @@ $ml->onChange(function ($rows) use ($f_total) {
     return $f_total->jsInput()->val($total);
 }, ['qty', 'box']);
 
-$f->onSubmit(function ($f) use($ml) {
+$f->onSubmit(function ($f) use ($ml) {
     $rows = $ml->saveRows()->getModel()->export();
+
     return new \atk4\ui\jsToast(json_encode(array_values($rows)));
 });

--- a/demos/multiline.php
+++ b/demos/multiline.php
@@ -61,6 +61,7 @@ $ml->onChange(function ($rows) use ($f_total) {
     return $f_total->jsInput()->val($total);
 }, ['qty', 'box']);
 
-$f->onSubmit(function ($f) {
-    return new \atk4\ui\jsToast('All good!');
+$f->onSubmit(function ($f) use($ml) {
+    $rows = $ml->saveRows()->getModel()->export();
+    return new \atk4\ui\jsToast(json_encode(array_values($rows)));
 });

--- a/demos/multiline.php
+++ b/demos/multiline.php
@@ -50,7 +50,7 @@ $c = $sub_layout->addColumn(4);
 $f_total = $c->addField('total', ['readonly' => true])->set($total);
 
 // Update total when qty and box value in any row has changed.
-$ml->onChange(function ($rows) use ($f_total) {
+$ml->onChange(function ($rows, $form) use ($f_total) {
     $total = 0;
     foreach ($rows as $row => $cols) {
         $qty = array_column($cols, 'qty')[0];

--- a/demos/multiline.php
+++ b/demos/multiline.php
@@ -40,7 +40,7 @@ for ($i = 1; $i < 3; $i++) {
 $f = $app->add('Form');
 
 // Add multiline field and set model.
-$ml = $f->addField('ml', ['MultiLine']);
+$ml = $f->addField('ml', ['MultiLine', 'options' => [ 'color' => 'blue']]);
 $ml->setModel($inventory);
 
 // Add total field.

--- a/demos/multiline.php
+++ b/demos/multiline.php
@@ -50,7 +50,7 @@ $c = $sub_layout->addColumn(4);
 $f_total = $c->addField('total', ['readonly' => true])->set($total);
 
 // Update total when qty and box value in any row has changed.
-$ml->onChange(function ($rows, $form) use ($f_total) {
+$ml->onLineChange(function ($rows, $form) use ($f_total) {
     $total = 0;
     foreach ($rows as $row => $cols) {
         $qty = array_column($cols, 'qty')[0];

--- a/demos/multiline.php
+++ b/demos/multiline.php
@@ -1,0 +1,66 @@
+<?php
+
+require 'init.php';
+
+/**
+ * Class Inventory Item
+ */
+class InventoryItem extends \atk4\data\Model
+{
+    public function init()
+    {
+        parent::init();
+
+        $this->addField('item', ['required' => true, 'default' => 'item']);
+        $this->addField('qty', ['type' => 'number', 'caption' => 'Qty / Box', 'required' => true]);
+        $this->addField('box', ['type' => 'number', 'caption' => '# of Boxes', 'required' => true]);
+        $this->addExpression('total', [ 'expr' => function($row){
+            return $row['qty'] * $row['box'];
+        }, 'type' => 'number']);
+    }
+}
+
+$app->add(['Header', 'MultiLine form field','icon' => 'database', 'subHeader' => 'Collect/Edit multiple rows of table record.']);
+
+$data = [];
+
+$inventory = new InventoryItem(new \atk4\data\Persistence_Array($data));
+
+$total = 0;
+for($i = 1; $i < 3; $i++){
+    $inventory['id']   = $i;
+    $inventory['item'] = 'item_' . $i;
+    $inventory['qty']  = rand(10, 100);
+    $inventory['box']  = rand(1, 10);
+    $total             = $total + ($inventory['qty'] * $inventory['box']);
+    $inventory->save();
+    $inventory->unload();
+}
+
+$f = $app->add('Form');
+
+// Add multiline field and set model.
+$ml = $f->addField('ml', ['MultiLine']);
+$ml->setModel($inventory);
+
+// Add total field.
+$sub_layout = $f->layout->addSublayout('Columns');
+$sub_layout->addColumn(12);
+$c = $sub_layout->addColumn(4);
+$f_total = $c->addField('total', ['readonly' => true])->set($total);
+
+// Update total when qty and box value in any row has changed.
+$ml->onChange(function($rows) use ($f_total) {
+    $total = 0;
+    foreach ($rows as $row => $cols) {
+        $qty = array_column($cols, 'qty')[0];
+        $box = array_column($cols, 'box')[0];
+        $total = $total + ($qty * $box);
+    }
+    return $f_total->jsInput()->val($total);
+
+}, ['qty', 'box']);
+
+$f->onSubmit(function($f){
+   return new \atk4\ui\jsToast('All good!');
+});

--- a/demos/multiline.php
+++ b/demos/multiline.php
@@ -28,9 +28,9 @@ $inventory = new InventoryItem(new \atk4\data\Persistence_Array($data));
 
 // Populate some data.
 $total = 0;
-for($i = 1; $i < 3; $i++){
+for ($i = 1; $i < 3; $i++) {
     $inventory['id'] = $i;
-    $inventory['item'] = 'item_' . $i;
+    $inventory['item'] = 'item_'.$i;
     $inventory['qty'] = rand(10, 100);
     $inventory['box'] = rand(1, 10);
     $total = $total + ($inventory['qty'] * $inventory['box']);

--- a/demos/multiline.php
+++ b/demos/multiline.php
@@ -40,7 +40,7 @@ for ($i = 1; $i < 3; $i++) {
 $f = $app->add('Form');
 
 // Add multiline field and set model.
-$ml = $f->addField('ml', ['MultiLine', 'options' => [ 'color' => 'blue']]);
+$ml = $f->addField('ml', ['MultiLine', 'options' => ['color' => 'blue']]);
 $ml->setModel($inventory);
 
 // Add total field.

--- a/demos/multiline.php
+++ b/demos/multiline.php
@@ -12,8 +12,8 @@ class InventoryItem extends \atk4\data\Model
         parent::init();
 
         $this->addField('item', ['required' => true, 'default' => 'item']);
-        $this->addField('qty', ['type' => 'number', 'caption' => 'Qty / Box', 'required' => true]);
-        $this->addField('box', ['type' => 'number', 'caption' => '# of Boxes', 'required' => true]);
+        $this->addField('qty', ['type' => 'number', 'caption' => 'Qty / Box', 'required' => true, 'ui' => ['multiline' => ['width' => 2]]]);
+        $this->addField('box', ['type' => 'number', 'caption' => '# of Boxes', 'required' => true, 'ui' => ['multiline' => ['width' => 2]]]);
         $this->addExpression('total', ['expr' => function ($row) {
             return $row['qty'] * $row['box'];
         }, 'type' => 'number']);

--- a/demos/multiline.php
+++ b/demos/multiline.php
@@ -26,6 +26,7 @@ $data = [];
 
 $inventory = new InventoryItem(new \atk4\data\Persistence_Array($data));
 
+// Populate some data.
 $total = 0;
 for($i = 1; $i < 3; $i++){
     $inventory['id']   = $i;
@@ -33,8 +34,7 @@ for($i = 1; $i < 3; $i++){
     $inventory['qty']  = rand(10, 100);
     $inventory['box']  = rand(1, 10);
     $total             = $total + ($inventory['qty'] * $inventory['box']);
-    $inventory->save();
-    $inventory->unload();
+    $inventory->saveAndUnload();
 }
 
 $f = $app->add('Form');

--- a/js/Release.md
+++ b/js/Release.md
@@ -1,5 +1,9 @@
 ## Release note
 
+### version 1.6.5
+
+ - Add multiline component for MultiLine form field.
+
 ### version 1.6.4
 
  - Add directives to Vue component;

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atkjs-ui",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "Agile Toolkit Javascript library.",
   "main": "lib/atkjs-ui.js",
   "scripts": {

--- a/js/src/components/multiline.component.js
+++ b/js/src/components/multiline.component.js
@@ -4,7 +4,7 @@ import multilineHeader from './multiline/multiline-header.component';
 export default {
   name: 'atk-multiline',
   template: `<div >
-                <sui-table celled size="small" compact="very" fixed>
+                <sui-table v-bind="tableProp">
                   <atk-multiline-header :fields="fieldData" :state="getMainToggleState" :errors="errors"></atk-multiline-header>
                   <atk-multiline-body :fieldDefs="fieldData" :rowData="rowData" :rowIdField="idField" :deletables="getDeletables" :errors="errors"></atk-multiline-body>
                   <sui-table-footer>
@@ -32,7 +32,19 @@ export default {
       eventFields : this.data.eventFields,
       deletables: [],
       hasChangeCb: this.data.hasChangeCb,
-      errors: {}
+      errors: {},
+      tableProp: Object.assign({}, this.tableDefault, this.data.options),
+      tableDefault : {
+        basic: false,
+        celled: false,
+        size: null,
+        compact: null,
+        collapsing: false,
+        stackable: false,
+        inverted: false,
+        color: null,
+        columns: null
+      }
     }
   },
   components: {

--- a/js/src/components/multiline.component.js
+++ b/js/src/components/multiline.component.js
@@ -1,0 +1,337 @@
+import multilineBody from './multiline/multiline-body.component';
+import multilineHeader from './multiline/multiline-header.component';
+
+export default {
+  name: 'atk-multiline',
+  template: `<div >
+                <sui-table celled size="small" compact="very" fixed>
+                  <atk-multiline-header :fields="fieldData" :state="getMainToggleState" :errors="errors"></atk-multiline-header>
+                  <atk-multiline-body :fieldDefs="fieldData" :rowData="rowData" :rowIdField="idField" :deletables="getDeletables" :errors="errors"></atk-multiline-body>
+                  <sui-table-footer>
+                    <sui-table-row>
+                        <sui-table-header-cell/>
+                        <sui-table-header-cell :colspan="getSpan" textAlign="right">
+                        <div is="sui-button-group">
+                         <sui-button size="small" @click.stop.prevent="onAdd" icon="plus" ref="addBtn"></sui-button>
+                         <sui-button size="small" @click.stop.prevent="onDelete" icon="trash" :disabled="isDeleteDisable"></sui-button>                        
+                         </div>
+                        </sui-table-header-cell>
+                    </sui-table-row>
+                  </sui-table-footer>
+                </sui-table>
+             </div>`,
+  props: {
+    data: Object
+  },
+  data() {
+    return {
+      linesField: this.data.linesField, //form field where to set multiline content value.
+      rows: [],
+      fieldData: this.data.fields,
+      idField: this.data.idField,
+      eventFields : this.data.eventFields,
+      deletables: [],
+      hasChangeCb: this.data.hasChangeCb,
+      errors: {}
+    }
+  },
+  components: {
+    'atk-multiline-body': multilineBody,
+    'atk-multiline-header' : multilineHeader
+  },
+  created: function() {
+    this.rowData = this.getInitData();
+    this.$nextTick(() => {
+      this.updateLinesField();
+    });
+
+    this.$root.$on('update-row', (rowId, field, value) => {
+      this.updateRow(rowId, field, value);
+    });
+
+    this.$root.$on('post-row', (rowId, field) => {
+      this.postRow(rowId, field);
+    });
+
+    this.$root.$on('toggle-delete', (id) => {
+      const idx = this.deletables.indexOf(id);
+      if (idx > -1) {
+        this.deletables.splice(idx, 1);
+      } else {
+        this.deletables.push(id);
+      }
+    });
+
+    this.$root.$on('toggle-delete-all', (isOn) => {
+      this.deletables = [];
+      if(isOn) {
+        this.rowData.forEach( row => {
+          this.deletables.push(this.getId(row));
+        });
+      }
+    });
+
+    atk.vueService.eventBus.$on('atkml-row-error', (data) => {
+      if (this.$root.$el.id === data.id) {
+        this.errors = {...data.errors};
+
+      }
+    });
+  },
+  methods: {
+    /**
+     * UUID v4 generator.
+     *
+     * @returns {string}
+     */
+    getUUID: function() {
+      return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+        let r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
+        return v.toString(16);
+      });
+    },
+    onAdd: function(){
+      this.rowData.push(this.newDataRow());
+      this.updateLinesField();
+    },
+    onDelete: function() {
+      this.deletables.forEach( id => {
+        this.deleteRow(id);
+      });
+      this.deletables = [];
+    },
+    deleteRow: function(id){
+      //find proper row index using id.
+      const idx = this.findRowIndex(id);
+      if (idx > -1) {
+        this.rowData.splice(idx,1);
+        delete this.errors[id];
+      }
+      this.updateLinesField();
+      // fire change callback if set and field is part of it.
+      if (this.hasChangeCb) {
+        this.postRaw();
+      }
+    },
+    findRowIndex: function(id){
+      for(let i=0; i < this.rowData.length; i++) {
+        if(this.getId(this.rowData[i]) === id) {
+          return i;
+        }
+      }
+      return -1;
+    },
+    /**
+     * Send a single row to server
+     * usually to get data expression from server.
+     *
+     * @param rowId
+     * @returns {Promise<void>}
+     */
+    postRow: async function(rowId, field) {
+      // find proper row index using id.
+      let idx = -1;
+      for(let i = 0; i < this.rowData.length; i++) {
+        this.rowData[i].forEach( cell => {
+          if (cell['__atkml'] === rowId) {
+            idx = i;
+            return;
+          }
+        })
+      }
+      // server will return expression field  - value if define.
+      let resp = await this.postData([...this.rowData[idx]]);
+      if (resp.expressions) {
+        let fields = Object.keys(resp.expressions);
+        fields.forEach(field => {
+          this.updateFieldInRow(idx, field, resp.expressions[field]);
+        });
+      }
+      // fire change callback if set and field is part of it.
+      if (this.hasChangeCb && (this.eventFields.indexOf(field) > -1 ) ) {
+        this.postRaw();
+      }
+    },
+    /**
+     * Update row with proper data value.
+     *
+     * @param id
+     * @param field
+     * @param value
+     */
+    updateRow: function(rowId, field, value) {
+      // find proper row index using id.
+      let idx = -1;
+      for(let i = 0; i < this.rowData.length; i++) {
+        this.rowData[i].forEach( cell => {
+          if (cell['__atkml'] === rowId) {
+            idx = i;
+            return;
+          }
+        })
+      }
+      this.updateFieldInRow(idx, field, value);
+      this.clearError(rowId, field);
+      this.updateLinesField();
+    },
+    clearError: function(rowId, field) {
+      if (rowId in this.errors) {
+        let errors = this.errors[rowId].filter( error => error.field != field);
+        this.errors[rowId] = [...errors];
+        if (errors.length === 0) {
+          delete this.errors[rowId];
+        }
+      }
+    },
+    /**
+     * Update the value of the field in rowData.
+     *
+     * @param idx
+     * @param field
+     * @param value
+     */
+    updateFieldInRow(idx, field, value) {
+      this.rowData[idx].forEach(cell => {
+        if (field in cell) {
+          cell[field] = value;
+        }
+      });
+    },
+    /**
+     * Update Multi-line Form input with all rowData values
+     * as json string.
+     */
+    updateLinesField: function() {
+      const field = document.getElementsByName(this.linesField)[0];
+      field.value = JSON.stringify(this.rowData);
+    },
+    /**
+     * Get initial rowData value.
+     *
+     * @returns {Array}
+     */
+    getInitData: function() {
+      let rows = [], value = '';
+      // check if input containing data is set and initialized.
+      let field = document.getElementsByName(this.linesField)[0];
+      if (field) {
+        //Map value to our rowData.
+        rows = JSON.parse(field.value).map(fields => {
+          let data = Object.keys(fields).map(field => {
+            return {[field]:fields[field]};
+          });
+          data.push({__atkml:this.getUUID()});
+          return data;
+        });
+      }
+      return rows;
+    },
+    /**
+     * Add a new row of data and
+     * set values to default if available.
+     *
+     * @returns {Array}
+     */
+    newDataRow: function() {
+      let columns = [];
+      // add __atkml property in order to identify each row.
+      columns.push({__atkml : this.getUUID()});
+      this.data.fields.forEach(item => {
+        columns.push({[item.field] : item.default});
+      });
+
+      return columns;
+    },
+    /**
+     * Return the __atkml id of the row.
+     *
+     * @param row
+     * @returns {*}
+     */
+    getId: function(row) {
+      let id;
+      row.forEach(input => {
+        if ('__atkml' in input) {
+          id = input['__atkml'];
+        }
+      });
+      return id;
+    },
+    /**
+     * Post raw data.
+     *
+     * Use regular api call in order
+     * for return js to be fully evaluate.
+     */
+    postRaw: function() {
+      jQuery(this.$refs['addBtn'].$el).api({
+        on: 'now',
+        url: this.data.url,
+        method: 'post',
+        data: {action: 'on-change', rows: JSON.stringify(this.rowData)}
+      });
+    },
+    postData: async function(row) {
+      let data = {};
+      const context = this.$refs['addBtn'].$el;
+      //console.log(context);
+      let fields = this.fieldData.map( field => field.field);
+      fields.forEach( field => {
+        data[field] = row.filter(item => field in item)[0][field];
+      });
+      //console.log(data);
+      data.action = 'update-row';
+      try {
+        let response = await atk.apiService.suiFetch(this.data.url, {data: data, method: 'post', stateContext:context});
+        return response;
+      } catch (e) {
+        console.error(e);
+      }
+    },
+  },
+  computed: {
+    rowData: {
+      get: function(){
+        return this.rows;
+      },
+      set: function(rows) {
+        this.rows = [...rows];
+      }
+    },
+    getSpan: function(){
+      return this.fieldData.length - 1;
+    },
+    /**
+     * Get id's of row set for deletion.
+     * @returns {Array}
+     */
+    getDeletables: function() {
+      return this.deletables;
+    },
+    /**
+     * Return Delete all checkbox state base on
+     * deletables entries.
+     *
+     * @returns {string}
+     */
+    getMainToggleState() {
+      let state = 'off';
+      if (this.deletables.length > 0) {
+        if (this.deletables.length === this.rowData.length) {
+          state = 'on';
+        } else {
+          state = 'indeterminate';
+        }
+      }
+      return state;
+    },
+    /**
+     * Set delete button disabled property.
+     *
+     * @returns {boolean}
+     */
+    isDeleteDisable() {
+      return !this.deletables.length > 0;
+    }
+  }
+}

--- a/js/src/components/multiline.component.js
+++ b/js/src/components/multiline.component.js
@@ -280,7 +280,7 @@ export default {
         on: 'now',
         url: this.data.url,
         method: 'post',
-        data: {action: 'on-change', rows: JSON.stringify(this.rowData)}
+        data: {__atkml_action: 'on-change', rows: JSON.stringify(this.rowData)}
       });
     },
     postData: async function(row) {
@@ -292,7 +292,7 @@ export default {
         data[field] = row.filter(item => field in item)[0][field];
       });
       //console.log(data);
-      data.action = 'update-row';
+      data.__atkml_action = 'update-row';
       try {
         let response = await atk.apiService.suiFetch(this.data.url, {data: data, method: 'post', stateContext:context});
         return response;

--- a/js/src/components/multiline/multiline-body.component.js
+++ b/js/src/components/multiline/multiline-body.component.js
@@ -1,0 +1,49 @@
+import multilineRow from "./multiline-row.component";
+
+export default {
+  name: "atk-multiline-body",
+  template: `
+    <sui-table-body>
+      <atk-multiline-row v-for="(row , idx) in rows" :key="getId(row)" 
+      :fields="fields" 
+      :rowId="getId(row)" 
+      :isDeletable="isDeletableRow(row)" 
+      :values="row"
+      :error="getError(getId(row))"></atk-multiline-row>
+    </sui-table-body>
+  `,
+  props: ['fieldDefs', 'rowData', 'rowIdField', 'deletables', 'errors'],
+  data: function() {
+    return {fields: this.fieldDefs}
+  },
+  created: function() {
+  },
+  components: {
+    'atk-multiline-row' : multilineRow,
+  },
+  computed: {
+    rows() {
+      return this.rowData;
+    },
+  },
+  methods: {
+    isDeletableRow(row) {
+      return this.deletables.indexOf(this.getId(row)) > -1;
+    },
+    getId: function(row) {
+      let id;
+      row.forEach(input => {
+        if ('__atkml' in input) {
+          id = input['__atkml'];
+        }
+      });
+      return id;
+    },
+    getError: function(rowId){
+      if (rowId in this.errors) {
+        return this.errors[rowId];
+      }
+      return null;
+    }
+  }
+}

--- a/js/src/components/multiline/multiline-cell.component.js
+++ b/js/src/components/multiline/multiline-cell.component.js
@@ -1,0 +1,75 @@
+
+export default {
+  name: 'atk-multiline-cell',
+  template: ` 
+    <component :is="fieldType"
+        :type="inputType"
+        :fluid="true" 
+        class="fluid" 
+        @blur="onBlur"
+        @input="onInput"
+        v-model="inputValue"
+        :name="fieldName"
+        ref="cell"><slot></slot></component>
+  `,
+  props: ['cellData', 'fieldType', 'fieldValue'],
+  data() {
+    return {
+      field: this.cellData.field,
+      type: this.cellData.type,
+      //this field name will not get serialized and sent on form submit.
+      fieldName: '-'+this.cellData.field,
+      inputValue: this.fieldValue,
+      dirtyValue: this.fieldValue,
+    }
+  },
+  computed: {
+    inputType() {
+      let type = this.cellData.type;
+      switch (type) {
+        case 'string':
+          type = 'text';
+          break;
+        case 'integer':
+        case 'money':
+          type = 'number';
+          break;
+      }
+
+      return type;
+    },
+    isDirty() {
+      return this.dirtyValue != this.inputValue;
+    }
+  },
+  methods: {
+    onInput: function(value) {
+      this.inputValue = this.getTypeValue(value);
+      this.$emit('update-value', this.field, this.inputValue);
+    },
+    /**
+     * Tell parent row that input value has changed.
+     *
+     * @param e
+     */
+    onBlur: function(e) {
+      if (this.isDirty) {
+        this.$emit('post-value', this.field);
+        this.dirtyValue = this.inputValue;
+      }
+    },
+    /**
+     * return input value based on their type.
+     *
+     * @param value
+     * @returns {*}
+     */
+    getTypeValue(value) {
+      let r = value;
+      if (this.type === 'boolean') {
+        r = value.target.checked;
+      }
+      return r;
+    }
+  }
+}

--- a/js/src/components/multiline/multiline-header.component.js
+++ b/js/src/components/multiline/multiline-header.component.js
@@ -1,0 +1,67 @@
+
+export default {
+  name: 'atk-multiline-header',
+  template: `
+     <sui-table-header>
+       <sui-table-row v-if="hasError()">
+        <sui-table-cell :style="{background:'none'}"></sui-table-cell>
+        <sui-table-cell :style="{background:'none'}" state="error" v-for="(column, idx) in columns" :key="idx" v-if="column.isVisible" :textAlign="getTextAlign(column)"><sui-icon name="attention" v-if="getErrorMsg(column)"></sui-icon>{{getErrorMsg(column)}}</sui-table-cell>
+      </sui-table-row>
+        <sui-table-row :verticalAlign="'top'">
+        <sui-table-header-cell width="one" textAlign="center"><input type="checkbox" @input="onToggleDeleteAll" :checked.prop="isChecked" :indeterminate.prop="isIndeterminate" ref="check"></input></sui-table-header-cell>
+        <sui-table-header-cell v-for="(column, idx) in columns" :key="idx" v-if="column.isVisible" :textAlign="getTextAlign(column)">
+         <div>{{column.caption}}</div>
+         <div :style="{position: 'absolute', top: '-22px'}" v-if="false"><sui-label pointing="below" basic color="red" v-if="getErrorMsg(column)">{{getErrorMsg(column)}}</sui-label></div>
+        </sui-table-header-cell>
+      </sui-table-row>
+    </sui-table-header>
+  `,
+  props: ['fields', 'state', 'errors'],
+  data() {
+    return {columns: this.fields, isDeleteAll: false}
+  },
+  methods: {
+    onToggleDeleteAll: function() {
+      this.$nextTick(() => {
+        this.$root.$emit('toggle-delete-all', this.$refs['check'].checked);
+      });
+    },
+    getTextAlign(column) {
+      let align = 'left';
+      if (!column.isEditable) {
+        switch(column.type) {
+          case 'money':
+          case 'integer':
+          case 'number':
+            align = 'right';
+            break;
+        }
+      }
+
+      return align;
+    },
+    hasError() {
+      return Object.keys(this.errors).length > 0;
+    },
+    getErrorMsg: function(column) {
+      if (this.hasError()) {
+        let rows = Object.keys(this.errors);
+        for( let i = 0; i < rows.length; i++) {
+          let error = this.errors[rows[i]].filter(col => col.field === column.field);
+          if (error.length > 0) {
+            return error[0].msg;
+          }
+        }
+      }
+      return null;
+    }
+  },
+  computed: {
+    isIndeterminate() {
+      return this.state === 'indeterminate';
+    },
+    isChecked() {
+      return this.state === 'on';
+    }
+  }
+}

--- a/js/src/components/multiline/multiline-row.component.js
+++ b/js/src/components/multiline/multiline-row.component.js
@@ -1,0 +1,126 @@
+import multilineCell from './multiline-cell.component'
+
+/**
+ * A row component.
+ * This will create a table td element using sui-table-cell.
+ * The td element is created only if column as set isVisible = true;
+ * The td element will add a multiline cell element.
+ *  the multiline cell will set it's own template component depending on the fieldType.
+ *  getValue
+ *
+ */
+export default {
+  name: 'atk-multiline-row',
+  template: `
+    <sui-table-row :verticalAlign="'middle'">
+        <sui-table-cell width="one" textAlign="center"><input type="checkbox" @input="onToggleDelete" v-model="toDelete"></input></sui-table-cell>
+        <sui-table-cell :state="getErrorState(column)" v-for="(column, idx) in columns" :key="idx" :style="{overflow: 'visible'}" v-if="column.isVisible" :textAlign="getTextAlign(column)">
+         <atk-multiline-cell 
+           :fieldType="getFieldType(column)" 
+           :cellData="column" 
+           @update-value="onUpdateValue" 
+           @post-value="onPostRow"
+           :fieldValue="getValue(column)">{{getReadOnlyValue(column)}}</atk-multiline-cell>
+        </sui-table-cell>
+    </sui-table-row>
+  `,
+  props : ['fields', 'rowId', 'isDeletable', 'values', 'error'],
+  data() {
+    return { columns: this.fields}
+  },
+  components: {
+    'atk-multiline-cell': multilineCell
+  },
+  inject: ['getRootData'],
+  computed: {
+    /**
+     * toDelete is bind by v-model, thus we need a setter for
+     * computed property to work.
+     * When isDeletable is pass, will set checkbox according to it's value.
+     */
+    toDelete: {
+      get: function() {
+        return this.isDeletable;
+      },
+      set: function(v) {
+        return v;
+      }
+    }
+  },
+  methods: {
+    getErrorState: function(column){
+      //console.log(column);
+      if (this.error) {
+        let error = this.error.filter(e => column.field === e.field);
+        if (error.length > 0) {
+          return 'error';
+        }
+      }
+      return null;
+    },
+    onEdit: function () {
+      this.isEditing = true;
+    },
+    onToggleDelete(e) {
+      this.$root.$emit('toggle-delete', this.rowId);
+    },
+    onUpdateValue: function (field, value) {
+      this.$root.$emit('update-row', this.rowId, field, value);
+    },
+    onPostRow: function(field) {
+      this.$root.$emit('post-row', this.rowId, field);
+    },
+    getReadOnlyValue(column) {
+      if (!column.isEditable) {
+        return this.getValue(column);
+      }
+      return null;
+    },
+    getValue: function(column) {
+      let temp = column.default;
+      this.values.forEach(field => {
+        if (column.field in field) {
+            temp = field[column.field];
+        }
+      });
+      return temp;
+    },
+    /**
+     * Setup component according to field type.
+     * For now support input - checkbox.
+     *
+     * @param column
+     * @returns {string}
+     */
+    getFieldType: function (column) {
+      let type = 'sui-input';
+      if (!column.isEditable){
+        type = 'div';
+      }
+      if (column.type === 'boolean') {
+        type = 'sui-checkbox'
+      }
+      return type;
+    },
+    /**
+     * return text alignement for cell depending on field type.
+     *
+     * @param column
+     * @returns {string}
+     */
+    getTextAlign(column) {
+      let align;
+      switch(column.type) {
+        case 'money':
+        case 'integer':
+        case 'number':
+          align = 'right';
+          break;
+        default:
+          align = 'left';
+          break;
+      }
+      return align;
+    }
+  }
+}

--- a/js/src/components/multiline/multiline-row.component.js
+++ b/js/src/components/multiline/multiline-row.component.js
@@ -14,7 +14,7 @@ export default {
   template: `
     <sui-table-row :verticalAlign="'middle'">
         <sui-table-cell width="one" textAlign="center"><input type="checkbox" @input="onToggleDelete" v-model="toDelete"></input></sui-table-cell>
-        <sui-table-cell  v-for="(column, idx) in columns" :key="idx" :state="getErrorState(column)" :style="{overflow: 'visible'}" v-if="column.isVisible" :textAlign="getTextAlign(column)">
+        <sui-table-cell  v-for="(column, idx) in columns" :key="idx" :state="getErrorState(column)" :width="column.width" :style="{overflow: 'visible'}" v-if="column.isVisible" :textAlign="getTextAlign(column)">
          <atk-multiline-cell 
            :fieldType="getFieldType(column)" 
            :cellData="column" 
@@ -26,7 +26,7 @@ export default {
   `,
   props : ['fields', 'rowId', 'isDeletable', 'values', 'error'],
   data() {
-    return { columns: this.fields}
+    return {columns: this.fields}
   },
   components: {
     'atk-multiline-cell': multilineCell

--- a/js/src/components/multiline/multiline-row.component.js
+++ b/js/src/components/multiline/multiline-row.component.js
@@ -14,7 +14,7 @@ export default {
   template: `
     <sui-table-row :verticalAlign="'middle'">
         <sui-table-cell width="one" textAlign="center"><input type="checkbox" @input="onToggleDelete" v-model="toDelete"></input></sui-table-cell>
-        <sui-table-cell :state="getErrorState(column)" v-for="(column, idx) in columns" :key="idx" :style="{overflow: 'visible'}" v-if="column.isVisible" :textAlign="getTextAlign(column)">
+        <sui-table-cell  v-for="(column, idx) in columns" :key="idx" :state="getErrorState(column)" :style="{overflow: 'visible'}" v-if="column.isVisible" :textAlign="getTextAlign(column)">
          <atk-multiline-cell 
            :fieldType="getFieldType(column)" 
            :cellData="column" 

--- a/js/src/services/vue.service.js
+++ b/js/src/services/vue.service.js
@@ -1,13 +1,14 @@
 import Vue from 'vue';
 import atkInlineEdit from '../components/inline-edit.component';
 import itemSearch from '../components/item-search.component';
+import multiLine from '../components/multiline.component'
 import atkClickOutside from '../directives/click-outside.directive';
 import {focus} from '../directives/commons.directive';
-
 
 let atkComponents = {
   'atk-inline-edit' : atkInlineEdit,
   'atk-item-search' : itemSearch,
+  'atk-multiline'   : multiLine,
 };
 
 

--- a/src/FormField/MultiLine.php
+++ b/src/FormField/MultiLine.php
@@ -575,7 +575,7 @@ class MultiLine extends Generic
                                       'url'         => $this->cb->getJSURL(),
                                       'eventFields' => $this->eventFields,
                                       'hasChangeCb' => $this->changeCb ? true : false,
-                                      'options'     => $this->options
+                                      'options'     => $this->options,
                                   ],
                               ]);
     }

--- a/src/FormField/MultiLine.php
+++ b/src/FormField/MultiLine.php
@@ -462,7 +462,7 @@ class MultiLine extends Generic
      *
      * @return Model
      */
-    public function setModel($model, $fields = [], $modelRef = null, $linkField = null)
+    public function setModel(\atk4\data\Model $model, $fields = [], $modelRef = null, $linkField = null)
     {
         //remove our self from model
         if ($model->hasElement($this->short_name)) {

--- a/src/FormField/MultiLine.php
+++ b/src/FormField/MultiLine.php
@@ -1,0 +1,755 @@
+<?php
+/**
+ * Create a multiple line input field.
+ * Allow to add/edit multiple row of a data table.
+ * If model define in Multiline contains expression, these expression
+ * will be evaluate on the fly while entering data.
+ * ex: Invoice Items model
+ *     $model->addExpression('total', ['expr'=>'[qty]*[price]', 'type' => 'money', 'caption' => 'Total']);
+ * If using total field in row of record, then the expression will be evaluated when user enter data in each
+ * row.
+ *
+ * Each rows will be added to db using Multiline::saveRows() method,
+ * usually on form submit. If you have setup a form model where multiline's
+ * model is a reference to your form model, form model should be saved prior to call saveRows() method.
+ *
+ *  $f = $app->add('Form');
+ *  $f->setModel($invoice, false);
+ *  //setup fiel in layout..
+ *
+ *  //add multiline field and set model for it.
+ *  $ml = $f->addField('ml', ['Multiline']);
+ *
+ *  //setting model using hasMany reference of Invoice.
+ *  $ml->setModel($invoice, ['item','cat','qty','price', 'total'], 'Items', 'invoice_id');
+ *
+ *  $f->onSubmit(function($f) use ($ml) {
+ *      $f->model->save();
+ *      $ml->saveRows();
+ *      return new \atk4\ui\jsToast('Saved!');
+ *  });
+ *
+ *  Multiline input also has an onChange callback that will return all rows data in an array.
+ *  It is also possible to fire onChange handler only for certain fields by passing
+ *  them as an array to the method.
+ *  Note that deleting a row will always fire the onChange callback.
+ *
+ *  Use this return data to update other related area of the form.
+ *  Ex: Updating Grand Total field of all invoice item.
+ *
+ *  $ml->onChange(function($rows) use ($f) {
+ *      $grand_total = 0;
+ *      foreach ($rows as $row => $cols) {
+ *          foreach ($cols as $col) {
+ *              $fieldName = key($col);
+ *                  if ($fieldName === 'total') {
+ *                      $grand_total = $grand_total + $col[$fieldName];
+ *                  }
+ *           }
+ *      }
+ *    return $f->js(true, null, 'input[name="grand_total"]')->val(number_format($grand_total, 2));
+ *  }, ['qty', 'price']);
+ *
+ * Finally, it is also possible to use Multiline for quickly adding record to a model.
+ * Be aware that all record in User model will be used. So if your model contains a lot
+ * of record, you should control it's limit somehow.
+ *
+ * $f = $app->add('Form');
+ * $ml = $f->addField('ml', ['MultiLine']);
+ * $ml->setModel($user, ['name','is_vip']);
+ *
+ * $f->onSubmit(function($f) use ($ml) {
+ *     $ml->saveRows();
+ *     return new \atk4\ui\jsToast('Saved!');
+ * });
+ *
+ */
+
+namespace atk4\ui\FormField;
+
+use atk4\data\Field\Callback;
+use atk4\data\Field_SQL_Expression;
+use atk4\data\Model;
+use atk4\data\ValidationException;
+use atk4\ui\Exception;
+use atk4\ui\jsVueService;
+use atk4\ui\Template;
+
+class MultiLine extends Generic
+{
+    /**
+     * Layout view as is within form layout.
+     * @var bool
+     */
+    public $layoutWrap = false;
+
+    /**
+     * The template need for the multiline view.
+     * @var null
+     */
+    public $multiLineTemplate = null;
+
+    /**
+     * The multiline View.
+     * Assign on init.
+     *
+     * @var null
+     */
+    private $multiLine = null;
+
+    /**
+     * The definition of each fields used in each multiline row.
+     *
+     * @var null
+     */
+    private $fieldDefs = null;
+
+    /**
+     * The js callback.
+     *
+     * @var null
+     */
+    private $cb = null;
+
+    /**
+     * The callback function trigger when field
+     * are changed or row are delete.
+     *
+     * @var null
+     */
+    public $changeCb = null;
+
+    /**
+     * An array of fields name that will trigger
+     * the change callback when field are changed.
+     *
+     * @var null
+     */
+    public $eventFields = null;
+
+    /**
+     * Collection of field errors.
+     *
+     * @var null
+     */
+    private $rowErrors = null;
+
+    /**
+     * The model reference use for multi line input.
+     *
+     * @var null
+     */
+    public $modelRef = null;
+
+    /**
+     * The link field used for reference.
+     *
+     * @var null
+     */
+    public $linkField = null;
+
+    /**
+     * The fields use in each line.
+     *
+     * @var null
+     */
+    public $rowFields = null;
+
+    /**
+     * The data sent for each line.
+     *
+     * @var null
+     */
+    public $rowData = null;
+
+    public function init()
+    {
+        parent::init();
+
+        $this->app->useSuiVue();
+
+        $this->app->requireJS('../public/atk-invoice.js');
+
+        if (!$this->multiLineTemplate) {
+            $this->multiLineTemplate = new Template('<div id="{$_id}" class="ui"><atk-multiline v-bind="initData"></atk-multiline>{$Input}</div>');
+        }
+
+        $this->multiLine = $this->add(['View', 'template' => $this->multiLineTemplate]);
+
+        $this->cb = $this->add('jsCallback');
+
+        //load data associate with this input and validate it.
+        $this->form->addHook('loadPOST', function($form){
+            $this->rowData = json_decode($_POST[$this->short_name], true);
+            if ($this->rowData) {
+                $this->rowErrors = $this->validate($this->rowData);
+                if ($this->rowErrors) {
+                    throw new ValidationException([$this->short_name => 'multine error']);
+                }
+            }
+        });
+
+        // Change form error handling.
+        $this->form->addHook('displayError', function($form, $fieldName, $str) {
+            // When error are coming from this multiline field then advice multiline component about these errors.
+            // otherwise use normal field error.
+            if ($fieldName === $this->short_name) {
+                $jsError = [(new jsVueService())->emitEvent('atkml-row-error', ['id' => $this->multiLine->name, 'errors' => $this->rowErrors])];
+            } else {
+                $jsError = [$form->js()->form('add prompt', $fieldName, $str)];
+            }
+
+            return $jsError;
+        });
+    }
+
+    /**
+     * Add a callback when fields are changed.
+     * It is possible to supply fields that will trigger the
+     * callback when changed. If no fields are supply then callback will trigger
+     * for all fields changed.
+     *
+     * @param array|\atk4\ui\FormField\jsExpression|callable|string $fx
+     * @param null $fields
+     *
+     * @throws Exception
+     */
+    public function onChange($fx, $fields = null)
+    {
+        if (!is_callable($fx)) {
+            throw new Exception('Function is required for onChange event.');
+        }
+        if ($fields) {
+            $this->eventFields = $fields;
+        }
+
+        $this->changeCb = $fx;
+    }
+
+    /**
+     * Input field collecting multiple rows of data.
+     *
+     * @return string
+     * @throws \atk4\core\Exception
+     */
+    public function getInput()
+    {
+        return $this->app->getTag('input', [
+            'name'        => $this->short_name,
+            'type'        => 'hidden',
+            'value'       => $this->getValue(),
+            'readonly'    => true,
+        ]);
+    }
+
+    /**
+     * Get multiline initial field value.
+     * Value is based on model set and will
+     * output data rows as json string value.
+     *
+     *
+     * @return false|string
+     * @throws \atk4\core\Exception
+     */
+    public function getValue()
+    {
+        $m = null;
+        $data = [];
+
+        //set model according to model reference if set; or simply the model pass to it.
+        if ($this->model->loaded() && $this->modelRef) {
+            $m = $this->model->ref($this->modelRef);
+        } else if (!$this->modelRef) {
+            $m = $this->model;
+        }
+        if ($m) {
+            foreach ($m as $id => $row) {
+                $d_row = [];
+                foreach ($this->rowFields as $fieldName) {
+                    $field = $m->getElement($fieldName);
+                    if ($field->isEditable()) {
+                        $value = $row->get($field);
+                    } else {
+                        $value = $this->app->ui_persistence->_typecastSaveField($field, $row->get($field));
+                    }
+                    $d_row[$fieldName] = $value;
+                }
+                $data[] = $d_row;
+            }
+        }
+
+        return json_encode($data, JSON_UNESCAPED_UNICODE);
+    }
+
+    /**
+     * Validate each row and return errors if found.
+     *
+     * @param $rows
+     *
+     * @return array|null
+     * @throws \atk4\core\Exception
+     */
+    public function validate($rows)
+    {
+        $rowErrors = [];
+        $m = $this->getModel();
+
+        foreach ($rows as $row => $cols) {
+            $rowId = $this->getMlRowId($cols);
+            foreach ($cols as $col) {
+                $fieldName = key($col);
+                if ($fieldName === '__atkml' ||  $fieldName === $m->id_field ) {
+                    continue;
+                }
+                $value = $col[$fieldName];
+                try {
+                    $field = $m->getElement($fieldName);
+                    // save field value only if field was editable in form at all
+                    if (!$field->read_only) {
+                        $m[$fieldName] = $this->app->ui_persistence->typecastLoadField($field, $value);
+                    }
+
+                } catch (\atk4\core\Exception $e) {
+                    $rowErrors[$rowId][] = ['field' => $fieldName, 'msg' => $e->getMessage()];
+                }
+            }
+            $rowErrors = $this->addModelValidateErrors($rowErrors, $rowId, $m);
+        }
+
+        if ($rowErrors) {
+            return $rowErrors;
+        }
+
+        return null;
+    }
+
+    /**
+     * Save rows.
+     *
+     * @throws Exception
+     * @throws \atk4\core\Exception
+     * @throws \atk4\data\Exception
+     */
+    public function saveRows()
+    {
+        // if we are using a reference, make sure main model is loaded.
+        if ($this->modelRef && !$this->model->loaded()) {
+            throw new Exception('Parent model need to be loaded');
+        }
+
+        $model = $this->model;
+        if ($this->modelRef) {
+            $model = $model->ref($this->modelRef);
+        }
+
+        $currentIds = [];
+        foreach ($this->getModel() as $id => $data) {
+            $currentIds[] = $id;
+        }
+
+        foreach ($this->rowData as $row => $cols) {
+            $rowId = $this->getMlRowId($cols);
+            if($this->modelRef && $this->linkField) {
+                $model[$this->linkField] = $this->model->get('id');
+            }
+            foreach ($cols as $col) {
+                $fieldName = key($col);
+                if ($fieldName === '__atkml') {
+                    continue;
+                }
+                $value = $col[$fieldName];
+                if ($fieldName === $model->id_field && $value) {
+                    $model->load($value);
+                }
+
+                $field = $model->getElement($fieldName);
+
+                if (!$field instanceof Field_SQL_Expression) {
+                    $field->set($value);
+                }
+            }
+            $id = $model->save()->get($model->id_field);//->unload();
+            $k = array_search($id, $currentIds);
+            if ( $k > -1) {
+                unset($currentIds[$k]);
+            }
+
+            $model->unload();
+        }
+        // if currentId are still there, then delete them.
+        forEach ($currentIds as $id) {
+            $model->delete($id);
+        }
+    }
+
+    /**
+     * Check for model validate error.
+     *
+     * @param $errors
+     * @param $rowId
+     * @param $model
+     *
+     * @return mixed
+     */
+    private function addModelValidateErrors($errors, $rowId, $model)
+    {
+        $e = $model->validate();
+        if ($e) {
+            foreach ($e as $f => $msg) {
+                $errors[$rowId][] = ['field' => $f, 'msg' => $msg];
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Return MultiLine row id in a row of data.
+     *
+     * @param $row
+     *
+     * @return |null
+     */
+    private function getMlRowId($row)
+    {
+        $rowId = null;
+        foreach ($row as $k => $col) {
+            foreach ($col as $fieldName => $value) {
+                if ($fieldName === '__atkml') {
+                    $rowId = $value;
+                }
+            }
+            if ($rowId) break;
+        }
+        return $rowId;
+    }
+
+    /**
+     * Will return a model reference if reference was set
+     * in setModel, Otherwise, will return main model.
+     *
+     * @return Model
+     * @throws \atk4\core\Exception
+     */
+    public function getModel()
+    {
+        $m = $this->model;
+        if ($this->modelRef) {
+            $m = $m->ref($this->modelRef);
+        }
+
+        return $m;
+    }
+
+    /**
+     * Set view model.
+     * If modelRef is used then getModel will return proper model.
+     *
+     *
+     * @param Model $m
+     * @param array $fields
+     * @param null $modelRef
+     * @param null $linkField
+     *
+     * @return Model
+     * @throws Exception
+     * @throws \atk4\core\Exception
+     */
+    public function setModel($model, $fields = [], $modelRef = null, $linkField = null)
+    {
+        //remove our self from model
+        if ($model->hasElement($this->short_name)){
+            $model->getElement($this->short_name)->never_persist = true;
+        }
+        $m = parent::setModel($model);
+
+        if ($modelRef) {
+            if (!$linkField) {
+                throw new Exception('Using model ref required to set $linkField');
+            }
+            $this->linkField = $linkField;
+            $this->modelRef = $modelRef;
+            $m = $m->ref($modelRef);
+        }
+
+        if (!$fields) {
+            $fields = $this->getModelFields($m);
+        }
+        $this->rowFields = array_merge([$m->id_field], $fields);
+
+        foreach ($this->rowFields as $fieldName) {
+            $field = $m->getElement($fieldName);
+
+            if (!$field instanceof \atk4\data\Field) {
+                continue;
+            }
+            $type = $field->type ?  $field->type : 'string';
+
+            if (isset($field->ui['form'])) {
+                $type = $field->ui['form'][0];
+            }
+
+            $this->fieldDefs[] = [
+                'field'       => $field->short_name,
+                'type'        => $type,
+                'caption'     => $field->getCaption(),
+                'default'     => $field->default,
+                'isEditable'  => $field->isEditable(),
+                'isHidden'    => $field->isHidden(),
+                'isVisible'   => $field->isVisible(),
+            ];
+
+        }
+
+        return $m;
+    }
+
+    /**
+     * Returns array of names of fields to automatically include them in form.
+     * This includes all editable or visible fields of the model.
+     *
+     * @param \atk4\data\Model $model
+     *
+     * @return array
+     */
+    protected function getModelFields(\atk4\data\Model $model)
+    {
+        $fields = [];
+        foreach ($model->elements as $f) {
+            if (!$f instanceof \atk4\data\Field) {
+                continue;
+            }
+
+            if ($f->isEditable() || $f->isVisible()) {
+                $fields[] = $f->short_name;
+            }
+        }
+
+        return $fields;
+    }
+
+    public function renderView()
+    {
+        if (!$this->getModel()) {
+            throw new Exception('Multiline field needs to have it\'s model setup.');
+        }
+
+        if ($this->cb->triggered()){
+            $this->cb->set(function() {
+                try {
+                    return $this->renderCallback();
+                } catch (\atk4\Core\Exception $e) {
+                    $this->app->terminate(json_encode(['success' => false, 'error' => $e->getMessage()]));
+                } catch (\Error $e) {
+                    $this->app->terminate(json_encode(['success' => false, 'error' => $e->getMessage()]));
+                }
+            });
+        }
+
+        $this->multiLine->template->setHTML('Input', $this->getInput());
+        parent::renderView();
+
+        $this->multiLine->vue('atk-multiline',
+                              [
+                                  'data' => [
+                                      'linesField'  => $this->short_name,
+                                      'fields'      => $this->fieldDefs,
+                                      'idField'     => $this->getModel()->id_field,
+                                      'url'         => $this->cb->getJSURL(),
+                                      'eventFields' => $this->eventFields,
+                                      'hasChangeCb' => $this->changeCb ? true: false,
+                                  ]
+                              ]);
+    }
+
+    /**
+     * Render callback.
+     *
+     * @throws ValidationException
+     * @throws \atk4\core\Exception
+     * @throws \atk4\data\Exception
+     */
+    private function renderCallback()
+    {
+        $action = isset($_POST['action']) ? $_POST['action'] : null;
+        $response = [
+            'success' => true,
+            'message' => 'Success',
+        ];
+
+        switch ($action) {
+            case 'update-row':
+                $m = $this->setDummyModelValue(clone $this->getModel());
+                $expressionValues = array_merge($this->getExpressionValues($m),  $this->getCallbackValues($m));
+                $this->app->terminate(json_encode(array_merge($response, ['expressions' => $expressionValues])));
+                break;
+            case 'on-change':
+                // let regular callback render output.
+                return call_user_func($this->changeCb, json_decode($_POST['rows'], true));
+                break;
+        }
+        return;
+    }
+
+    /**
+     * return values associate with callback field.
+     *
+     * @param $model
+     *
+     * @return array
+     */
+    private function getCallbackValues($model)
+    {
+        $values =[];
+        foreach ($this->fieldDefs as $def) {
+            $fieldName = $def['field'];
+            if ($fieldName === $model->id_field) {
+                continue;
+            }
+            $field = $model->getElement($fieldName);
+            if ($field instanceof Callback) {
+                $value = call_user_func($field->expr, $model);
+                $values[$fieldName] = $this->app->ui_persistence->_typecastSaveField($field, $value);
+            }
+        }
+
+        return $values;
+    }
+    /**
+     * Looks inside the POST of the request and loads data into model.
+     * Allow to Run expression base on rowData value.
+     */
+    private function setDummyModelValue($model)
+    {
+        $post = $_POST;
+
+        foreach ($this->fieldDefs as $def) {
+            $fieldName = $def['field'];
+            if ($fieldName === $model->id_field) {
+                continue;
+            }
+
+            $value = isset($post[$fieldName]) ? $post[$fieldName] : null;
+            if ($model->getElement($fieldName)->isEditable()) {
+                try {
+                    $model[$fieldName] = $value;
+                } catch (ValidationException $e) {
+                    //bypass validation at this point.
+                }
+            }
+        }
+        return $model;
+    }
+
+    /**
+     * Return values associated to field expression.
+     *
+     * @param $m
+     *
+     * @return array
+     * @throws \atk4\core\Exception
+     * @throws \atk4\data\Exception
+     */
+    private function getExpressionValues($m)
+    {
+        $dummyFields = [];
+        $formatValues = [];
+
+        foreach ($this->getExpressionFields($m) as $k => $field) {
+            $dummyFields[$k]['name'] = $field->short_name;
+            $dummyFields[$k]['expr'] = $this->getDummyExpression($field, $m);
+        }
+
+        if (!empty($dummyFields)) {
+            $dummyModel = new Model($m->persistence, ['table' => $m->table]);
+            foreach ($dummyFields as $f) {
+                $dummyModel->addExpression($f['name'], ['expr'=>$f['expr'], 'type' => $m->getElement($f['name'])->type]);
+            }
+            $values = $dummyModel->loadAny()->get();
+            unset($values[$m->id_field]);
+
+            foreach ($values as $f => $value) {
+                $field = $m->getElement($f);
+                $formatValues[$f] = $this->app->ui_persistence->_typecastSaveField($field, $value);
+            }
+        }
+
+        return $formatValues;
+    }
+
+    /**
+     * Get all field expression in model.
+     * But only evaluate expression used in rowFields.
+     *
+     * @return array
+     */
+    private function getExpressionFields($model)
+    {
+        $fields = [];
+        foreach ($model->elements as $f) {
+            if (!$f instanceof Field_SQL_Expression || !in_array($f->short_name, $this->rowFields)) {
+                continue;
+            }
+
+            $fields[] = $f;
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Return expression where field are replace with their current or default value.
+     * ex: total field expression = [qty] * [price] will return 4 * 100
+     * where qty and price current value are 4 and 100 respectively.
+     *
+     * @param $expr
+     *
+     * @return mixed
+     * @throws \atk4\core\Exception
+     */
+    private function getDummyExpression($exprField, $model)
+    {
+        $expr = $exprField->expr;
+        $matches = [];
+
+        preg_match_all('/\[[a-z0-9_]*\]|{[a-z0-9_]*}/i', $expr, $matches);
+
+        foreach ($matches[0] as $match) {
+            $fieldName = substr($match, 1, -1);
+            $field = $model->getElement($fieldName);
+            if ($field instanceof Field_SQL_Expression) {
+                $expr = str_replace($match, $this->getDummyExpression($field, $model), $expr);
+            } else {
+                $expr = str_replace($match, $this->getValueForExpression($exprField, $fieldName, $model), $expr);
+            }
+        }
+
+        return $expr;
+    }
+
+    /**
+     * Return a value according to field use in expression and the expression type.
+     * If field use in expression is null , the default value is return.
+     *
+     * @param $exprField
+     * @param $fieldName
+     *
+     * @return int|mixed|string
+     */
+    private function getValueForExpression($exprField, $fieldName, $model)
+    {
+        switch($exprField->type) {
+            case 'money':
+            case 'integer':
+            case 'number':
+                //Value is 0 or the field value.
+                $value = $model[$fieldName] ? $model[$fieldName] : 0;
+                break;
+            default:
+                //Value is "" or field value enclosed in bracket: "value"
+                $value = $model[$fieldName] ? '"'.$model[$fieldName].'"' : '""';
+        }
+
+        return $value;
+    }
+}

--- a/src/FormField/MultiLine.php
+++ b/src/FormField/MultiLine.php
@@ -519,7 +519,7 @@ class MultiLine extends Generic
                 'isEditable'  => $field->isEditable(),
                 'isHidden'    => $field->isHidden(),
                 'isVisible'   => $field->isVisible(),
-                'width'       => $field->ui['multiline']['width'] ? $field->ui['multiline']['width'] : null
+                'width'       => $field->ui['multiline']['width'] ? $field->ui['multiline']['width'] : null,
             ];
         }
 

--- a/src/FormField/MultiLine.php
+++ b/src/FormField/MultiLine.php
@@ -393,6 +393,8 @@ class MultiLine extends Generic
         foreach ($currentIds as $id) {
             $model->delete($id);
         }
+
+        return $this;
     }
 
     /**

--- a/src/FormField/MultiLine.php
+++ b/src/FormField/MultiLine.php
@@ -226,7 +226,7 @@ class MultiLine extends Generic
      *
      * @throws Exception
      */
-    public function onChange($fx, $fields)
+    public function onLineChange($fx, $fields)
     {
         if (!is_callable($fx)) {
             throw new Exception('Function is required for onChange event.');

--- a/src/FormField/MultiLine.php
+++ b/src/FormField/MultiLine.php
@@ -217,23 +217,20 @@ class MultiLine extends Generic
 
     /**
      * Add a callback when fields are changed.
-     * It is possible to supply fields that will trigger the
-     * callback when changed. If no fields are supply then callback will trigger
-     * for all fields changed.
+     * You must supply array of fields that will trigger the
+     * callback when changed.
      *
      * @param array|\atk4\ui\FormField\jsExpression|callable|string $fx
-     * @param null                                                  $fields
+     * @param arra                                                  $fields
      *
      * @throws Exception
      */
-    public function onChange($fx, $fields = null)
+    public function onChange($fx, $fields)
     {
         if (!is_callable($fx)) {
             throw new Exception('Function is required for onChange event.');
         }
-        if ($fields) {
-            $this->eventFields = $fields;
-        }
+        $this->eventFields = $fields;
 
         $this->changeCb = $fx;
     }

--- a/src/FormField/MultiLine.php
+++ b/src/FormField/MultiLine.php
@@ -180,9 +180,7 @@ class MultiLine extends Generic
         parent::init();
 
         $this->app->useSuiVue();
-
-        $this->app->requireJS('../public/atk-invoice.js');
-
+        
         if (!$this->multiLineTemplate) {
             $this->multiLineTemplate = new Template('<div id="{$_id}" class="ui"><atk-multiline v-bind="initData"></atk-multiline>{$Input}</div>');
         }

--- a/src/FormField/MultiLine.php
+++ b/src/FormField/MultiLine.php
@@ -62,6 +62,9 @@
  *     $ml->saveRows();
  *     return new \atk4\ui\jsToast('Saved!');
  * });
+ *
+ * 2019-05-06 - now check if field isEditable instead of just expression when saving row(line 376).
+ * 2019=05-06 - Add options property for table css options
  */
 
 namespace atk4\ui\FormField;
@@ -97,6 +100,14 @@ class MultiLine extends Generic
      * @var null
      */
     private $multiLine = null;
+
+    /**
+     * An array of options for sui-table property.
+     * example: ['celled' => true] will render column line in table.
+     *
+     * @var array
+     */
+    public $options = [];
 
     /**
      * The definition of each fields used in each multiline row.
@@ -366,7 +377,7 @@ class MultiLine extends Generic
 
                 $field = $model->getElement($fieldName);
 
-                if (!$field instanceof Field_SQL_Expression) {
+                if ($field->isEditable()) {
                     $field->set($value);
                 }
             }
@@ -564,6 +575,7 @@ class MultiLine extends Generic
                                       'url'         => $this->cb->getJSURL(),
                                       'eventFields' => $this->eventFields,
                                       'hasChangeCb' => $this->changeCb ? true : false,
+                                      'options'     => $this->options
                                   ],
                               ]);
     }

--- a/src/FormField/MultiLine.php
+++ b/src/FormField/MultiLine.php
@@ -406,7 +406,7 @@ class MultiLine extends Generic
      *
      * @return mixed
      */
-    private function addModelValidateErrors($errors, $rowId, $model)
+    protected function addModelValidateErrors($errors, $rowId, $model)
     {
         $e = $model->validate();
         if ($e) {
@@ -419,6 +419,8 @@ class MultiLine extends Generic
     }
 
     /**
+     * for javascript use - changing this method may brake js functionality.
+     *
      * Return MultiLine row id in a row of data.
      *
      * @param $row
@@ -517,6 +519,7 @@ class MultiLine extends Generic
                 'isEditable'  => $field->isEditable(),
                 'isHidden'    => $field->isHidden(),
                 'isVisible'   => $field->isVisible(),
+                'width'       => $field->ui['multiline']['width'] ? $field->ui['multiline']['width'] : null
             ];
         }
 
@@ -583,6 +586,8 @@ class MultiLine extends Generic
     }
 
     /**
+     * for javascript use - changing these methods may brake js functionality.
+     *
      * Render callback.
      *
      * @throws ValidationException
@@ -611,6 +616,8 @@ class MultiLine extends Generic
     }
 
     /**
+     * for javascript use - changing this method may brake js functionality.
+     *
      * return values associate with callback field.
      *
      * @param $model
@@ -636,6 +643,8 @@ class MultiLine extends Generic
     }
 
     /**
+     * for javascript use - changing this method may brake js functionality.
+     *
      * Looks inside the POST of the request and loads data into model.
      * Allow to Run expression base on rowData value.
      */
@@ -663,6 +672,8 @@ class MultiLine extends Generic
     }
 
     /**
+     * for javascript use - changing this method may brake js functionality.
+     *
      * Return values associated to field expression.
      *
      * @param $m
@@ -700,6 +711,8 @@ class MultiLine extends Generic
     }
 
     /**
+     * for javascript use - changing this method may brake js functionality.
+     *
      * Get all field expression in model.
      * But only evaluate expression used in rowFields.
      *
@@ -720,6 +733,8 @@ class MultiLine extends Generic
     }
 
     /**
+     * for javascript use - changing this method may brake js functionality.
+     *
      * Return expression where field are replace with their current or default value.
      * ex: total field expression = [qty] * [price] will return 4 * 100
      * where qty and price current value are 4 and 100 respectively.
@@ -751,6 +766,8 @@ class MultiLine extends Generic
     }
 
     /**
+     * for javascript use - changing this method may brake js functionality.
+     *
      * Return a value according to field use in expression and the expression type.
      * If field use in expression is null , the default value is return.
      *

--- a/src/FormField/MultiLine.php
+++ b/src/FormField/MultiLine.php
@@ -63,8 +63,9 @@
  *     return new \atk4\ui\jsToast('Saved!');
  * });
  *
- * 2019-05-06 - now check if field isEditable instead of just expression when saving row(line 376).
- * 2019=05-06 - Add options property for table css options
+ * 2019-05-06   - now check if field isEditable instead of just expression when saving row(line 376).
+ *              - Add options property for table css options.
+ * 2019-05-07   - add form as parameter to the onChange callback. This allow to perform calculation at form model level.
  */
 
 namespace atk4\ui\FormField;
@@ -607,7 +608,7 @@ class MultiLine extends Generic
                 break;
             case 'on-change':
                 // let regular callback render output.
-                return call_user_func($this->changeCb, json_decode($_POST['rows'], true));
+                return call_user_func_array($this->changeCb, [json_decode($_POST['rows'], true), $this->form]);
                 break;
         }
     }

--- a/src/FormField/MultiLine.php
+++ b/src/FormField/MultiLine.php
@@ -180,7 +180,7 @@ class MultiLine extends Generic
         parent::init();
 
         $this->app->useSuiVue();
-        
+
         if (!$this->multiLineTemplate) {
             $this->multiLineTemplate = new Template('<div id="{$_id}" class="ui"><atk-multiline v-bind="initData"></atk-multiline>{$Input}</div>');
         }
@@ -592,7 +592,7 @@ class MultiLine extends Generic
      */
     private function renderCallback()
     {
-        $action = isset($_POST['action']) ? $_POST['action'] : null;
+        $action = isset($_POST['__atkml_action']) ? $_POST['__atkml_action'] : null;
         $response = [
             'success' => true,
             'message' => 'Success',


### PR DESCRIPTION
## MultiLine field

New form input in order to allow add/edit multiple record within a form.

## Usage

```
$f = $app->add('Form');
$f->setModel($invoice, false);

$sub_layout = $f->layout->addSubLayout('Generic');
$sub_layout->setModel($invoice, ['name', 'client_id', 'address']);

$sub_layout = $f->layout->addSubLayout('Generic');

//Add multi line input to the layout.
$ml = $sub_layout->addField('ml', ['MultiLine']);
$ml->setModel($invoice, ['item','cat','qty','price', 'sub', 'tx', 'grd'], 'Items', 'invoice_id');

// add onchange handler and update grand total.
$ml->onChange(function($rows) use ($f) {
    $total = 0;
    foreach ($rows as $row => $cols) {
        foreach ($cols as $col) {
            $fieldName = key($col);
            if ($fieldName === 'grd') {
                $total = $total + substr($col[$fieldName], 4);
            }
        }
    }
 return $f->js(true, null, 'input[name="g_total"]')->val(number_format($total, 2));

}, ['qty', 'price']);
```

<img width="938" alt="Screen Shot 2019-05-03 at 11 06 02 AM" src="https://user-images.githubusercontent.com/2204478/57156268-8d5c9180-6dab-11e9-868b-b65818192657.png">

## Demo file
multiline.php

## Feature

- Adding row will use Model/Field default value if set.
- Multiple row deletion;
- Calculate Expression or Callback value from Field definition;
- onChange callback for entire row record or on specify field.
- Validate according to Field definition in model.
- Validation is apply on every row when form is saved.

<img width="933" alt="Screen Shot 2019-05-03 at 11 06 31 AM" src="https://user-images.githubusercontent.com/2204478/57156325-acf3ba00-6dab-11e9-8a9f-0ef907c31366.png">
