### PR TITLE
Allows to add HTML markup in addParagraph

### DIFF
--- a/src/Text.php
+++ b/src/Text.php
@@ -25,14 +25,15 @@ class Text extends View
      * Adds HTML paragraph.
      *
      * @param string $text
+     * @param bool   $allow_html
      *
      * @return $this
      */
-    public function addParagraph($text)
+    public function addParagraph($text, $allow_html = false)
     {
         $this->content .= isset($this->app)
             ? $this->app->getTag('p', $text)
-            : '<p>'.htmlspecialchars($text).'</p>';
+            : '<p>'.($allow_html ? $text : htmlspecialchars($text)).'</p>';
 
         return $this;
     }


### PR DESCRIPTION
I guess sometimes we would like to allow HTML markup in `addParagraph()`.
Important here is to not allow it by default, but if developer is sure controlled HTML is ok there, then why not?