### PR TITLE
Fix caughtException() and normalizeClassNameApp()

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -385,7 +385,7 @@ class App
 
         // if we have prefix, then use it - it's there for a purpose
         if ($prefix) {
-            $checkClass = $prefix.'\\'.$checkClass;
+            $checkClass = str_replace('/', '\\', $prefix).'\\'.$checkClass;
         }
 
         // check FQCN existence without prepend \\
@@ -406,6 +406,12 @@ class App
         // @case $name = "FormField/AutoComplete"
         if (class_exists($checkClass)) {
             return $checkClass;
+        }
+
+        // Backward compatibility with legacy version
+        $testClass = "\\atk4\ui\\" . $prefix . $checkClass;
+        if (class_exists($testClass)) {
+            return $testClass;
         }
 
         return $name;

--- a/src/App.php
+++ b/src/App.php
@@ -234,7 +234,7 @@ class App
     {
         $this->catch_runaway_callbacks = false;
 
-        $l = new \atk4\ui\App();
+        $l = new static();
         $l->initLayout('Centered');
 
         //check for error type.

--- a/src/App.php
+++ b/src/App.php
@@ -409,7 +409,7 @@ class App
         }
 
         // Backward compatibility with legacy version
-        $testClass = "\\atk4\ui\\" . $prefix . $checkClass;
+        $testClass = "\\atk4\ui\\".$prefix.$checkClass;
         if (class_exists($testClass)) {
             return $testClass;
         }

--- a/src/App.php
+++ b/src/App.php
@@ -371,16 +371,22 @@ class App
      * Normalizes class name.
      *
      * @param string $name
+     * @param string $prefix
      *
      * @return string
      */
-    public function normalizeClassNameApp($name)
+    public function normalizeClassNameApp($name, $prefix = null)
     {
         /**
          * @see https://agile-core.readthedocs.io/en/develop/factory.html#FactoryTrait::normalizeClassName
          * replacing / to \
          */
         $checkClass = str_replace('/', '\\', $name);
+
+        // if we have prefix, then use it - it's there for a purpose
+        if ($prefix) {
+            $checkClass = $prefix . '\\' . $checkClass;
+        }
 
         // check FQCN existence without prepend \\
         // @case $name = "\\externalNamespace\\className"

--- a/src/App.php
+++ b/src/App.php
@@ -385,7 +385,7 @@ class App
 
         // if we have prefix, then use it - it's there for a purpose
         if ($prefix) {
-            $checkClass = $prefix . '\\' . $checkClass;
+            $checkClass = $prefix.'\\'.$checkClass;
         }
 
         // check FQCN existence without prepend \\

--- a/src/FormLayout/Generic.php
+++ b/src/FormLayout/Generic.php
@@ -101,7 +101,7 @@ class Generic extends _Abstract
      */
     public function addSubLayout($seed = 'Generic', $addDivider = true)
     {
-        $v = $this->add($this->factory($seed, ['form' => $this->form], 'FormLayout/Section'));
+        $v = $this->add($this->factory($seed, ['form' => $this->form], 'FormLayout\Section'));
         if ($v instanceof \atk4\ui\FormLayout\Section\Generic) {
             $v = $v->addSection();
         }


### PR DESCRIPTION
1. `caughtException` should use static class not always core \atk4\ui\App class (in case we have extended App class).

2. `normalizeClassNameApp` should not ignore $prefix argument which it gets from FactoryTrait. fix #740