### PR TITLE
Fix/Form::success()

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -288,37 +288,43 @@ class Form extends View //implements \ArrayAccess - temporarily so that our buil
     /**
      * Causes form to generate success message.
      *
-     * @param string $str        Success message
-     * @param string $sub_header Sub-header
+     * @param View|string $success  Success message or a View to display in modal
+     * @param string $sub_header    Sub-header
+     * @param bool   $useTemplate   Backward compatibility
      *
      * @return jsChain
+     * @throws Exception
+     * @throws \atk4\core\Exception
      */
-    public function success($str = 'Success', $sub_header = null)
+    public function success($success = 'Success', $sub_header = null, $useTemplate = true)
     {
+        $response = null;
         // by using this hook you can overwrite default behavior of this method
         if ($this->hookHasCallbacks('displaySuccess')) {
-            return $this->hook('displaySuccess', [$str, $sub_header]);
+            return $this->hook('displaySuccess', [$success, $sub_header]);
         }
 
-        /* below code works, but pollutes output with bad id=xx
-        $success = new Message([$str, 'id'=>false, 'type'=>'success', 'icon'=>'check']);
-        $success->app = $this->app;
-        $success->init();
-        $success->text->addParagraph($sub_header);
-         */
-        $success = $this->app->loadTemplate($this->successTemplate);
-        $success['header'] = $str;
+        if ($success instanceof View) {
+            $response = $success;
+        } else if ($useTemplate) {
+            $response = $this->app->loadTemplate($this->successTemplate);
+            $response['header'] = $success;
 
-        if ($sub_header) {
-            $success['message'] = $sub_header;
+            if ($sub_header) {
+                $response['message'] = $sub_header;
+            } else {
+                $response->del('p');
+            }
+
+            $response = $this->js()->html($response->render());
         } else {
-            $success->del('p');
+            $response = new Message([$success, 'type'=>'success', 'icon'=>'check']);
+            $response->app = $this->app;
+            $response->init();
+            $response->text->addParagraph($sub_header);
         }
 
-        $js = $this->js()
-            ->html($success->render());
-
-        return $js;
+        return $response;
     }
 
     // }}}

--- a/src/Form.php
+++ b/src/Form.php
@@ -288,13 +288,14 @@ class Form extends View //implements \ArrayAccess - temporarily so that our buil
     /**
      * Causes form to generate success message.
      *
-     * @param View|string $success  Success message or a View to display in modal
-     * @param string $sub_header    Sub-header
-     * @param bool   $useTemplate   Backward compatibility
+     * @param View|string $success     Success message or a View to display in modal
+     * @param string      $sub_header  Sub-header
+     * @param bool        $useTemplate Backward compatibility
      *
-     * @return jsChain
      * @throws Exception
      * @throws \atk4\core\Exception
+     *
+     * @return jsChain
      */
     public function success($success = 'Success', $sub_header = null, $useTemplate = true)
     {
@@ -306,7 +307,7 @@ class Form extends View //implements \ArrayAccess - temporarily so that our buil
 
         if ($success instanceof View) {
             $response = $success;
-        } else if ($useTemplate) {
+        } elseif ($useTemplate) {
             $response = $this->app->loadTemplate($this->successTemplate);
             $response['header'] = $success;
 

--- a/src/jsCallback.php
+++ b/src/jsCallback.php
@@ -130,8 +130,8 @@ class jsCallback extends Callback implements jsExpressionable
         }
 
         if ($response instanceof View) {
-            $response = new jsExpression('$([html]).modal("show")', [
-                        'html' => '<div class="ui fullscreen modal"> <i class="close icon"></i>  <div class="content"> '.
+            $response = new jsExpression('$([html]).modal("show").data("needRemove", true)', [
+                        'html' => '<div class="ui modal"> <i class="close icon"></i>  <div class="content atk-content"> '.
                         $response->render()
                         .' </div> </div>',
                     ]);


### PR DESCRIPTION
Fixes:
- Allow to pass a view  and return a view to form success callback.
-  jsCallback return response from duplicating Modals dialog.
```
$f = $app->add('Form');
$f->setModel($country);
$f->onSubmit(function($f){
    $modal = new \atk4\ui\View();
    $modal->add(new \atk4\ui\Message(['Country is saved.', 'text' => 'What will you like to do?']));
    $modal->add($newBtn = new \atk4\ui\Button('Add New Country'));
    $modal->add($editBtn = new \atk4\ui\Button('Edit Country'));

    $newBtn->on('click', [$modal->js()->parents('.modal')->modal('hide'), $f->jsReload()]);
    $editBtn->on('click', [$modal->js()->parents('.modal')->modal('hide')]);

    return $f->success($modal);
});
```

Will display:

<img width="601" alt="Screen Shot 2019-06-27 at 10 56 20 AM" src="https://user-images.githubusercontent.com/2204478/60276897-82653f80-98ca-11e9-88d3-edf44f98f918.png">
