### PR TITLE
fix/File upload - jsModal Css

### DIFF
--- a/js/Release.md
+++ b/js/Release.md
@@ -4,7 +4,7 @@
 
 - Babel configuration.
     - fix core.js warning during build. 
-- create-modal.pluing
+- create-modal.plugin
     - fix: now allow to pass css class name to create modal. 
     Useful when need to create modal with full width for example.
 - file-upload.plugin

--- a/js/Release.md
+++ b/js/Release.md
@@ -1,5 +1,17 @@
 ## Release note
 
+### version 1.6.8
+
+- Babel configuration.
+    - fix core.js warning during build. 
+- create-modal.pluing
+    - fix: now allow to pass css class name to create modal. 
+    Useful when need to create modal with full width for example.
+- file-upload.plugin
+    - remove support for opening file dialog when input get focus. Because File dialog
+    will remove blur and focus input field again, this was causing the file dialog to open
+    multiple time. Now only open when input or button is clicked.
+
 ### version 1.6.7
    
 - plugin.js

--- a/js/babel.config.js
+++ b/js/babel.config.js
@@ -9,6 +9,7 @@ const presets = [
     "@babel/env",
     {
       targets: "> 1% , not dead",
+      "corejs": "2",
       "useBuiltIns": "usage"
     },
   ],

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atkjs-ui",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "description": "Agile Toolkit Javascript library.",
   "main": "lib/atkjs-ui.js",
   "scripts": {

--- a/js/src/plugins/create-modal.plugin.js
+++ b/js/src/plugins/create-modal.plugin.js
@@ -10,7 +10,7 @@ export default class createModal extends atkPlugin {
           options.uri_options = {};
       }
       // create modal and add it to the DOM
-      let $m = $('<div class="atk-modal ui modal scrolling"/>')
+      let $m = $('<div class="atk-modal ui modal"/>')
           .appendTo('body')
           .html(this.getDialogHtml(options.title));
 
@@ -19,12 +19,13 @@ export default class createModal extends atkPlugin {
 
       //call semantic-ui modal
       $m.modal(options.modal).modal('show');
+      $m.addClass(this.settings.modalCss);
   }
 
   getDialogHtml(title) {
     return `<i class="icon close"></i>
           <div class="${this.settings.headerCss}">${title}</div>
-          <div class="image content atk-dialog-content">
+          <div class="${this.settings.contentCss} content atk-dialog-content">
             </div>
           </div>`;
   }
@@ -35,6 +36,8 @@ createModal.DEFAULTS = {
   uri: null,
   uri_options: {},
   headerCss: 'header',
+  modalCss: 'scrolling',
+  contentCss: 'image',
   label: 'Loading...',
   modal: {
       duration: 100

--- a/js/src/plugins/file-upload.plugin.js
+++ b/js/src/plugins/file-upload.plugin.js
@@ -27,12 +27,12 @@ export default class fileUpload extends atkPlugin {
         percent: '{percent}%',
         active: '{percent}%',
       }
-    })
-      .hide();
+    }).hide();
 
     this.$el.data().fileId = this.settings.file.id;
     this.hiddenInput.val(this.settings.file.id);
     this.textInput.val(this.settings.file.name);
+    this.textInput.data('isTouch', false);
     if (this.settings.file.id) {
       this.setState('delete');
     }
@@ -60,17 +60,11 @@ export default class fileUpload extends atkPlugin {
    */
   setEventHandler() {
     const that = this;
-    // Open file dialog on focus.
-    if (this.settings.hasFocus) {
-      this.textInput.on('focus', function(e) {
-        if (!e.target.value) {
-          that.fileInput.click();
-        }
-      });
-    }
+
     this.textInput.on('click', function(e) {
-      this.blur();
-      this.focus();
+      if (!e.target.value) {
+        that.fileInput.click();
+      }
     });
 
     // add event handler to action button.
@@ -212,7 +206,6 @@ fileUpload.DEFAULTS = {
   uri: null,
   file: {id: null, name: null},
   uri_options: {},
-  hasFocus: true,
   action: null,
   completeLabel: '100%',
   submit: null

--- a/src/FormField/Upload.php
+++ b/src/FormField/Upload.php
@@ -34,8 +34,11 @@ class Upload extends Input
      * default to true.
      *
      * @var bool
+     * @obsolete
+     * hasFocusEnable has been disable in js plugin and this property will be removed.
+     * Upload field is only using click handler now.
      */
-    public $hasFocusEnable = true;
+    public $hasFocusEnable = false;
 
     /**
      * The input default template.

--- a/src/jsModal.php
+++ b/src/jsModal.php
@@ -40,6 +40,15 @@ class jsModal extends jsExpression
      *      ex: changing default 'Loading...' for no text
      *      $jsModal->setOption('label', '');
      *
+     *   'modalCss' -> customize css class name for the entire modal.
+     *      ex: making modal fullscreen
+     *      $jsModal->setOption('modalCss', 'fullscreen');
+     *
+     *   'contentCss' -> customize css class name for Modal content.
+     *       ex: making content scrollable
+     *       $jsModal->setOption('contentCss', 'scrolling');
+     *       Note: Default to 'image' for backward compatibility.
+     *
      * You can set option individually or supply an array.
      *
      * @param $options


### PR DESCRIPTION
### fix #717 

### Other Fix:
- Babel configuration.
    - fix core.js warning during build.
- file-upload.plugin
    - remove support for opening file dialog when input get focus. Because File dialog
    will blur and re focus input field again. This was causing file dialog to open
    multiple times. Now only open when input or button is clicked.

### Enhancement
- create-modal.plugin
    Now allow to pass css class name to create modal.
    Useful when need to create modal with full width for example.

``` php
$btn = $app->add(['Button', 'Add']);
$btn->on('click', (new jsModal('Add new', $vp))->setOption('modalCss', 'fullscreen'));
```
