### PR TITLE
Only prepend namespace for known classes

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -376,8 +376,33 @@ class App
      */
     public function normalizeClassNameApp($name)
     {
-        if (class_exists('\\'.__NAMESPACE__.'\\'.$name)) {
-            return '\\'.__NAMESPACE__.'\\'.$name;
+        /**
+         * @see https://agile-core.readthedocs.io/en/develop/factory.html#FactoryTrait::normalizeClassName
+         * replacing / to \
+         */
+        $checkClass = str_replace("/","\\",$name);
+
+        // check FQCN existence without prepend \\
+        // @case $name = "\\externalNamespace\\className"
+        if(class_exists($checkClass))
+        {
+            return $checkClass;
+        }
+
+        $checkClass = "\\" . $checkClass;
+        // check FQCN existence prepending \
+        // @case $name = "externalNamespace\\className"
+        if(class_exists($checkClass))
+        {
+            return $checkClass;
+        }
+
+        $checkClass = "\\" . __NAMESPACE__ . $checkClass;
+        // check FQCN existence prepending FQNS \atk4\ui
+        // @case $name = "FormField/AutoComplete"
+        if(class_exists($checkClass))
+        {
+            return $checkClass;
         }
 
         return $name;

--- a/src/App.php
+++ b/src/App.php
@@ -379,6 +379,7 @@ class App
         if (class_exists('\\'.__NAMESPACE__.'\\'.$name)) {
             return '\\'.__NAMESPACE__.'\\'.$name;
         }
+
         return $name;
     }
 

--- a/src/App.php
+++ b/src/App.php
@@ -376,7 +376,10 @@ class App
      */
     public function normalizeClassNameApp($name)
     {
-        return '\\'.__NAMESPACE__.'\\'.$name;
+        if (class_exists('\\'.__NAMESPACE__.'\\'.$name)) {
+            return '\\'.__NAMESPACE__.'\\'.$name;
+        }
+        return $name;
     }
 
     /**

--- a/src/App.php
+++ b/src/App.php
@@ -380,28 +380,25 @@ class App
          * @see https://agile-core.readthedocs.io/en/develop/factory.html#FactoryTrait::normalizeClassName
          * replacing / to \
          */
-        $checkClass = str_replace("/","\\",$name);
+        $checkClass = str_replace('/', '\\', $name);
 
         // check FQCN existence without prepend \\
         // @case $name = "\\externalNamespace\\className"
-        if(class_exists($checkClass))
-        {
+        if (class_exists($checkClass)) {
             return $checkClass;
         }
 
-        $checkClass = "\\" . $checkClass;
+        $checkClass = '\\'.$checkClass;
         // check FQCN existence prepending \
         // @case $name = "externalNamespace\\className"
-        if(class_exists($checkClass))
-        {
+        if (class_exists($checkClass)) {
             return $checkClass;
         }
 
-        $checkClass = "\\" . __NAMESPACE__ . $checkClass;
+        $checkClass = '\\'.__NAMESPACE__.$checkClass;
         // check FQCN existence prepending FQNS \atk4\ui
         // @case $name = "FormField/AutoComplete"
-        if(class_exists($checkClass))
-        {
+        if (class_exists($checkClass)) {
             return $checkClass;
         }
 


### PR DESCRIPTION
Currently `atk4\ui\App` normalize class will prepend `\atk4\ui\` when using short name of the class, like this:

``` php
$app->add('CRUD');

# factory uses \atk4\ui\CRUD
```

However, this requires us to always use full name for the class:

``` php
$app->add('\my\test\MyClass')
```

This is incompatible with:

``` php
use \my\test\MyClass;

$app->add(MyClass::class);
```

because it uses `my\test\MyClass` without opening backslash.

This PR fixes problem by checking for the presence of the class inside \atk4\ui\ before attempting to use the prefix.