### PR TITLE
Feature/allow dbconnect before setlayout

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -508,7 +508,9 @@ class App
      */
     public function dbConnect($dsn, $user = null, $password = null, $args = [])
     {
-        return $this->db = $this->add(\atk4\data\Persistence::connect($dsn, $user, $password, $args));
+        $this->db = \atk4\data\Persistence::connect($dsn, $user, $password, $args);
+        $this->db->app = $this;
+        return $this->db;
     }
 
     protected function getRequestURI()

--- a/src/App.php
+++ b/src/App.php
@@ -510,6 +510,7 @@ class App
     {
         $this->db = \atk4\data\Persistence::connect($dsn, $user, $password, $args);
         $this->db->app = $this;
+
         return $this->db;
     }
 


### PR DESCRIPTION
Currently when you execute `dbConnect` before `initLayout` you get this error:

<img width="1160" alt="image" src="https://user-images.githubusercontent.com/453929/58967992-29175e00-87ad-11e9-8d37-22a1a18f9a9b.png">

This is because app tries to do `$this->layout->add(persistence)`. This does not make sense, persistence is not supposed to go inside layout.

All we need for persistence is to set the `app` property, so this PR does that directly and the error is no longer popping up.