### PR TITLE
Allow easy routing implementation

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -125,8 +125,7 @@ class App
      * Remove and re-add the extension of the file during parsing requests and building urls
      */
     protected $url_building_ext = '.php';
-    
-    
+
     /**
      * Constructor.
      *

--- a/src/App.php
+++ b/src/App.php
@@ -118,7 +118,14 @@ class App
      */
     private $is_sui_init = false;
 
+    /**
+     * @var string used in method App::url to build the url
+     *
+     * Used only in method App::url
+     * Remove and re-add the extension of the file during parsing requests and building urls
+     */
     protected $url_building_ext = ".php";
+    
     /**
      * Constructor.
      *

--- a/src/App.php
+++ b/src/App.php
@@ -124,7 +124,7 @@ class App
      * Used only in method App::url
      * Remove and re-add the extension of the file during parsing requests and building urls
      */
-    protected $url_building_ext = ".php";
+    protected $url_building_ext = '.php';
     
     /**
      * Constructor.
@@ -591,7 +591,7 @@ class App
 
         // put URL together
         $args = http_build_query($result);
-        $url = ($page[0] ? $page[0] . $this->url_building_ext : '').($args ? '?'.$args : '');
+        $url = ($page[0] ? $page[0].$this->url_building_ext : '').($args ? '?'.$args : '');
 
         return $url;
     }

--- a/src/App.php
+++ b/src/App.php
@@ -118,6 +118,7 @@ class App
      */
     private $is_sui_init = false;
 
+    protected $url_building_ext = ".php";
     /**
      * Constructor.
      *
@@ -538,7 +539,7 @@ class App
             if (substr($uri, -1, 1) == '/') {
                 $this->page = 'index';
             } else {
-                $this->page = basename($uri, '.php');
+                $this->page = basename($uri, $this->url_building_ext);
             }
         }
 
@@ -583,7 +584,7 @@ class App
 
         // put URL together
         $args = http_build_query($result);
-        $url = ($page[0] ? $page[0].'.php' : '').($args ? '?'.$args : '');
+        $url = ($page[0] ? $page[0] . $this->url_building_ext : '').($args ? '?'.$args : '');
 
         return $url;
     }

--- a/src/App.php
+++ b/src/App.php
@@ -126,6 +126,7 @@ class App
      */
     protected $url_building_ext = '.php';
     
+    
     /**
      * Constructor.
      *


### PR DESCRIPTION
if you extend App class and want to use routing in place of direct call to files, you have to complete override the method url of App, to change only 2 occurence of ".php", even if the first occurence at line 542 is only for completeness, the other one on line 587 must be changed to avoid reparsing the result of a parent::url(args) if you plan to only partially override that is nonsense.

i put the variable protected because is something that never change and must work in extended class.