### PR TITLE
 Let user overwrite all calendar options

### DIFF
--- a/src/FormField/Calendar.php
+++ b/src/FormField/Calendar.php
@@ -71,6 +71,12 @@ class Calendar extends Input
             $this->options['firstDayOfWeek'] = $dayOfWeek;
         }
 
+		if ($options = $this->app->ui_persistence->options) {
+			foreach ($options as $k => $v) {
+				$this->options[$k] = $v;
+			}
+		}
+
         $this->js(true)->calendar($this->options);
 
         parent::renderView();

--- a/src/FormField/Calendar.php
+++ b/src/FormField/Calendar.php
@@ -71,11 +71,11 @@ class Calendar extends Input
             $this->options['firstDayOfWeek'] = $dayOfWeek;
         }
 
-		if ($options = $this->app->ui_persistence->options) {
-			foreach ($options as $k => $v) {
-				$this->options[$k] = $v;
-			}
-		}
+        if ($options = $this->app->ui_persistence->options) {
+            foreach ($options as $k => $v) {
+                $this->options[$k] = $v;
+            }
+        }
 
         $this->js(true)->calendar($this->options);
 

--- a/src/FormField/Calendar.php
+++ b/src/FormField/Calendar.php
@@ -25,7 +25,7 @@ class Calendar extends Input
 
     /**
      * Any other options you'd like to pass to calendar JS.
-     * See https://github.com/mdehoog/Semantic-UI-Calendar for all possible options.
+     * See https://fomantic-ui.com/modules/calendar.html#/settings for all possible options.
      */
     public $options = [];
 
@@ -71,7 +71,7 @@ class Calendar extends Input
             $this->options['firstDayOfWeek'] = $dayOfWeek;
         }
 
-        if ($options = $this->app->ui_persistence->options) {
+        if ($options = $this->app->ui_persistence->calendar_options) {
             foreach ($options as $k => $v) {
                 $this->options[$k] = $v;
             }

--- a/src/Persistence/UI.php
+++ b/src/Persistence/UI.php
@@ -36,7 +36,6 @@ class UI extends \atk4\data\Persistence
 
     public $yes = 'Yes';
     public $no = 'No';
-    
     public $calendar_options = [];
 
     /**

--- a/src/Persistence/UI.php
+++ b/src/Persistence/UI.php
@@ -37,7 +37,7 @@ class UI extends \atk4\data\Persistence
     public $yes = 'Yes';
     public $no = 'No';
     
-    public $calendar_options = array();
+    public $calendar_options = [];
 
     /**
      * This method contains the logic of casting generic values into user-friendly format.

--- a/src/Persistence/UI.php
+++ b/src/Persistence/UI.php
@@ -36,6 +36,8 @@ class UI extends \atk4\data\Persistence
 
     public $yes = 'Yes';
     public $no = 'No';
+    
+    public $options = array();
 
     /**
      * This method contains the logic of casting generic values into user-friendly format.

--- a/src/Persistence/UI.php
+++ b/src/Persistence/UI.php
@@ -36,6 +36,7 @@ class UI extends \atk4\data\Persistence
 
     public $yes = 'Yes';
     public $no = 'No';
+
     public $calendar_options = [];
 
     /**

--- a/src/Persistence/UI.php
+++ b/src/Persistence/UI.php
@@ -37,7 +37,7 @@ class UI extends \atk4\data\Persistence
     public $yes = 'Yes';
     public $no = 'No';
     
-    public $options = array();
+    public $calendar_options = array();
 
     /**
      * This method contains the logic of casting generic values into user-friendly format.


### PR DESCRIPTION
User will be able to overwrite all options mentioned here ( https://github.com/mdehoog/Semantic-UI-Calendar ) in an easier, more intuitive way by extending UI persistence like that:

```
class UI extends \atk4\ui\Persistence\UI
{
    public $date_format = 'd.m.Y';

    public $time_format = 'H:i';

    public $datetime_format = 'd.m.Y H:i:s';
    // 'D, d M Y H:i:s O';

    /**
     * Calendar input first day of week.
     *  0 = sunday;.
     *
     * @var int
     */
    public $firstDayOfWeek = 1;

    public $currency = '€';

	public $yes = 'Ja';
	public $no = 'Nein';

	public $options = array('today' => true,
							'monthFirst' => false,
							'touchReadonly' => true,
							'startMode' => year,
							'ampm' => false,
							'formatInput' => true,
							'multiMonth' => 1,

							'text' => array(
								'days' => ['S', 'M', 'D', 'M', 'D', 'F', 'S'],
								'months' => ['Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember'],
								'monthsShort' => ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
								'today' => 'Heute',
								'now' => 'Jetzt',
								'am' => 'AM',
								'pm' => 'PM')
						);
}
```