### PR TITLE
Add TableColumn Caption definition in model

### DIFF
--- a/src/TableColumn/Generic.php
+++ b/src/TableColumn/Generic.php
@@ -303,7 +303,7 @@ class Generic
         if ($f === null) {
             return $this->getTag('head', $this->caption ?: '', $this->table->sortable ? ['class' => ['disabled']] : []);
         }
-        
+
         // if $this->caption is empty, header caption will be overriden by linked field definition
         if(empty($this->caption)) {
             $caption = $f->getCaption();

--- a/src/TableColumn/Generic.php
+++ b/src/TableColumn/Generic.php
@@ -303,6 +303,11 @@ class Generic
         if ($f === null) {
             return $this->getTag('head', $this->caption ?: '', $this->table->sortable ? ['class' => ['disabled']] : []);
         }
+        
+        // if $this->caption is empty, header caption will be overriden by linked field definition
+        if(empty($this->caption)) {
+            $caption = $f->getCaption();
+        }
 
         // If table is being sorted by THIS column, set the proper class
         $attr = [];
@@ -324,7 +329,7 @@ class Generic
             $attr = array_merge($attr, ['id' => $this->name.'_th']);
             $tag = $this->getTag(
                 'head',
-                [$f->getCaption(),
+                [$caption,
                     $this->headerActionTag,
                 ],
                 $attr
@@ -332,7 +337,7 @@ class Generic
         } else {
             $tag = $this->getTag(
                 'head',
-                $f->getCaption(),
+                $caption,
                 $attr
             );
         }

--- a/src/TableColumn/Generic.php
+++ b/src/TableColumn/Generic.php
@@ -305,9 +305,7 @@ class Generic
         }
 
         // if $this->caption is empty, header caption will be overriden by linked field definition
-        if (empty($this->caption)) {
-            $caption = $f->getCaption();
-        }
+        $caption = empty($this->caption) ? $f->getCaption() : $this->caption;
 
         // If table is being sorted by THIS column, set the proper class
         $attr = [];

--- a/src/TableColumn/Generic.php
+++ b/src/TableColumn/Generic.php
@@ -305,7 +305,7 @@ class Generic
         }
 
         // if $this->caption is empty, header caption will be overriden by linked field definition
-        if(empty($this->caption)) {
+        if (empty($this->caption)) {
             $caption = $f->getCaption();
         }
 


### PR DESCRIPTION
In Model we can define the default caption for the field, usually in Table we use abbreviation or acronim of that long caption, to centralize TableColumn the definition of the ui rappresentation of the field in all table.

