### PR TITLE
refactor to use getFields()

### DIFF
--- a/demos/database.php
+++ b/demos/database.php
@@ -108,8 +108,8 @@ if (!class_exists('Country')) {
             $this->addFields(['project_hours_est', 'project_hours_reported'], ['type' => 'integer']);
 
             $this->addFields(['project_expenses_est', 'project_expenses'], ['type' => 'money']);
-            $this->add(new Percent(), 'project_mgmt_cost_pct');
-            $this->add(new Percent(), 'project_qa_cost_pct');
+            $this->addField('project_mgmt_cost_pct', new Percent());
+            $this->addField('project_qa_cost_pct', new Percent());
 
             $this->addFields(['start_date', 'finish_date'], ['type' => 'date']);
             $this->addField('finish_time', ['type' => 'time']);

--- a/demos/form3.php
+++ b/demos/form3.php
@@ -32,7 +32,7 @@ $form->onSubmit(function ($form) {
     $errors = [];
     foreach ($form->model->dirty as $field => $value) {
         // we should care only about editable fields
-        if ($form->model->getElement($field)->isEditable()) {
+        if ($form->model->getField($field)->isEditable()) {
             $errors[] = $form->error($field, 'Value was changed, '.json_encode($value).' to '.json_encode($form->model[$field]));
         }
     }

--- a/demos/somedatadef.php
+++ b/demos/somedatadef.php
@@ -49,10 +49,8 @@ if (!class_exists('SomeData')) {
         public function export($m, $fields = [])
         {
             if (!$fields) {
-                foreach ($m->elements as $name => $e) {
-                    if ($e instanceof \atk4\data\Field) {
-                        $fields[] = $name;
-                    }
+                foreach ($m->getFields() as $name => $e) {
+                    $fields[] = $name;
                 }
             }
 

--- a/demos/somedatadef.php
+++ b/demos/somedatadef.php
@@ -65,7 +65,7 @@ if (!class_exists('SomeData')) {
                         continue;
                     }
 
-                    $actual = $m->getElement($field)->actual;
+                    $actual = $m->getField($field)->actual;
                     if ($actual) {
                         $type = $actual;
                     }

--- a/demos/table2.php
+++ b/demos/table2.php
@@ -10,7 +10,7 @@ $data = [
 ];
 
 $m = new \atk4\data\Model(new \atk4\data\Persistence_Static($data));
-$m->getElement('amount')->type = 'money';
+$m->getField('amount')->type = 'money';
 
 // ========================================================
 $app->add(['Header', 'Table with various headers', 'subHeader'=>'Demonstrates how you can add subheaders, footnotes and other insertions into your data table', 'icon'=>'table']);

--- a/src/CardTable.php
+++ b/src/CardTable.php
@@ -32,7 +32,7 @@ class CardTable extends Table
             if (!$columndef || ($columndef && in_array($key, $columndef))) {
                 $data[] = [
                     'id'   => $key,
-                    'field'=> $m->getElement($key)->getCaption(),
+                    'field'=> $m->getField($key)->getCaption(),
                     'value'=> $ui_values[$key],
                 ];
             }
@@ -41,7 +41,7 @@ class CardTable extends Table
         $this->_bypass = true;
         $mm = parent::setSource($data);
         $this->addDecorator('value', ['Multiformat', function ($row, $field) use ($m) {
-            $field = $m->getElement($row->data['id']);
+            $field = $m->getField($row->data['id']);
             $ret = $this->decoratorFactory($field);
             if ($ret instanceof \atk4\ui\TableColumn\Money) {
                 $ret->attr['all']['class'] = ['single line'];

--- a/src/Component/InlineEdit.php
+++ b/src/Component/InlineEdit.php
@@ -90,7 +90,7 @@ class InlineEdit extends View
         // Set default validation error handler.
         if (!$this->formatErrorMsg || !is_callable($this->formatErrorMsg)) {
             $this->formatErrorMsg = function ($e, $value) {
-                $caption = $this->model->getElement($this->field)->getCaption();
+                $caption = $this->model->getField($this->field)->getCaption();
 
                 return "{$caption} - {$e->getMessage()}. <br>Trying to set this value: '{$value}'";
             };
@@ -113,7 +113,7 @@ class InlineEdit extends View
                 $value = $_POST['value'] ? $_POST['value'] : null;
                 $this->cb->set(function () use ($value) {
                     try {
-                        $this->model[$this->field] = $this->app->ui_persistence->typecastLoadField($this->model->getElement($this->field), $value);
+                        $this->model[$this->field] = $this->app->ui_persistence->typecastLoadField($this->model->getField($this->field), $value);
                         $this->model->save();
 
                         return $this->jsSuccess('Update successfully');

--- a/src/Component/InlineEdit.php
+++ b/src/Component/InlineEdit.php
@@ -192,7 +192,7 @@ class InlineEdit extends View
     {
         parent::renderView();
 
-        $type = ($this->model && $this->field) ? $this->model->elements[$this->field]->type : 'text';
+        $type = ($this->model && $this->field) ? $this->model->getField($this->field)->type : 'text';
         $type = ($type === 'string') ? 'text' : $type;
 
         if ($type != 'text' && $type != 'number') {

--- a/src/FormField/Lookup.php
+++ b/src/FormField/Lookup.php
@@ -236,7 +236,7 @@ class Lookup extends Input
      */
     public function addFilter($field, $label = null)
     {
-        if (!$this->model->hasElement($field) instanceof \atk4\data\Field) {
+        if (!$this->model->hasField($field)) {
             throw new \atk4\ui\Exception([
                 'Unable to filter by non-existant field',
                 'field'=> $field,

--- a/src/FormField/MultiLine.php
+++ b/src/FormField/MultiLine.php
@@ -534,18 +534,7 @@ class MultiLine extends Generic
      */
     protected function getModelFields(\atk4\data\Model $model)
     {
-        $fields = [];
-        foreach ($model->elements as $f) {
-            if (!$f instanceof \atk4\data\Field) {
-                continue;
-            }
-
-            if ($f->isEditable() || $f->isVisible()) {
-                $fields[] = $f->short_name;
-            }
-        }
-
-        return $fields;
+        return array_keys($model->getFields('not system'));
     }
 
     public function renderView()
@@ -719,7 +708,7 @@ class MultiLine extends Generic
     private function getExpressionFields($model)
     {
         $fields = [];
-        foreach ($model->elements as $f) {
+        foreach ($model->getFields() as $f) {
             if (!$f instanceof Field_SQL_Expression || !in_array($f->short_name, $this->rowFields)) {
                 continue;
             }

--- a/src/FormField/MultiLine.php
+++ b/src/FormField/MultiLine.php
@@ -276,7 +276,7 @@ class MultiLine extends Generic
             foreach ($m as $id => $row) {
                 $d_row = [];
                 foreach ($this->rowFields as $fieldName) {
-                    $field = $m->getElement($fieldName);
+                    $field = $m->getField($fieldName);
                     if ($field->isEditable()) {
                         $value = $row->get($field);
                     } else {
@@ -315,7 +315,7 @@ class MultiLine extends Generic
                 $value = $col[$fieldName];
 
                 try {
-                    $field = $m->getElement($fieldName);
+                    $field = $m->getField($fieldName);
                     // save field value only if field was editable in form at all
                     if (!$field->read_only) {
                         $m[$fieldName] = $this->app->ui_persistence->typecastLoadField($field, $value);
@@ -371,7 +371,7 @@ class MultiLine extends Generic
                     $model->load($value);
                 }
 
-                $field = $model->getElement($fieldName);
+                $field = $model->getField($fieldName);
 
                 if ($field->isEditable()) {
                     $field->set($value);
@@ -476,8 +476,8 @@ class MultiLine extends Generic
     public function setModel(\atk4\data\Model $model, $fields = [], $modelRef = null, $linkField = null)
     {
         //remove our self from model
-        if ($model->hasElement($this->short_name)) {
-            $model->getElement($this->short_name)->never_persist = true;
+        if ($model->hasField($this->short_name)) {
+            $model->getField($this->short_name)->never_persist = true;
         }
         $m = parent::setModel($model);
 
@@ -496,7 +496,7 @@ class MultiLine extends Generic
         $this->rowFields = array_merge([$m->id_field], $fields);
 
         foreach ($this->rowFields as $fieldName) {
-            $field = $m->getElement($fieldName);
+            $field = $m->getField($fieldName);
 
             if (!$field instanceof \atk4\data\Field) {
                 continue;
@@ -619,7 +619,7 @@ class MultiLine extends Generic
             if ($fieldName === $model->id_field) {
                 continue;
             }
-            $field = $model->getElement($fieldName);
+            $field = $model->getField($fieldName);
             if ($field instanceof Callback) {
                 $value = call_user_func($field->expr, $model);
                 $values[$fieldName] = $this->app->ui_persistence->_typecastSaveField($field, $value);
@@ -646,7 +646,7 @@ class MultiLine extends Generic
             }
 
             $value = isset($post[$fieldName]) ? $post[$fieldName] : null;
-            if ($model->getElement($fieldName)->isEditable()) {
+            if ($model->getField($fieldName)->isEditable()) {
                 try {
                     $model[$fieldName] = $value;
                 } catch (ValidationException $e) {
@@ -683,13 +683,13 @@ class MultiLine extends Generic
         if (!empty($dummyFields)) {
             $dummyModel = new Model($m->persistence, ['table' => $m->table]);
             foreach ($dummyFields as $f) {
-                $dummyModel->addExpression($f['name'], ['expr'=>$f['expr'], 'type' => $m->getElement($f['name'])->type]);
+                $dummyModel->addExpression($f['name'], ['expr'=>$f['expr'], 'type' => $m->getField($f['name'])->type]);
             }
             $values = $dummyModel->loadAny()->get();
             unset($values[$m->id_field]);
 
             foreach ($values as $f => $value) {
-                $field = $m->getElement($f);
+                $field = $m->getField($f);
                 $formatValues[$f] = $this->app->ui_persistence->_typecastSaveField($field, $value);
             }
         }
@@ -741,7 +741,7 @@ class MultiLine extends Generic
 
         foreach ($matches[0] as $match) {
             $fieldName = substr($match, 1, -1);
-            $field = $model->getElement($fieldName);
+            $field = $model->getField($fieldName);
             if ($field instanceof Field_SQL_Expression) {
                 $expr = str_replace($match, $this->getDummyExpression($field, $model), $expr);
             } else {

--- a/src/FormLayout/_Abstract.php
+++ b/src/FormLayout/_Abstract.php
@@ -119,18 +119,7 @@ abstract class _Abstract extends \atk4\ui\View
      */
     protected function getModelFields(\atk4\data\Model $model)
     {
-        $fields = [];
-        foreach ($model->elements as $f) {
-            if (!$f instanceof \atk4\data\Field) {
-                continue;
-            }
-
-            if ($f->isEditable() || $f->isVisible()) {
-                $fields[] = $f->short_name;
-            }
-        }
-
-        return $fields;
+        return array_keys($model->getFields('editable'));
     }
 
     /**

--- a/src/FormLayout/_Abstract.php
+++ b/src/FormLayout/_Abstract.php
@@ -41,7 +41,7 @@ abstract class _Abstract extends \atk4\ui\View
         }
 
         if ($name) {
-            $existingField = $this->form->model->hasElement($name);
+            $existingField = $this->form->model->hasField($name);
         }
 
         try {
@@ -145,7 +145,7 @@ abstract class _Abstract extends \atk4\ui\View
         // prepare array of fields - check if fields are editable or read_only/disabled
         $add_fields = [];
         foreach ($fields as $field) {
-            $f = $model->getElement($field);
+            $f = $model->getField($field);
 
             if ($f->isEditable()) {
                 $add_fields[] = [$f->short_name];

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -525,7 +525,7 @@ class Grid extends View
         if (
             $sortBy
             && isset($this->table->columns[$sortBy])
-            && $this->model->hasElement($sortBy) instanceof \atk4\data\Field
+            && $this->model->hasField($sortBy)
         ) {
             $this->model->setOrder($sortBy, $desc);
             $this->table->sort_by = $sortBy;

--- a/src/Persistence/POST.php
+++ b/src/Persistence/POST.php
@@ -11,11 +11,7 @@ class POST extends \atk4\data\Persistence
         // carefully copy stuff from $_POST into the model
         $data = [];
 
-        foreach ($m->elements as $field => $def) {
-            if (!$def instanceof \atk4\data\Field) {
-                continue;
-            }
-
+        foreach ($m->getFields() as $field => $def) {
             if ($def->type === 'boolean') {
                 $data[$field] = isset($_POST[$field]);
                 continue;

--- a/src/Persistence/UI.php
+++ b/src/Persistence/UI.php
@@ -170,7 +170,7 @@ class UI extends \atk4\data\Persistence
         foreach ($row as $key => $value) {
 
             // Look up field object
-            $f = $m->hasElement($key);
+            $f = $m->hasField($key);
 
             // Figure out the name of the destination field
             $field = $key;

--- a/src/Table.php
+++ b/src/Table.php
@@ -269,7 +269,7 @@ class Table extends Lister
 
         // set filter to all column when null.
         if (!$cols) {
-            foreach ($this->model->elements as $key => $field) {
+            foreach ($this->model->getFields() as $key => $field) {
                 if (isset($this->columns[$key]) && $this->columns[$key]) {
                     $cols[] = $field->short_name;
                 }
@@ -451,16 +451,7 @@ class Table extends Lister
         parent::setModel($m);
 
         if ($columns === null) {
-            $columns = [];
-            foreach ($m->elements as $name => $element) {
-                if (!$element instanceof \atk4\data\Field) {
-                    continue;
-                }
-
-                if ($element->isVisible()) {
-                    $columns[] = $name;
-                }
-            }
+            $columns = array_keys($m->getFields('visible'));
         } elseif ($columns === false) {
             return $this->model;
         }

--- a/src/Table.php
+++ b/src/Table.php
@@ -197,7 +197,7 @@ class Table extends Lister
         }
 
         if (is_string($name) && $name) {
-            $existingField = $this->model->hasElement($name);
+            $existingField = $this->model->hasField($name);
         } else {
             $existingField = null;
         }
@@ -280,7 +280,7 @@ class Table extends Lister
         foreach ($cols as $colName) {
             $col = $this->columns[$colName];
             if ($col) {
-                $pop = $col->addPopup(new FilterPopup(['field' => $this->model->getElement($colName), 'reload' => $this->reload, 'colTrigger' => '#'.$col->name.'_ac']));
+                $pop = $col->addPopup(new FilterPopup(['field' => $this->model->getField($colName), 'reload' => $this->reload, 'colTrigger' => '#'.$col->name.'_ac']));
                 $pop->isFilterOn() ? $col->setHeaderPopupIcon('green caret square down') : null;
                 $pop->form->onSubmit(function ($f) use ($pop) {
                     return new jsReload($this->reload);
@@ -550,7 +550,7 @@ class Table extends Lister
                 if (!is_array($columns)) {
                     $columns = [$columns];
                 }
-                $field = $this->model->hasElement($name);
+                $field = $this->model->hasField($name);
                 foreach ($columns as $column) {
                     if (!method_exists($column, 'getHTMLTags')) {
                         continue;
@@ -676,7 +676,7 @@ class Table extends Lister
             }
 
             if (!is_int($name)) {
-                $field = $this->model->getElement($name);
+                $field = $this->model->getField($name);
 
                 $output[] = $column->getHeaderCellHTML($field);
             } else {
@@ -706,7 +706,7 @@ class Table extends Lister
             // if totals plan is set as array, then show formatted value
             if (is_array($this->totals_plan[$name])) {
                 // todo - format
-                $field = $this->model->getElement($name);
+                $field = $this->model->getField($name);
                 $output[] = $column->getTotalsCellHTML($field, $this->totals[$name]);
                 continue;
             }
@@ -731,7 +731,7 @@ class Table extends Lister
             // If multiple formatters are defined, use the first for the header cell
 
             if (!is_int($name)) {
-                $field = $this->model->getElement($name);
+                $field = $this->model->getField($name);
             } else {
                 $field = null;
             }

--- a/src/TableColumn/FilterModel/TypeDate.php
+++ b/src/TableColumn/FilterModel/TypeDate.php
@@ -82,13 +82,13 @@ class TypeDate extends Generic
                     $d1 = $this->getDate($filter['value']);
                     $d2 = $this->getDate($filter['range']);
                     if ($d2 >= $d1) {
-                        $value = $m->persistence->typecastSaveField($m->getElement($filter['name']), $d1);
-                        $value2 = $m->persistence->typecastSaveField($m->getElement($filter['name']), $d2);
+                        $value = $m->persistence->typecastSaveField($m->getField($filter['name']), $d1);
+                        $value2 = $m->persistence->typecastSaveField($m->getField($filter['name']), $d2);
                     } else {
-                        $value = $m->persistence->typecastSaveField($m->getElement($filter['name']), $d2);
-                        $value2 = $m->persistence->typecastSaveField($m->getElement($filter['name']), $d1);
+                        $value = $m->persistence->typecastSaveField($m->getField($filter['name']), $d2);
+                        $value2 = $m->persistence->typecastSaveField($m->getField($filter['name']), $d1);
                     }
-                    $m->addCondition($m->expr('[field] between [value] and [value2]', ['field' => $m->getElement($filter['name']), 'value' => $value, 'value2' => $value2]));
+                    $m->addCondition($m->expr('[field] between [value] and [value2]', ['field' => $m->getField($filter['name']), 'value' => $value, 'value2' => $value2]));
                     break;
                 default:
                     $m->addCondition($filter['name'], $filter['op'], $this->getDate($filter['value']));

--- a/src/TableColumn/FilterModel/TypeDatetime.php
+++ b/src/TableColumn/FilterModel/TypeDatetime.php
@@ -82,27 +82,27 @@ class TypeDatetime extends Generic
                     $d1 = $this->getDatetime($filter['value'])->setTime(0, 0, 0);
                     $d2 = $this->getDatetime($filter['range'])->setTime(23, 59, 59);
                     if ($d2 >= $d1) {
-                        $value = $m->persistence->typecastSaveField($m->getElement($filter['name']), $d1);
-                        $value2 = $m->persistence->typecastSaveField($m->getElement($filter['name']), $d2);
+                        $value = $m->persistence->typecastSaveField($m->getField($filter['name']), $d1);
+                        $value2 = $m->persistence->typecastSaveField($m->getField($filter['name']), $d2);
                     } else {
-                        $value = $m->persistence->typecastSaveField($m->getElement($filter['name']), $d2);
-                        $value2 = $m->persistence->typecastSaveField($m->getElement($filter['name']), $d1);
+                        $value = $m->persistence->typecastSaveField($m->getField($filter['name']), $d2);
+                        $value2 = $m->persistence->typecastSaveField($m->getField($filter['name']), $d1);
                     }
-                    $m->addCondition($m->expr('[field] between [value] and [value2]', ['field' => $m->getElement($filter['name']), 'value' => $value, 'value2' => $value2]));
+                    $m->addCondition($m->expr('[field] between [value] and [value2]', ['field' => $m->getField($filter['name']), 'value' => $value, 'value2' => $value2]));
                     break;
                 case '!=':
                 case '=':
                     $d1 = $this->getDatetime($filter['value'])->setTime(0, 0, 0);
                     $d2 = $this->getDatetime($filter['value'])->setTime(23, 59, 59);
                     if ($d2 >= $d1) {
-                        $value = $m->persistence->typecastSaveField($m->getElement($filter['name']), $d1);
-                        $value2 = $m->persistence->typecastSaveField($m->getElement($filter['name']), $d2);
+                        $value = $m->persistence->typecastSaveField($m->getField($filter['name']), $d1);
+                        $value2 = $m->persistence->typecastSaveField($m->getField($filter['name']), $d2);
                     } else {
-                        $value = $m->persistence->typecastSaveField($m->getElement($filter['name']), $d2);
-                        $value2 = $m->persistence->typecastSaveField($m->getElement($filter['name']), $d1);
+                        $value = $m->persistence->typecastSaveField($m->getField($filter['name']), $d2);
+                        $value2 = $m->persistence->typecastSaveField($m->getField($filter['name']), $d1);
                     }
                     $between_condition = $filter['op'] == '!=' ? 'not between' : 'between';
-                    $m->addCondition($m->expr("[field] {$between_condition} [value] and [value2]", ['field' => $m->getElement($filter['name']), 'value' => $value, 'value2' => $value2]));
+                    $m->addCondition($m->expr("[field] {$between_condition} [value] and [value2]", ['field' => $m->getField($filter['name']), 'value' => $value, 'value2' => $value2]));
                     break;
                 case '>':
                 case '<=':

--- a/src/TableColumn/FilterModel/TypeNumber.php
+++ b/src/TableColumn/FilterModel/TypeNumber.php
@@ -30,7 +30,7 @@ class TypeNumber extends Generic
             switch ($filter['op']) {
                 case 'between':
                     $m->addCondition(
-                        $m->expr('[field] between [value] and [range]', ['field' => $m->getElement($filter['name']), 'value' => $filter['value'], 'range' => $filter['range']])
+                        $m->expr('[field] between [value] and [range]', ['field' => $m->getField($filter['name']), 'value' => $filter['value'], 'range' => $filter['range']])
                     );
                     break;
                 default:

--- a/src/TableColumn/FilterModel/TypeTime.php
+++ b/src/TableColumn/FilterModel/TypeTime.php
@@ -32,13 +32,13 @@ class TypeTime extends Generic
                     $d1 = $filter['value'];
                     $d2 = $filter['range'];
                     if ($d2 >= $d1) {
-                        $value = $m->persistence->typecastSaveField($m->getElement($filter['name']), $d1);
-                        $value2 = $m->persistence->typecastSaveField($m->getElement($filter['name']), $d2);
+                        $value = $m->persistence->typecastSaveField($m->getField($filter['name']), $d1);
+                        $value2 = $m->persistence->typecastSaveField($m->getField($filter['name']), $d2);
                     } else {
-                        $value = $m->persistence->typecastSaveField($m->getElement($filter['name']), $d2);
-                        $value2 = $m->persistence->typecastSaveField($m->getElement($filter['name']), $d1);
+                        $value = $m->persistence->typecastSaveField($m->getField($filter['name']), $d2);
+                        $value2 = $m->persistence->typecastSaveField($m->getField($filter['name']), $d1);
                     }
-                    $m->addCondition($m->expr('[field] between [value] and [value2]', ['field' => $m->getElement($filter['name']), 'value' => $value, 'value2' => $value2]));
+                    $m->addCondition($m->expr('[field] between [value] and [value2]', ['field' => $m->getField($filter['name']), 'value' => $value, 'value2' => $value2]));
                     break;
                 default:
                     $m->addCondition($filter['name'], $filter['op'], $filter['value']);

--- a/src/TableColumn/Link.php
+++ b/src/TableColumn/Link.php
@@ -156,7 +156,7 @@ class Link extends Generic
                 $key = $val;
             }
 
-            if ($row->hasElement($val)) {
+            if ($row->hasField($val)) {
                 $p[$key] = $row[$val];
             }
         }


### PR DESCRIPTION
atk4\data (`develop`, v2 branch) is now expects you to use `$model->getFields()`. I have refactored by removing any uses of $model->elements directly (except when it's used with a View).