### PR TITLE
should check numeric value not int

### DIFF
--- a/src/Header.php
+++ b/src/Header.php
@@ -58,8 +58,8 @@ class Header extends View
     public function renderView()
     {
         if ($this->size) {
-            if (is_int($this->size)) {
-                $this->element = 'h'.$this->size;
+            if (is_numeric($this->size)) {
+                $this->setElement('h'.$this->size);
             } else {
                 $this->addClass($this->size);
             }


### PR DESCRIPTION
Should better check for numeric value not int.
For example, string '3' is not int, but is numeric and sometimes we get numbers as strings.