### PR TITLE
Feature/confirm modal

### DIFF
--- a/demos/jsactions.php
+++ b/demos/jsactions.php
@@ -54,6 +54,5 @@ $executor = new \atk4\ui\ActionExecutor\jsEvent($btn, $f_action, null, ['path' =
 $executor->addHook('afterExecute', function ($t, $m) {
     return new \atk4\ui\jsToast('Files imported');
 });
-$executor->setConfirm('This will import a lot of file. Are you sure?');
 
-$btn->on('click', $executor);
+$btn->on('click', $executor, ['confirm'=> 'This will import a lot of file. Are you sure?']);

--- a/js/Release.md
+++ b/js/Release.md
@@ -1,5 +1,9 @@
 ## Release note
 
+### version 1.7.0
+
+- New atkConfirm plugin. Will display a user confirmaton dialog using fomantic ui modal.
+
 ### version 1.6.8
 
 - Babel configuration.

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atkjs-ui",
-  "version": "1.6.8",
+  "version": "1.7.0",
   "description": "Agile Toolkit Javascript library.",
   "main": "lib/atkjs-ui.js",
   "scripts": {

--- a/js/src/plugin.js
+++ b/js/src/plugin.js
@@ -11,6 +11,7 @@ import jsSortable from "./plugins/js-sortable.plugin";
 import conditionalForm from "./plugins/conditional-form.plugin";
 import columnResizer from "./plugins/column-resizer.plugin";
 import scroll from "./plugins/scroll.plugin";
+import confirm from "./plugins/confirm.plugin";
 
 /**
  * Generate a jQuery plugin
@@ -94,6 +95,7 @@ function createAtkplugins() {
     {name: 'ConditionalForm', plugin: conditionalForm, sh: true},
     {name: 'ColumnResizer', plugin: columnResizer, sh: false},
     {name: 'Scroll', plugin: scroll, sh: false},
+    {name: 'Confirm', plugin: confirm, sh: true},
   ];
 
   atkJqPlugins.forEach((atkJqPlugin) => {

--- a/js/src/plugins/ajaxec.plugin.js
+++ b/js/src/plugins/ajaxec.plugin.js
@@ -6,9 +6,15 @@ export default class ajaxec extends atkPlugin {
     main() {
         //Allow user to confirm if available.
         if(this.settings.confirm){
-            if(confirm(this.settings.confirm)) {
-                this.doExecute();
-            }
+            const that = this;
+            $.atkConfirm({title: this.settings.confirm, onApprove: function(){that.doExecute()}})
+            // const that = this;
+            // let $m = $('<div class="ui tiny modal"/>')
+            //   .appendTo('body')
+            //   .html(this.getDialogHtml(this.settings.confirm));
+            //
+            // $m.modal({onApprove: function(){that.doExecute()}}).modal('show');
+
         } else {
             if (!this.$el.hasClass('loading')){
               this.doExecute();

--- a/js/src/plugins/ajaxec.plugin.js
+++ b/js/src/plugins/ajaxec.plugin.js
@@ -6,12 +6,12 @@ export default class ajaxec extends atkPlugin {
     main() {
         //Allow user to confirm if available.
         if(this.settings.confirm){
-            const that = this;
-            $.atkConfirm({message: this.settings.confirm, onApprove: function(){that.doExecute()}});
-
+            if(confirm(this.settings.confirm)) {
+                this.doExecute();
+            }
         } else {
             if (!this.$el.hasClass('loading')){
-              this.doExecute();
+                this.doExecute();
             }
         }
     }

--- a/js/src/plugins/ajaxec.plugin.js
+++ b/js/src/plugins/ajaxec.plugin.js
@@ -7,13 +7,7 @@ export default class ajaxec extends atkPlugin {
         //Allow user to confirm if available.
         if(this.settings.confirm){
             const that = this;
-            $.atkConfirm({title: this.settings.confirm, onApprove: function(){that.doExecute()}})
-            // const that = this;
-            // let $m = $('<div class="ui tiny modal"/>')
-            //   .appendTo('body')
-            //   .html(this.getDialogHtml(this.settings.confirm));
-            //
-            // $m.modal({onApprove: function(){that.doExecute()}}).modal('show');
+            $.atkConfirm({message: this.settings.confirm, onApprove: function(){that.doExecute()}});
 
         } else {
             if (!this.$el.hasClass('loading')){

--- a/js/src/plugins/confirm.plugin.js
+++ b/js/src/plugins/confirm.plugin.js
@@ -1,0 +1,39 @@
+import atkPlugin from './atk.plugin';
+
+
+export default class confirm extends atkPlugin {
+
+  main() {
+
+    let $m = $('<div class="ui tiny modal"/>')
+      .appendTo('body')
+      .html(this.getDialogHtml(this.settings.title));
+
+    let options = {};
+    if (this.settings.onApprove) {
+      options.onApprove = this.settings.onApprove;
+    }
+    if (this.settings.onDeny) {
+      options.onDeny = this.settings.onDeny;
+    }
+    $m.data('needRemove', true).modal(options).modal('show');
+  }
+
+  getDialogHtml(message) {
+    return `
+          <div class=" content">${message}</div>
+          <div class="actions">
+            <div class="ui approve primary button">${this.settings.options.button.ok}</div>
+            <div class="ui cancel button">${this.settings.options.button.cancel}</div>
+           </div>
+          `;
+  }
+}
+
+
+confirm.DEFAULTS = {
+  title: null,
+  onApprove: null,
+  onDeny: null,
+  options: {button: {ok : 'Ok', cancel: 'Cancel'}}
+};

--- a/js/src/plugins/confirm.plugin.js
+++ b/js/src/plugins/confirm.plugin.js
@@ -5,13 +5,22 @@ export default class confirm extends atkPlugin {
 
   main() {
 
-    let $m = $('<div class="ui tiny modal"/>')
+    let context = this;
+    const that = this;
+    let $m = $('<div class="ui modal"/>')
       .appendTo('body')
-      .html(this.getDialogHtml(this.settings.title));
+      .html(this.getDialogHtml(this.settings.message));
+
+    $m.addClass(this.settings.size);
 
     let options = {};
+
+    if (this.settings.context) {
+      context = this.settings.context;
+    }
+
     if (this.settings.onApprove) {
-      options.onApprove = this.settings.onApprove;
+      options.onApprove = function(){that.settings.onApprove.call(context)};
     }
     if (this.settings.onDeny) {
       options.onDeny = this.settings.onDeny;
@@ -32,8 +41,10 @@ export default class confirm extends atkPlugin {
 
 
 confirm.DEFAULTS = {
-  title: null,
+  message: null,
+  size: 'tiny',
   onApprove: null,
   onDeny: null,
-  options: {button: {ok : 'Ok', cancel: 'Cancel'}}
+  options: {button: {ok : 'Ok', cancel: 'Cancel'}},
+  context: null
 };

--- a/js/src/plugins/confirm.plugin.js
+++ b/js/src/plugins/confirm.plugin.js
@@ -6,6 +6,9 @@ import atkPlugin from './atk.plugin';
  * Will execute onApprove function when user click ok button;
  * Will execute onDeny function when user click cancel button.
  *
+ * Fomantic UI modal option can be pass using modalOptions object.
+ * Setting onApprove and onDeny function within modalOptions object will override
+ * onApprove and onDeny current setting. 
  */
 export default class confirm extends atkPlugin {
 
@@ -32,6 +35,9 @@ export default class confirm extends atkPlugin {
     if (this.settings.onDeny) {
       options.onDeny = function(){that.settings.onDeny.call(context)};
     }
+
+    options = Object.assign(options, this.settings.modalOptions);
+
     $m.data('needRemove', true).modal(options).modal('show');
   }
 
@@ -52,5 +58,6 @@ confirm.DEFAULTS = {
   onApprove: null,
   onDeny: null,
   options: {button: {ok : 'Ok', cancel: 'Cancel'}},
+  modalOptions: {closable: false},
   context: null
 };

--- a/js/src/plugins/confirm.plugin.js
+++ b/js/src/plugins/confirm.plugin.js
@@ -1,6 +1,12 @@
 import atkPlugin from './atk.plugin';
 
-
+/**
+ * A Fomantic UI Modal dialog for confirming an action.
+ *
+ * Will execute onApprove function when user click ok button;
+ * Will execute onDeny function when user click cancel button.
+ *
+ */
 export default class confirm extends atkPlugin {
 
   main() {
@@ -19,11 +25,12 @@ export default class confirm extends atkPlugin {
       context = this.settings.context;
     }
 
+    //Create wrapper function for using proper "this" context.
     if (this.settings.onApprove) {
       options.onApprove = function(){that.settings.onApprove.call(context)};
     }
     if (this.settings.onDeny) {
-      options.onDeny = this.settings.onDeny;
+      options.onDeny = function(){that.settings.onDeny.call(context)};
     }
     $m.data('needRemove', true).modal(options).modal('show');
   }
@@ -38,7 +45,6 @@ export default class confirm extends atkPlugin {
           `;
   }
 }
-
 
 confirm.DEFAULTS = {
   message: null,

--- a/src/ActionExecutor/jsEvent.php
+++ b/src/ActionExecutor/jsEvent.php
@@ -6,6 +6,10 @@
  *
  * Usage:
  * $btn->on('click', new jsEvent($btn, $action, $actionArgs));
+ *
+ * You can add confirmation via the on handler.
+ *
+ * $btn->on('click', new jsEvent($btn, $action, $actionArgs), ['confirm' => 'Sure?']);
  */
 
 namespace atk4\ui\ActionExecutor;
@@ -41,9 +45,6 @@ class jsEvent implements jsExpressionable
     /** @var jsCallback */
     public $cb;
 
-    /** @var string|null The confirmation message. */
-    public $confirm = null;
-
     public function __construct(View $context, Generic $action, $modelId = null, array $args = [])
     {
         $this->context = $context;
@@ -77,20 +78,6 @@ class jsEvent implements jsExpressionable
         return $errors;
     }
 
-    /**
-     * Ask for confirmation prior to add an action.
-     *
-     * @param string $text
-     *
-     * @return $this
-     */
-    public function setConfirm($text = 'Are you sure')
-    {
-        $this->confirm = $text;
-
-        return $this;
-    }
-
     public function jsRender()
     {
         $this->cb->set(function () {
@@ -120,7 +107,6 @@ class jsEvent implements jsExpressionable
             ->atkAjaxec([
                 'uri'           => $this->cb->getJSURL(),
                 'uri_options'   => array_merge(['atk_event_id' => $this->modelId], $this->args),
-                'confirm'       => $this->confirm,
         ]);
 
         return $final->jsRender();

--- a/src/Card.php
+++ b/src/Card.php
@@ -328,12 +328,16 @@ class Card extends View
      * as target.
      *
      * @param Generic $action
-     * @param null    $button
+     * @param null $button
+     * @param []      $args    The action argument
+     * @param string $confirm The confirmation message.
      *
+     * @return Card
      * @throws Exception
      */
     public function addClickAction(Generic $action, $button = null, $args = [], $confirm = null)
     {
+        $defaults = [];
         if (!$button) {
             $button = new Button([$action->caption]);
         }
@@ -341,10 +345,11 @@ class Card extends View
 
         $id = $this->model ? $this->model[$this->model->id_field] : null;
 
-        $btn->on('click', $executor = new jsEvent($btn, $action, $id, $args));
         if ($confirm) {
-            $executor->setConfirm($confirm);
+            $defaults['confirm'] = $confirm;
         }
+
+        $btn->on('click', $executor = new jsEvent($btn, $action, $id, $args), $defaults);
 
         return $this;
     }

--- a/src/Card.php
+++ b/src/Card.php
@@ -328,12 +328,13 @@ class Card extends View
      * as target.
      *
      * @param Generic $action
-     * @param null $button
+     * @param null    $button
      * @param []      $args    The action argument
-     * @param string $confirm The confirmation message.
+     * @param string  $confirm The confirmation message.
+     *
+     * @throws Exception
      *
      * @return Card
-     * @throws Exception
      */
     public function addClickAction(Generic $action, $button = null, $args = [], $confirm = null)
     {

--- a/src/TableColumn/Delete.php
+++ b/src/TableColumn/Delete.php
@@ -23,10 +23,9 @@ class Delete extends Generic
 
     public function getDataCellTemplate(\atk4\data\Field $f = null)
     {
-        $this->table->on('click', 'a.'.$this->short_name)->atkAjaxec([
+        $this->table->on('click', 'a.'.$this->short_name, null, ['confirm' => (new \atk4\ui\jQuery())->attr('title')])->atkAjaxec([
             'uri'         => $this->vp->getJSURL(),
             'uri_options' => [$this->name => $this->table->jsRow()->data('id')],
-            'confirm'     => (new \atk4\ui\jQuery())->attr('title'),
         ]);
 
         return $this->app->getTag(

--- a/src/View.php
+++ b/src/View.php
@@ -1074,7 +1074,6 @@ class View implements jsExpressionable
             }, $arguments);
 
             $actions[] = $cb;
-
         } elseif (is_array($action)) {
             $actions = array_merge($actions, $action);
         } elseif ($action) {

--- a/src/View.php
+++ b/src/View.php
@@ -1081,11 +1081,11 @@ class View implements jsExpressionable
 
         // Do we need confirm action.
         if ($defaults['confirm'] ?? null) {
-            array_unshift($event_stmts, new jsExpression('$.atkConfirm({title:[confirm], onApprove: [action], options: {button:{ok:[ok], cancel:[cancel]}}})', [
+            array_unshift($event_stmts, new jsExpression('$.atkConfirm({message:[confirm], onApprove: [action], options: {button:{ok:[ok], cancel:[cancel]}}, context:this})', [
                                           'confirm' => $defaults['confirm'],
                                           'action'  => new jsFunction($actions),
                                           'ok'      => $defaults['ok'] ?? 'Ok',
-                                          'cancel'  => $defaults['cancel'] ?? 'Cancel'
+                                          'cancel'  => $defaults['cancel'] ?? 'Cancel',
                                       ]));
         } else {
             $event_stmts = array_merge($event_stmts, $actions);

--- a/src/View.php
+++ b/src/View.php
@@ -1022,6 +1022,8 @@ class View implements jsExpressionable
 
         $cb = null;
         $actions = [];
+        $chain = new jQuery();
+        $actions[] = $chain;
 
         // second argument may be omitted
         if (!is_string($selector) && (is_null($action) || is_array($action))) {
@@ -1099,7 +1101,7 @@ class View implements jsExpressionable
             $this->js(true)->on($event, $event_function);
         }
 
-        return new jQuery();
+        return $chain;
     }
 
     /**

--- a/src/View.php
+++ b/src/View.php
@@ -1056,7 +1056,7 @@ class View implements jsExpressionable
                 $urlData = $action;
                 unset($urlData[0]);
                 foreach ($urlData as $a) {
-                    $event_stmts[] = $a;
+                    $actions[] = $a;
                 }
                 $action = $action[0];
             } else {

--- a/src/View.php
+++ b/src/View.php
@@ -1018,7 +1018,11 @@ class View implements jsExpressionable
      */
     public function on($event, $selector = null, $action = null, $defaults = null)
     {
+        $event_stmts = [];
+
         $cb = null;
+        $actions = [];
+
         // second argument may be omitted
         if (!is_string($selector) && (is_null($action) || is_array($action))) {
             $defaults = $action;
@@ -1026,6 +1030,7 @@ class View implements jsExpressionable
             $selector = null;
         }
 
+        // check for arguments.
         $arguments = isset($defaults['args']) ? $defaults['args'] : [];
         if (is_null($defaults)) {
             $defaults = [];
@@ -1039,18 +1044,17 @@ class View implements jsExpressionable
             }
         }
 
-        $actions = [];
-        $actions['preventDefault'] = isset($defaults['preventDefault']) ? $defaults['preventDefault'] : true;
-        $actions['stopPropagation'] = isset($defaults['stopPropagation']) ? $defaults['stopPropagation'] : true;
+        // set event stmts to use preventDefault and/or stopPropagation
+        $event_stmts['preventDefault'] = $defaults['preventDefault'] ?? true;
+        $event_stmts['stopPropagation'] = $defaults['stopPropagation'] ?? true;
 
+        // Dealing with callback action.
         if (is_callable($action) || (is_array($action) && isset($action[0]) && is_callable($action[0]))) {
-            // if callable $action is passed, then execute ajaxec()
-
             if (is_array($action)) {
                 $urlData = $action;
                 unset($urlData[0]);
                 foreach ($urlData as $a) {
-                    $actions[] = $a;
+                    $event_stmts[] = $a;
                 }
                 $action = $action[0];
             } else {
@@ -1068,37 +1072,34 @@ class View implements jsExpressionable
             }, $arguments);
 
             $actions[] = $cb;
-        //$thisAction->api(['on'=>'now', 'url'=>$cb->getJSURL(), 'urlData'=>$urlData, 'obj'=>new jsExpression('this')]);
+
         } elseif (is_array($action)) {
             $actions = array_merge($actions, $action);
         } elseif ($action) {
-            // otherwise include
             $actions[] = $action;
         }
 
-        $chain = new jQuery();
-        $actions[] = $chain;
-
         // Do we need confirm action.
-        if (isset($defaults['confirm']) && $defaults['confirm']) {
-            if (isset($cb)) {
-                $cb->setConfirm($defaults['confirm']);
-            } else {
-                array_unshift($actions,
-                              new jsExpression('if(!confirm([])){return;}', [$defaults['confirm']])
-                );
-            }
+        if ($defaults['confirm'] ?? null) {
+            array_unshift($event_stmts, new jsExpression('$.atkConfirm({title:[confirm], onApprove: [action], options: {button:{ok:[ok], cancel:[cancel]}}})', [
+                                          'confirm' => $defaults['confirm'],
+                                          'action'  => new jsFunction($actions),
+                                          'ok'      => $defaults['ok'] ?? 'Ok',
+                                          'cancel'  => $defaults['cancel'] ?? 'Cancel'
+                                      ]));
+        } else {
+            $event_stmts = array_merge($event_stmts, $actions);
         }
 
-        $action = new jsFunction($actions);
+        $event_function = new jsFunction($event_stmts);
 
         if ($selector) {
-            $this->js(true)->on($event, $selector, $action);
+            $this->js(true)->on($event, $selector, $event_function);
         } else {
-            $this->js(true)->on($event, $action);
+            $this->js(true)->on($event, $event_function);
         }
 
-        return $chain;
+        return new jQuery();
     }
 
     /**


### PR DESCRIPTION
Implementation of confirm dialog using Fomantic UI modal (see ticket fix #763 ). 

Simple use:

``` php
$view->on('click', $actions, ['confirm' => 'Are you sure?']);
```

<img width="571" alt="Screen Shot 2019-07-05 at 3 02 02 PM" src="https://user-images.githubusercontent.com/2204478/60741433-5afc1b80-9f37-11e9-89f0-87dba7f57586.png">
<img width="599" alt="Screen Shot 2019-07-05 at 3 01 19 PM" src="https://user-images.githubusercontent.com/2204478/60741434-5afc1b80-9f37-11e9-8be6-1968c1fbc615.png">


Note: Setting up atkAjaxec manually using confirm will still use the old alert dialog.

Possible workaround:

```
// if your previous code look like below
$table->on('click', 'a.delete')->atkAjaxec(['uri'=>$url, 'confirm'=>'Sure???']);

// change to this one, for using a modal confirmation
$table->on('click', 'a.delete', null, ['confirm'=>'Sure???''])->atkAjaxec(['uri'=>$url]);
```

### Note:
atkjs-ui need rebuild
