### PR TITLE
Fix #651 - Modal fails on js load if a php exception is thrown

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,11 +62,11 @@ before_script:
 
 after_script:
     - echo $TRAVIS_BRANCH
-      #- if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.1" ]]; then echo "Sending coverage report"; vendor/bin/test-reporter --coverage-report clover.xml; fi
-      #- if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.1" ]]; then echo "Sending codecov report"; TRAVIS_CMD="" bash <(curl -s https://codecov.io/bash) -f clover.xml; fi
+    - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then echo "Sending coverage report"; vendor/bin/test-reporter --coverage-report clover.xml; fi
+    - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then echo "Sending codecov report"; TRAVIS_CMD="" bash <(curl -s https://codecov.io/bash) -f clover.xml; fi
 
 script:
-    - if [[ ${TRAVIS_PHP_VERSION:0:3} != "7.1" ]]; then NC="--no-coverage"; fi
+    - if [[ ${TRAVIS_PHP_VERSION:0:3} != "7.2" ]]; then NC="--no-coverage"; fi
     - ./vendor/phpunit/phpunit/phpunit $NC #- wget -O - http://localhost:8888/demos/button2.php 
     - bash tools/test.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,8 @@ before_script:
     - wget  https://selenium-release.storage.googleapis.com/${SELENIUM_MAJ_VER}/${SELENIUM_JAR}
     - java -jar ${SELENIUM_JAR} > /dev/null 2>&1 &
 
-    - wget -N http://chromedriver.storage.googleapis.com/2.44/chromedriver_linux64.zip -P ~/
+    # Setup chromedriver
+    - wget http://chromedriver.storage.googleapis.com/${CHROME_DRIVER_VER}/chromedriver_linux64.zip -P ~/
     - unzip ~/chromedriver_linux64.zip -d ~/
     - rm ~/chromedriver_linux64.zip
     - sudo mv -f ~/chromedriver /usr/local/share/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,12 @@ services:
     - mysql
     - xvfb
 
+env:
+  global:
+    - SELENIUM_MAJ_VER=3.141
+    - SELENIUM_VER=${SELENIUM_MAJ_VER}.59
+    - SELENIUM_JAR=selenium-server-standalone-${SELENIUM_VER}.jar
+    - CHROME_DRIVER_VER=75.0.3770.90
 
 addons:
   apt:
@@ -27,9 +33,10 @@ before_script:
 
      #- "sh -e /etc/init.d/xvfb start"
      #- "export DISPLAY=:99.0"
-    - "wget http://selenium-release.storage.googleapis.com/2.43/selenium-server-standalone-2.43.1.jar"
-    - "java -jar selenium-server-standalone-2.43.1.jar > /dev/null 2>/dev/null &"
 
+    # Setup selenium
+    - wget  https://selenium-release.storage.googleapis.com/${SELENIUM_MAJ_VER}/${SELENIUM_JAR}
+    - java -jar ${SELENIUM_JAR} > /dev/null 2>&1 &
 
     - wget -N http://chromedriver.storage.googleapis.com/2.44/chromedriver_linux64.zip -P ~/
     - unzip ~/chromedriver_linux64.zip -d ~/
@@ -54,8 +61,8 @@ before_script:
 
 after_script:
     - echo $TRAVIS_BRANCH
-    - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.1" ]]; then echo "Sending coverage report"; vendor/bin/test-reporter --coverage-report clover.xml; fi
-    - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.1" ]]; then echo "Sending codecov report"; TRAVIS_CMD="" bash <(curl -s https://codecov.io/bash) -f clover.xml; fi
+      #- if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.1" ]]; then echo "Sending coverage report"; vendor/bin/test-reporter --coverage-report clover.xml; fi
+      #- if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.1" ]]; then echo "Sending codecov report"; TRAVIS_CMD="" bash <(curl -s https://codecov.io/bash) -f clover.xml; fi
 
 script:
     - if [[ ${TRAVIS_PHP_VERSION:0:3} != "7.1" ]]; then NC="--no-coverage"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     - SELENIUM_MAJ_VER=3.141
     - SELENIUM_VER=${SELENIUM_MAJ_VER}.59
     - SELENIUM_JAR=selenium-server-standalone-${SELENIUM_VER}.jar
-    - CHROME_DRIVER_VER=75.0.3770.90
+    - CHROME_DRIVER_VER=2.44
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
 
 services:
     - mysql
+    - xvfb
 
 
 addons:
@@ -15,7 +16,7 @@ addons:
     packages:
       - google-chrome-stable
 install:
-  - export DISPLAY=':99'
+  #- export DISPLAY=':99'
   - Xvfb :99 -screen 0 1280x1024x16 +extension RANDR > /dev/null 2>&1 &
 
 before_install:
@@ -24,8 +25,8 @@ before_install:
 
 before_script:
 
-    - "sh -e /etc/init.d/xvfb start"
-    - "export DISPLAY=:99.0"
+     #- "sh -e /etc/init.d/xvfb start"
+     #- "export DISPLAY=:99.0"
     - "wget http://selenium-release.storage.googleapis.com/2.43/selenium-server-standalone-2.43.1.jar"
     - "java -jar selenium-server-standalone-2.43.1.jar > /dev/null 2>/dev/null &"
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "require": {
         "atk4/data": "dev-develop",
         "atk4/core": "dev-develop",
-        "php": ">=7.2.0"
+        "php": ">=7.2.0",
+        "ext-json": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "<6",

--- a/demos/console.php
+++ b/demos/console.php
@@ -2,23 +2,26 @@
 
 require 'init.php';
 
-class Test extends \atk4\data\Model
-{
-    use \atk4\core\DebugTrait;
+if (!class_exists('TestConsole')) {
 
-    public function generateReport()
+    class TestConsole extends \atk4\data\Model
     {
-        $this->log('info', 'Console will automatically pick up output from all DebugTrait objects');
-        $this->debug('debug {foo}', ['foo'=>'bar']);
-        $this->emergency('emergency {foo}', ['foo'=>'bar']);
-        $this->alert('alert {foo}', ['foo'=>'bar']);
-        $this->critical('critical {foo}', ['foo'=>'bar']);
-        $this->error('error {foo}', ['foo'=>'bar']);
-        $this->warning('warning {foo}', ['foo'=>'bar']);
-        $this->notice('notice {foo}', ['foo'=>'bar']);
-        $this->info('info {foo}', ['foo'=>'bar']);
+        use \atk4\core\DebugTrait;
 
-        return 123;
+        public function generateReport()
+        {
+            $this->log('info', 'Console will automatically pick up output from all DebugTrait objects');
+            $this->debug('debug {foo}', ['foo' => 'bar']);
+            $this->emergency('emergency {foo}', ['foo' => 'bar']);
+            $this->alert('alert {foo}', ['foo' => 'bar']);
+            $this->critical('critical {foo}', ['foo' => 'bar']);
+            $this->error('error {foo}', ['foo' => 'bar']);
+            $this->warning('warning {foo}', ['foo' => 'bar']);
+            $this->notice('notice {foo}', ['foo' => 'bar']);
+            $this->info('info {foo}', ['foo' => 'bar']);
+
+            return 123;
+        }
     }
 }
 
@@ -38,7 +41,7 @@ $t->add('Console')->set(function ($console) {
     sleep(1);
     echo 'direct output is captured';
 
-    throw new \atk4\data\Exception('BOOM - exceptions are caught');
+    throw new \atk4\core\Exception('BOOM - exceptions are caught');
 });
 
 $t = $tt->addTab('runMethod()', function ($t) {
@@ -48,7 +51,7 @@ $t = $tt->addTab('runMethod()', function ($t) {
         'Non-interractive method invocation',
         'subHeader'=> 'console can invoke a method, which normaly would be non-interractive and can still capture debug output',
     ]);
-    $t->add('Console')->runMethod($t->add(new Test()), 'generateReport');
+    $t->add('Console')->runMethod($t->add(new TestConsole()), 'generateReport');
 });
 
 $t = $tt->addTab('exec() single', function ($t) {
@@ -116,6 +119,8 @@ $t = $tt->addTab('Use after form submit', function ($t) {
         $m = $_SESSION['data'];
         $c->output('Executing process...');
         $c->info(var_export($m->get(), true));
+        sleep(1);
+        $c->output('Wait...');
         sleep(3);
         $c->output('Process finished');
     });

--- a/demos/console.php
+++ b/demos/console.php
@@ -3,7 +3,6 @@
 require 'init.php';
 
 if (!class_exists('TestConsole')) {
-
     class TestConsole extends \atk4\data\Model
     {
         use \atk4\core\DebugTrait;

--- a/demos/database.php
+++ b/demos/database.php
@@ -5,7 +5,7 @@ try {
     if (file_exists('db.php')) {
         include 'db.php';
     } else {
-        $db = new \atk4\data\Persistence_SQL('mysql:dbname=atk4;host=localhost', 'root', 'root');
+        $db = new \atk4\data\Persistence\SQL('mysql:dbname=atk4;host=localhost', 'root', 'root');
     }
 } catch (PDOException $e) {
     throw new \atk4\ui\Exception([

--- a/demos/db.example.php
+++ b/demos/db.example.php
@@ -1,3 +1,3 @@
 <?php
 
-$db = new \atk4\data\Persistence_SQL('mysql:dbname=atk4;host=localhost', 'user', 'secret');
+$db = new \atk4\data\Persistence\SQL('mysql:dbname=atk4;host=localhost', 'user', 'secret');

--- a/demos/popup.php
+++ b/demos/popup.php
@@ -260,4 +260,4 @@ $i_pop->add('View')->set('You can use this field to search data.');
 $button = $app->add(['Button', null, 'icon'=>'volume down']);
 $b_pop = $app->add(['Popup', $button, 'triggerOn'=>'hover'])->setHoverable();
 
-$b_pop->add(['FormField\CheckBox', 'Just On/Off', 'slider'])->on('change', $button->js()->find('.icon')->toggleClass('up down'));
+$b_pop->add(['FormField/CheckBox', 'Just On/Off', 'slider'])->on('change', $button->js()->find('.icon')->toggleClass('up down'));

--- a/demos/sse.php
+++ b/demos/sse.php
@@ -12,7 +12,10 @@ $button = $app->add(['Button', 'Turn On']);
 
 $sse = $app->add(['jsSSE', 'showLoader' => true]);
 
-$button->on('click', $sse->set(function () use ($sse, $bar) {
+$button->on('click', $sse->set(function () use ($button, $sse, $bar) {
+
+    $sse->send($button->js()->addClass('disabled'));
+
     $sse->send($bar->jsValue(20));
     sleep(1);
     $sse->send($bar->jsValue(40));
@@ -23,5 +26,8 @@ $button->on('click', $sse->set(function () use ($sse, $bar) {
     sleep(1);
 
     // non-SSE way
-    return $bar->jsValue(100);
+    return [
+        $bar->jsValue(100),
+        $button->js()->removeClass('disabled')
+    ];
 }));

--- a/demos/sse.php
+++ b/demos/sse.php
@@ -28,6 +28,6 @@ $button->on('click', $sse->set(function () use ($button, $sse, $bar) {
     // non-SSE way
     return [
         $bar->jsValue(100),
-        $button->js()->removeClass('disabled')
+        $button->js()->removeClass('disabled'),
     ];
 }));

--- a/demos/sse.php
+++ b/demos/sse.php
@@ -13,7 +13,6 @@ $button = $app->add(['Button', 'Turn On']);
 $sse = $app->add(['jsSSE', 'showLoader' => true]);
 
 $button->on('click', $sse->set(function () use ($button, $sse, $bar) {
-
     $sse->send($button->js()->addClass('disabled'));
 
     $sse->send($bar->jsValue(20));

--- a/demos/wizard.php
+++ b/demos/wizard.php
@@ -37,7 +37,7 @@ $t->addStep(['Select Model', 'description'=>'"Country" or "Stat"', 'icon'=>'tabl
     if (isset($_GET['name'])) {
         $p->memorize('model', $_GET['name']);
         header('Location: '.$p->urlNext());
-        exit;
+        $p->app->terminate();
     }
 
     $c = $p->add('Columns');

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,6 +4,7 @@
         <var name="DB_USER" value="travis" />
         <var name="DB_PASSWD" value="" />
         <var name="DB_DBNAME" value="dsql_test" />
+        <var name="UNIT_TESTING" value="1" />
     </php>
     <filter>
         <blacklist>

--- a/src/App.php
+++ b/src/App.php
@@ -182,9 +182,13 @@ class App
 
         // Set our exception handler
         if ($this->catch_exceptions) {
-            set_exception_handler(function ($exception) {
-                return $this->caughtException($exception);
-            });
+            set_exception_handler(Closure::fromCallable([$this,'caughtException']));
+            set_error_handler(
+                function($err_severity, $err_msg, $err_file, $err_line, array $err_context) {
+                    throw new ErrorException($err_msg, 0, $err_severity, $err_file, $err_line);
+                },
+                E_ALL
+            );
         }
 
         if (!$this->_initialized) {

--- a/src/App.php
+++ b/src/App.php
@@ -189,7 +189,7 @@ class App
                 function ($err_severity, $err_msg, $err_file, $err_line, array $err_context) {
                     throw new ErrorException($err_msg, 0, $err_severity, $err_file, $err_line);
                 },
-                E_ALL
+                E_ALL & ~E_NOTICE
             );
         }
 
@@ -205,9 +205,11 @@ class App
     }
 
     /**
+     * @param bool $from_shutdown
+     * @throws ExitApplicationException
      * @throws \atk4\core\Exception
      */
-    public function callExit()
+    public function callExit($from_shutdown = false)
     {
         if (!$this->exit_called) {
             $this->exit_called = true;
@@ -235,7 +237,7 @@ class App
      *
      * @return bool
      */
-    public function caughtException(Throwable $exception)
+    protected function caughtException(Throwable $exception)
     {
         $this->catch_runaway_callbacks = false;
 
@@ -920,7 +922,7 @@ class App
                     }
                 }
 
-                $this->callExit();
+                $this->callExit(true);
             }
         );
     }

--- a/src/App.php
+++ b/src/App.php
@@ -9,6 +9,7 @@ use atk4\core\FactoryTrait;
 use atk4\core\HookTrait;
 use atk4\core\InitializerTrait;
 use atk4\data\Persistence;
+use atk4\ui\Exception\ExitApplicationException;
 use atk4\ui\Layout\Generic;
 use atk4\ui\Persistence\UI;
 use Closure;
@@ -212,7 +213,17 @@ class App
             $this->exit_called = true;
             $this->hook('beforeExit');
         }
-        exit;
+
+        if($from_shutdown) {
+            return;
+        }
+
+        if (defined('UNIT_TESTING')) {
+            throw new ExitApplicationException();
+            return;
+        }
+
+        exit(0);
     }
 
     /**

--- a/src/App.php
+++ b/src/App.php
@@ -206,6 +206,7 @@ class App
 
     /**
      * @param bool $from_shutdown
+     *
      * @throws ExitApplicationException
      * @throws \atk4\core\Exception
      */
@@ -216,13 +217,12 @@ class App
             $this->hook('beforeExit');
         }
 
-        if($from_shutdown) {
+        if ($from_shutdown) {
             return;
         }
 
         if (defined('UNIT_TESTING')) {
             throw new ExitApplicationException();
-            return;
         }
 
         exit(0);
@@ -902,7 +902,7 @@ class App
         }
     }
 
-    public function setupAlwaysRun(): void
+    protected function setupAlwaysRun(): void
     {
         if ($this->_cwd_restore) {
             $this->_cwd_restore = getcwd();

--- a/src/App.php
+++ b/src/App.php
@@ -400,7 +400,7 @@ class App
     /**
      * Add a new object into the app. You will need to have Layout first.
      *
-     * @param mixed  $seed New object to add
+     * @param mixed  $seed   New object to add
      * @param string $region
      *
      * @throws Exception

--- a/src/App.php
+++ b/src/App.php
@@ -264,7 +264,10 @@ class App
     {
         $this->catch_runaway_callbacks = false;
 
-        $l = new self();
+        // must be static to support extended App
+        // if not the App will use default value
+        // e.g. Title = 'Agile UI - Untitled Application'
+        $l = new static();
         $l->initLayout('Centered');
 
         //check for error type.

--- a/src/App.php
+++ b/src/App.php
@@ -183,9 +183,9 @@ class App
 
         // Set our exception handler
         if ($this->catch_exceptions) {
-            set_exception_handler(Closure::fromCallable([$this,'caughtException']));
+            set_exception_handler(Closure::fromCallable([$this, 'caughtException']));
             set_error_handler(
-                function($err_severity, $err_msg, $err_file, $err_line, array $err_context) {
+                function ($err_severity, $err_msg, $err_file, $err_line, array $err_context) {
                     throw new ErrorException($err_msg, 0, $err_severity, $err_file, $err_line);
                 },
                 E_ALL
@@ -220,9 +220,9 @@ class App
      *
      * @param Throwable $exception
      *
-     * @return bool
-     *
      * @throws \atk4\core\Exception
+     *
+     * @return bool
      */
     public function caughtException(Throwable $exception)
     {
@@ -236,8 +236,7 @@ class App
 
         // -- CHECK ERROR BY TYPE
 
-        switch(true)
-        {
+        switch (true) {
             case $exception instanceof \atk4\core\Exception:
                 $l->layout->template->setHTML('Content', $exception->getHTML());
                 break;
@@ -258,7 +257,7 @@ class App
         if ($this->isJsonRequest()) {
             echo json_encode([
                 'success'   => false,
-                'message' => $l->layout->getHtml(),
+                'message'   => $l->layout->getHtml(),
             ]);
         } else {
             $l->catch_runaway_callbacks = false;
@@ -305,6 +304,7 @@ class App
      * other classes.
      *
      * @param string $output
+     *
      * @throws \atk4\core\Exception
      */
     public function terminate($output = null)
@@ -321,9 +321,10 @@ class App
      *
      * @param string|Layout\Generic|array $seed
      *
-     * @return $this
      * @throws Exception
      * @throws \atk4\core\Exception
+     *
+     * @return $this
      */
     public function initLayout($seed)
     {
@@ -372,6 +373,7 @@ class App
      * and use file include instead.
      *
      * @param string $style CSS rules, like ".foo { background: red }".
+     *
      * @throws Exception
      */
     public function addStyle($style)
@@ -398,11 +400,12 @@ class App
     /**
      * Add a new object into the app. You will need to have Layout first.
      *
-     * @param mixed $seed New object to add
+     * @param mixed  $seed New object to add
      * @param string $region
      *
-     * @return object
      * @throws Exception
+     *
+     * @return object
      */
     public function add($seed, $region = null)
     {
@@ -415,6 +418,7 @@ class App
 
     /**
      * Runs app and echo rendered template.
+     *
      * @throws \atk4\core\Exception
      */
     public function run()
@@ -676,6 +680,7 @@ class App
      * A convenient wrapper for sending user to another page.
      *
      * @param array|string $page Destination page
+     *
      * @throws \atk4\core\Exception
      */
     public function redirect($page)
@@ -690,6 +695,7 @@ class App
      * Generate action for redirecting user to another page.
      *
      * @param string|array $page Destination URL or page/arguments
+     *
      * @return jsExpression
      */
     public function jsRedirect($page)

--- a/src/Exception/ExitApplicationException.php
+++ b/src/Exception/ExitApplicationException.php
@@ -4,5 +4,4 @@ namespace atk4\ui\Exception;
 
 class ExitApplicationException extends \Exception
 {
-
 }

--- a/src/Exception/ExitApplicationException.php
+++ b/src/Exception/ExitApplicationException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace atk4\ui\Exception;
+
+class ExitApplicationException extends \Exception
+{
+
+}

--- a/src/FormField/Lookup.php
+++ b/src/FormField/Lookup.php
@@ -251,12 +251,13 @@ class Lookup extends Input
     public function applyFilters()
     {
         if ($this->filters) {
+            $requested_filter = $_GET['filter'] ?? null;
             foreach ($this->filters as $k => $filter) {
                 if (
                     isset($_GET[$filter['field']]) &&
                     !empty($_GET[$filter['field']]) &&
                     $_GET[$filter['field']] != $this->filterEmpty &&
-                    @$_GET['filter'] != $filter['field']
+                    $requested_filter != $filter['field']
                 ) {
                     $this->model->addCondition($filter['field'], $_GET[$filter['field']]);
                 }

--- a/src/FormField/Upload.php
+++ b/src/FormField/Upload.php
@@ -175,9 +175,7 @@ class Upload extends Input
             $this->hasDeleteCb = true;
             $action = $_POST['action'] ?? null;
             if ($this->cb->triggered() && $action === 'delete') {
-
                 $fileName = $_POST['f_name'] ?? null;
-
                 $this->cb->set(function () use ($fx, $fileName) {
                     $this->addJsAction(call_user_func_array($fx, [$fileName]));
 

--- a/src/FormField/Upload.php
+++ b/src/FormField/Upload.php
@@ -173,8 +173,11 @@ class Upload extends Input
     {
         if (is_callable($fx)) {
             $this->hasDeleteCb = true;
-            if ($this->cb->triggered() && @$_POST['action'] === 'delete') {
-                $fileName = @$_POST['f_name'];
+            $action = $_POST['action'] ?? null;
+            if ($this->cb->triggered() && $action === 'delete') {
+
+                $fileName = $_POST['f_name'] ?? null;
+
                 $this->cb->set(function () use ($fx, $fileName) {
                     $this->addJsAction(call_user_func_array($fx, [$fileName]));
 
@@ -195,8 +198,9 @@ class Upload extends Input
         if (is_callable($fx)) {
             $this->hasUploadCb = true;
             if ($this->cb->triggered()) {
-                $action = @$_POST['action'];
-                if ($files = @$_FILES) {
+                $action = $_POST['action'] ?? null;
+                $files = $_FILES ?? null;
+                if ($files) {
                     //set fileId to file name as default.
                     $this->fileId = $files['file']['name'];
                     // display file name to user as default.

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -183,7 +183,6 @@ class Grid extends View
             $this->addItemsPerPageSelector($ipp, $label);
 
             $this->ipp = $_GET['ipp'] ?? $ipp[0];
-
         } else {
             $this->ipp = $ipp;
         }

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -181,11 +181,9 @@ class Grid extends View
     {
         if (is_array($ipp)) {
             $this->addItemsPerPageSelector($ipp, $label);
-            if (@$_GET['ipp']) {
-                $this->ipp = $_GET['ipp'];
-            } else {
-                $this->ipp = $ipp[0];
-            }
+
+            $this->ipp = $_GET['ipp'] ?? $ipp[0];
+
         } else {
             $this->ipp = $ipp;
         }

--- a/src/ItemsPerPageSelector.php
+++ b/src/ItemsPerPageSelector.php
@@ -80,7 +80,7 @@ class ItemsPerPageSelector extends View
         if (is_callable($fx)) {
             if ($this->cb->triggered()) {
                 $this->cb->set(function () use ($fx) {
-                    $ipp = @$_GET['ipp'];
+                    $ipp = $_GET['ipp'] ?? null;
                     //$this->pageLength->set(preg_replace("/\[ipp\]/", $ipp, $this->label));
                     $this->set($ipp);
                     $reload = call_user_func($fx, $ipp);

--- a/src/SSE.php
+++ b/src/SSE.php
@@ -48,7 +48,9 @@ class SSE
      * Executes user-specified action when call-back is triggered.
      *
      * @param callable $callback
-     * @param array    $args
+     * @param array $args
+     *
+     * @throws Exception
      *
      * @return mixed|null
      */
@@ -60,9 +62,7 @@ class SSE
 
         $this->view = $this->owner;
 
-        if (isset($_GET[$this->name])) {
-            $this->triggered = $_GET[$this->name];
-
+        if ($this->triggered()) {
             $this->app->run_called = true;
             $this->app->stickyGet($this->name);
             $ret = call_user_func_array($callback, $args);
@@ -88,7 +88,7 @@ class SSE
      */
     public function triggered()
     {
-        return isset($_GET[$this->name]) ? $_GET[$this->name] : false;
+        return $_GET[$this->name] ?? false;
     }
 
     /**
@@ -115,16 +115,10 @@ class SSE
     {
         $this->initSse();
         $this->setStart(time());
-        header('Content-Type: text/event-stream');
-        header('Cache-Control: no-cache');
-        header('Cache-Control: private');
-        //header('Content-Encoding: none;');
-        header('Pragma: no-cache');
 
-        echo 'retry: '.$this->clientReconnect * 1000 ."\n";
+        $this->send("retry: ".$this->clientReconnect * 1000 ."\n");
 
         $this->sendBlock('1000', $this->view->renderJSON(), null);
-        $this->flush();
     }
 
     /**
@@ -132,8 +126,14 @@ class SSE
      */
     public function flush()
     {
-        @ob_flush();
-        @flush();
+        // do not flush if is in testing
+        if (defined('UNIT_TESTING')) {
+            return;
+        }
+
+        if (ob_get_level() > 0) {
+            ob_end_flush();
+        }
     }
 
     /**
@@ -143,7 +143,13 @@ class SSE
      */
     private function send($content)
     {
+        if (!headers_sent()) {
+            $this->sendHeaders();
+        }
+
         echo $content;
+
+        $this->flush();
     }
 
     /**
@@ -179,7 +185,9 @@ class SSE
      */
     public function sleep()
     {
-        usleep($this->defaults[sleep_time] * 1000000);
+        $sleepTime = $this->defaults["sleep_time"] ?? $this->sleepTime;
+
+        usleep($sleepTime * 1000000);
     }
 
     public function setStart($time)
@@ -204,21 +212,38 @@ class SSE
      */
     public function isTick()
     {
-        return $this->getUptime() % $this->defaults[keep_alive_time] === 0;
+        $keepAliveTime = $this->defaults['keep_alive_time'] ?? $this->keepAliveTime;
+        return $this->getUptime() % $keepAliveTime === 0;
     }
 
     protected function initSse()
     {
         @set_time_limit(0); // Disable time limit
+
         // Prevent buffering
         if (function_exists('apache_setenv')) {
             @apache_setenv('no-gzip', 1);
         }
-        @ini_set('zlib.output_compression', 0);
-        @ini_set('implicit_flush', 1);
-        while (ob_get_level() != 0) {
-            ob_end_flush();
+
+        if (ob_get_level()) {
+            ob_end_clean();
         }
-        ob_implicit_flush(1);
+    }
+
+    protected function sendHeaders()
+    {
+        @ini_set('zlib.output_compression', 0);
+
+        header('Content-Type: text/event-stream');
+
+        header('Cache-Control: no-cache');
+        header('Cache-Control: private');
+
+        //header('Content-Encoding: none;');
+
+        header('Pragma: no-cache');
+
+        // nginx @http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffers
+        header('X-Accel-Buffering: no');
     }
 }

--- a/src/SSE.php
+++ b/src/SSE.php
@@ -48,7 +48,7 @@ class SSE
      * Executes user-specified action when call-back is triggered.
      *
      * @param callable $callback
-     * @param array $args
+     * @param array    $args
      *
      * @throws Exception
      *
@@ -116,7 +116,7 @@ class SSE
         $this->initSse();
         $this->setStart(time());
 
-        $this->send("retry: ".$this->clientReconnect * 1000 ."\n");
+        $this->send('retry: '.$this->clientReconnect * 1000 ."\n");
 
         $this->sendBlock('1000', $this->view->renderJSON(), null);
     }
@@ -185,7 +185,7 @@ class SSE
      */
     public function sleep()
     {
-        $sleepTime = $this->defaults["sleep_time"] ?? $this->sleepTime;
+        $sleepTime = $this->defaults['sleep_time'] ?? $this->sleepTime;
 
         usleep($sleepTime * 1000000);
     }
@@ -213,6 +213,7 @@ class SSE
     public function isTick()
     {
         $keepAliveTime = $this->defaults['keep_alive_time'] ?? $this->keepAliveTime;
+
         return $this->getUptime() % $keepAliveTime === 0;
     }
 

--- a/src/TableColumn/FilterModel/Generic.php
+++ b/src/TableColumn/FilterModel/Generic.php
@@ -54,7 +54,7 @@ class Generic extends Model
     public static function factoryType($field)
     {
         $data = [];
-        $persistence = new Persistence_Array($data);
+        $persistence = new Persistence\Array_($data);
         $filterDomain = 'atk4\\ui\\TableColumn\\FilterModel\Type';
 
         // check if field as a type and use string as default
@@ -102,8 +102,7 @@ class Generic extends Model
             // create a name for our filter model to save as session data.
             $this->name = 'filter_model_'.$this->lookupField->short_name;
 
-            $atk_clear_filter = $_GET['atk_clear_filter'] ?? false;
-            if ($atk_clear_filter) {
+            if ($_GET['atk_clear_filter'] ?? false) {
                 $this->forget();
             }
 

--- a/src/TableColumn/FilterModel/Generic.php
+++ b/src/TableColumn/FilterModel/Generic.php
@@ -102,7 +102,8 @@ class Generic extends Model
             // create a name for our filter model to save as session data.
             $this->name = 'filter_model_'.$this->lookupField->short_name;
 
-            if (@$_GET['atk_clear_filter']) {
+            $atk_clear_filter = $_GET['atk_clear_filter'] ?? false;
+            if ($atk_clear_filter) {
                 $this->forget();
             }
 

--- a/src/TableColumn/FilterModel/Generic.php
+++ b/src/TableColumn/FilterModel/Generic.php
@@ -6,7 +6,6 @@ use atk4\core\SessionTrait;
 use atk4\data\Field;
 use atk4\data\Model;
 use atk4\data\Persistence;
-use atk4\data\Persistence_Array;
 
 /**
  * Implement a generic Type model for filtering data.

--- a/src/TableColumn/Generic.php
+++ b/src/TableColumn/Generic.php
@@ -106,8 +106,7 @@ class Generic
         $popup->popOptions = array_merge($popup->popOptions, ['on' =>'click', 'position' => 'bottom right', 'movePopup' => false]);
         $popup->stopClickEvent = true;
 
-        $need_reload = $_GET['__atk_reload'] ?? false;
-        if ($need_reload) {
+        if ($_GET['__atk_reload'] ?? false) {
             //This is part of a reload, need to reactivate popup.
             $this->table->js(true, $popup->jsPopup());
         }

--- a/src/TableColumn/Generic.php
+++ b/src/TableColumn/Generic.php
@@ -106,7 +106,8 @@ class Generic
         $popup->popOptions = array_merge($popup->popOptions, ['on' =>'click', 'position' => 'bottom right', 'movePopup' => false]);
         $popup->stopClickEvent = true;
 
-        if (@$_GET['__atk_reload']) {
+        $need_reload = $_GET['__atk_reload'] ?? false;
+        if ($need_reload) {
             //This is part of a reload, need to reactivate popup.
             $this->table->js(true, $popup->jsPopup());
         }

--- a/src/TableColumn/jsHeader.php
+++ b/src/TableColumn/jsHeader.php
@@ -18,7 +18,7 @@ class jsHeader extends jsCallback
     {
         if (is_callable($fx)) {
             if ($this->triggered()) {
-                $param = [$_GET['id'],  @$_GET['item']];
+                $param = [$_GET['id'],  $_GET['item'] ?? null];
                 $this->set(function () use ($fx, $param) {
                     return call_user_func_array($fx, $param);
                 });

--- a/src/jsPaginator.php
+++ b/src/jsPaginator.php
@@ -76,7 +76,7 @@ class jsPaginator extends jsCallback
      */
     public function getPage()
     {
-        return @$_GET['page'];
+        return (int) ($_GET['page'] ?? 0);
     }
 
     /**

--- a/src/jsSSE.php
+++ b/src/jsSSE.php
@@ -20,7 +20,10 @@ class jsSSE extends jsCallback
     public function init()
     {
         parent::init();
-        if (@$_GET['event'] === 'sse') {
+
+        $event = $_GET['event'] ?? null;
+
+        if ($event === 'sse') {
             $this->browserSupport = true;
             $this->initSse();
         }

--- a/src/jsSSE.php
+++ b/src/jsSSE.php
@@ -149,7 +149,7 @@ class jsSSE extends jsCallback
     protected function sendHeaders()
     {
         @ini_set('zlib.output_compression', 0);
-        @ini_set('output_buffering',false);
+        @ini_set('output_buffering', false);
         @ini_set('implicit_flush', 1);
 
         header('Content-Type: text/event-stream');

--- a/src/jsSortable.php
+++ b/src/jsSortable.php
@@ -79,10 +79,10 @@ class jsSortable extends jsCallback
     {
         if (is_callable($fx)) {
             if ($this->triggered()) {
-                $sortOrders = explode(',', @$_POST['order']);
-                $source = @$_POST['source'];
-                $newIdx = @$_POST['new_idx'];
-                $orgIdx = @$_POST['org_idx'];
+                $sortOrders = explode(',', $_POST['order'] ?? '');
+                $source = $_POST['source'] ?? null;
+                $newIdx = $_POST['new_idx'] ?? null;
+                $orgIdx = $_POST['org_idx'] ?? null;
                 $this->set(function () use ($fx, $sortOrders, $source, $newIdx, $orgIdx) {
                     return call_user_func_array($fx, [$sortOrders, $source, $newIdx, $orgIdx]);
                 });

--- a/tests/DemoTest.php
+++ b/tests/DemoTest.php
@@ -2,14 +2,23 @@
 
 namespace atk4\ui\tests;
 
+use atk4\core\Exception;
+use atk4\ui\App;
+use atk4\ui\Exception\ExitApplicationException;
+use PHPUnit\Framework\TestCase;
+
 /**
  * Making sure demo pages don't throw exceptions and coverage is
  * handled.
  */
-class DemoTest extends \atk4\core\PHPUnit_AgileTestCase
+class DemoTest extends TestCase
 {
     public function setUp()
     {
+        if (!defined('UNIT_TESTING')) {
+            define('UNIT_TESTING', 'atk4');
+        }
+
         chdir('demos');
     }
 
@@ -18,124 +27,418 @@ class DemoTest extends \atk4\core\PHPUnit_AgileTestCase
         chdir('..');
     }
 
-    public function inc($f)
+    public function inc($file, $get, $post): App
     {
-        $_SERVER['REQUEST_URI'] = '/ui/'.$f;
-        include $f;
+        $app = null;
+
+        $_SERVER['REQUEST_URI'] = '/ui/' . $file;
+
+        $_GET = $get ?? [];
+        $_POST = $post ?? [];
+
+        include $file;
 
         return $app;
     }
 
-    private $regex = '/^..DOCTYPE/';
+    private $regexHTML = '/^..DOCTYPE/';
+    private $regexJSON = '
+  /
+  (?(DEFINE)
+     (?<number>   -? (?= [1-9]|0(?!\d) ) \d+ (\.\d+)? ([eE] [+-]? \d+)? )    
+     (?<boolean>   true | false | null )
+     (?<string>    " ([^"\\\\]* | \\\\ ["\\\\bfnrt\/] | \\\\ u [0-9a-f]{4} )* " )
+     (?<array>     \[  (?:  (?&json)  (?: , (?&json)  )*  )?  \s* \] )
+     (?<pair>      \s* (?&string) \s* : (?&json)  )
+     (?<object>    \{  (?:  (?&pair)  (?: , (?&pair)  )*  )?  \s* \} )
+     (?<json>   \s* (?: (?&number) | (?&boolean) | (?&string) | (?&array) | (?&object) ) \s* )
+  )
+  \A (?&json) \Z
+  /six   
+';
+    private $regexSSE = '/^[data|id|event].*$/m';
 
     /**
-     * @dataProvider demoList
+     * @runInSeparateProcess
+     * @dataProvider HTMLResponseDataProvider
+     *
+     * @param string     $page
+     * @param array|null $get
+     * @param array|null $post
+     *
+     * @throws Exception
      */
-    public function testDemo($page)
+    public function testDemoHTMLResponse($page, ?array $get = null, ?array $post = null)
     {
-        $this->expectOutputRegex($this->regex);
+        $this->expectOutputRegex($this->regexHTML);
 
         try {
-            $this->inc($page)->run();
-        } catch (\atk4\core\Exception $e) {
-            $e->addMoreInfo('test', $page);
+            $app = $this->inc($page, $get, $post);
+            if (!$app->run_called) {
+                $app->run();
+            }
+        } catch (ExitApplicationException $e) {
+        } catch (Exception $e) {
+            $e->addMoreInfo('page', $page);
+            $e->addMoreInfo('get', $get);
+            $e->addMoreInfo('post', $post);
+
+            throw $e;
+        }
+
+        // echo the page to where is the error
+        // PCRE checks only the beginning of the output
+        var_dump(
+            [
+                $page,
+                $get,
+                $post,
+            ]
+        );
+    }
+
+    public function HTMLResponseDataProvider()
+    {
+        $files = [];
+
+        $files[] = ["accordion.php"];
+        $files[] = ["accordion-nested.php"];
+        $files[] = ["autocomplete.php"];
+        $files[] = ["breadcrumb.php"];
+        $files[] = ["button.php"];
+        $files[] = ["card.php"];
+        $files[] = ["checkbox.php"];
+        $files[] = ["columns.php"];
+        $files[] = ["console.php"];
+        $files[] = ["crud.php"];
+        $files[] = ["crud2.php"];
+        $files[] = ["crud3.php"];
+        $files[] = ["dropdown-plus.php"];
+        $files[] = ["field.php"];
+        $files[] = ["field2.php"];
+        $files[] = ["form.php"];
+        $files[] = ["form2.php"];
+        $files[] = ["form3.php"];
+        $files[] = ["form4.php"];
+        $files[] = ["form5.php"];
+        $files[] = ["form6.php"];
+        $files[] = ["form-custom-layout.php"];
+        $files[] = ["form-section.php"];
+        $files[] = ["form-section-accordion.php"];
+        $files[] = ["grid.php"];
+        $files[] = ["grid-layout.php"];
+        $files[] = ["header.php"];
+        $files[] = ["index.php"];
+        $files[] = ["init.php"];
+        $files[] = ["js.php"];
+        $files[] = ["jscondform.php"];
+        $files[] = ["menu.php"];
+        $files[] = ["message.php"];
+        $files[] = ["modal.php"];
+        $files[] = ["multitable.php"];
+        $files[] = ["notify.php"];
+        $files[] = ["notify2.php"];
+        $files[] = ["paginator.php"];
+        $files[] = ["progress.php"];
+        $files[] = ["recursive.php"];
+        $files[] = ["reloading.php"];
+        $files[] = ["scroll-container.php"];
+        $files[] = ["scroll-grid.php"];
+        $files[] = ["scroll-grid-container.php"];
+        $files[] = ["scroll-lister.php"];
+        $files[] = ["scroll-table.php"];
+
+        $files[] = ["sse.php"];
+
+        $files[] = ["sticky.php"];
+        $files[] = [
+            "sticky.php",
+            [
+                "c" => "OHO",
+            ],
+        ];
+
+        $files[] = ["sticky2.php"];
+
+        $files[] = ["table.php"];
+        $files[] = ["table2.php"];
+        $files[] = ["tablecolumnmenu.php"];
+        $files[] = ["tablecolumns.php"];
+        $files[] = ["tabs.php"];
+        $files[] = ["toast.php"];
+        $files[] = ["upload.php"];
+        $files[] = ["view.php"];
+
+        $files[] = ["virtual.php"];
+
+        $files[] = [
+            "virtual.php",
+            [
+                "atk_admin_virtualpage" => "callback",
+                "__atk_callback"        => 1,
+            ],
+        ];
+
+        $files[] = ["wizard.php"];
+
+        $files[] = [
+            "wizard.php",
+            [
+                "atk_admin_wizard" => 1,
+                "__atk_callback"   => 1,
+            ],
+        ];
+
+        $files[] = [
+            "wizard.php",
+            [
+                "atk_admin_wizard" => 2,
+                "__atk_callback"   => 1,
+            ],
+        ];
+
+        /* need session
+        $files[]=["wizard.php", [
+                "atk_admin_wizard"=>2,
+                "name" => "Country"
+            ]
+        ];
+        */
+
+        $files[] = [
+            "wizard.php",
+            [
+                "atk_admin_wizard" => 3,
+                "__atk_callback"   => 1,
+            ],
+        ];
+
+        $files[] = [
+            "wizard.php",
+            [
+                "atk_admin_wizard" => 4,
+                "__atk_callback"   => 1,
+            ],
+        ];
+
+        //$files[]="jssearch.php"; // this call Method Grid->addJsSearch which not exists
+
+        $files[] = ["jssortable.php"];
+        $files[] = ["label.php"];
+        $files[] = ["layouts.php"];
+        $files[] = ["layouts_admin.php"];
+
+        //$files[]="layouts_error.php"; // intended to raise exception and display nicely
+        //$files[]="layouts_manual.php"; // doesn't use $app and gives error in DemoTest->inc
+        //$files[]="layouts_nolayout.php"; // doesn't use $app and gives error in DemoTest->inc
+
+        $files[] = ["lister.php"];
+        $files[] = ["lister-ipp.php"];
+        $files[] = ["loader2.php"];
+        $files[] = ["loader.php"];
+        $files[] = ["modal2.php"];
+        $files[] = ["popup.php"];
+        $files[] = ["tablefilter.php"];
+        $files[] = ["vue-component.php"];
+
+        return $files;
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @dataProvider layoutDataProvider
+     *
+     * @param string     $page
+     * @param array|null $get
+     * @param array|null $post
+     *
+     * @throws Exception
+     */
+    public function testDemoLayout($file)
+    {
+        $this->expectOutputRegex($this->regexHTML);
+        include $file;
+    }
+
+    public function layoutDataProvider()
+    {
+        return [
+            ["layouts_manual.php"],
+        ];
+    }
+
+    /**
+     * @dataProvider JSONResponseDataProvider
+     *
+     * @param string     $page
+     * @param array|null $get
+     * @param array|null $post
+     *
+     * @throws Exception
+     */
+    public function testDemoAssertJSONResponse($page, ?array $get = null, ?array $post = null)
+    {
+        $this->expectOutputRegex($this->regexJSON);
+
+        try {
+            $app = $this->inc($page, $get, $post);
+            if (!$app->run_called) {
+                $app->run();
+            }
+        } catch (ExitApplicationException $e) {
+        } catch (Exception $e) {
+            $e->addMoreInfo('page', $page);
+            $e->addMoreInfo('get', $get);
+            $e->addMoreInfo('post', $post);
 
             throw $e;
         }
     }
 
-    public function demoList()
+    public function JSONResponseDataProvider()
     {
-        $copy_paste = trim('
-  accordion.php
-  accordion-nested.php
-  autocomplete.php
-  breadcrumb.php
-  button.php
-  card.php
-  checkbox.php
-  columns.php
-  console.php
-  crud.php
-  crud2.php
-  crud3.php
-  dropdown-plus.php
-  field.php
-  field2.php
-  form.php
-  form2.php
-  form3.php
-  form4.php
-  form5.php
-  form6.php
-  form-custom-layout.php
-  form-section.php
-  form-section-accordion.php
-  grid.php
-  grid-layout.php
-  header.php
-  index.php
-  init.php
-  js.php
-  jscondform.php
-  menu.php
-  message.php
-  modal.php
-  multitable.php
-  notify.php
-  notify2.php
-  paginator.php
-  progress.php
-  recursive.php
-  reloading.php
-  scroll-container.php
-  scroll-grid.php
-  scroll-grid-container.php
-  scroll-lister.php
-  scroll-table.php
-  sse.php
-  sticky.php
-  sticky2.php
-  table.php
-  table2.php
-  tablecolumnmenu.php
-  tablecolumns.php
-  tabs.php
-  toast.php
-  upload.php
-  view.php
-  virtual.php
-  wizard.php
-');
-        /* DO NOT WORK
-        jssearch.php.
-        jssortable.php
-        label.php
-        layouts.php
-        layouts_admin.php
-        layouts_error.php
-        layouts_manual.php
-        layouts_nolayout.php
-        lister.php
-        lister-ipp.php
-        loader2.php
-        loader.php
-        modal2.php
-        popup.php
-        tablefilter.php
-        vue-component.php
-        */
-        $copy_paste = explode("\n", $copy_paste);
-        $copy_paste = array_map(function ($i) {
-            return [trim($i)];
-        }, $copy_paste);
+        $files = [];
 
-        return $copy_paste;
+        $files[] = [
+            "sticky2.php",
+            [
+                "__atk_reload" => "atk_admin_button",
+            ],
+        ];
+
+        $files[] = [
+            "sticky2.php",
+            [
+                "atk_admin_loader_callback" => "ajax",
+                "__atk_callback"            => "1",
+            ],
+        ];
+
+        $files[] = [
+            "virtual.php",
+            [
+                "atk_admin_label_2_click" => "ajax",
+                "__atk_callback"          => "1",
+            ],
+        ];
+
+        $files[] = [
+            "wizard.php",
+            [
+                "atk_admin_wizard"             => 1,
+                "atk_admin_wizard_form_submit" => "ajax",
+                "__atk_callback"               => 1,
+            ],
+            [
+                "dsn"                          => "mysql://root:root@localhost/atk4",
+                "atk_admin_wizard_form_submit" => "submit",
+            ],
+        ];
+
+        return $files;
     }
 
-    public function testLayout()
+    /**
+     * @dataProvider SSEResponseDataProvider
+     *
+     * @param string     $page
+     * @param array|null $get
+     * @param array|null $post
+     *
+     * @throws Exception
+     */
+    public function testDemoAssertSSEResponse($page, ?array $get = null, ?array $post = null)
     {
-        $this->expectOutputRegex($this->regex);
-        include 'layouts_manual.php';
+        ob_start();
+
+        $exit_correctly = false;
+        try {
+            $app = $this->inc($page, $get, $post);
+            $app->run();
+        } catch (ExitApplicationException $e) {
+            $exit_correctly = true;
+        } catch (\Throwable $t) {
+            $test = true;
+        }
+
+        $output_rows = explode(PHP_EOL, ob_get_clean());
+
+        // SSE is grredy on flushing buffers,
+        // sometimes it will close buffer of PHPUnit giving an error
+        if (ob_get_level() === 0) {
+            ob_start();
+        }
+
+        // check if SSE exit from application correctly
+        $this->assertTrue($exit_correctly);
+
+        $this->assertGreaterThan(0, count($output_rows));
+
+        // check SSE Syntax
+        foreach ($output_rows as $line) {
+            if (empty($line) || $line === null) {
+                continue;
+            }
+
+            preg_match('/^[id|event|data].*$/', $line, $matches);
+            $this->assertEquals($line, $matches[0]);
+        }
+    }
+
+    public function SSEResponseDataProvider()
+    {
+        $files = [];
+
+        $files[] = [
+            "sse.php",
+            [
+                "atk_admin_jssse" => "ajax",
+                "__atk_callback"  => "1",
+                "event"           => "sse",
+            ],
+        ];
+
+        /*
+        // Cannot be done need previous steps
+        // and session opened
+        $files[]=["wizard.php", [
+                "atk_admin_wizard"=>3,
+                "atk_admin_wizard_console_jssse"=>"ajax",
+                "__atk_callback"=>1,
+                "event"=>"sse"
+            ]
+        ];
+        */
+
+        $files[] = [
+            "console.php",
+            [
+                "atk_admin_tabs_tabssubview_console_jssse" => "ajax",
+                "__atk_callback"                           => "1",
+                "event"                                    => "sse",
+            ],
+        ];
+
+        $files[] = [
+            "console.php",
+            [
+                "atk_admin_tabs_tabssubview_2_virtualpage"               => "cut",
+                "atk_admin_tabs_tabssubview_2_virtualpage_console_jssse" => "ajax",
+                "__atk_callback"                                         => 1,
+                "event"                                                  => "sse",
+            ],
+        ];
+
+        $files[] = [
+            "console.php",
+            [
+                "atk_admin_tabs_tabssubview_3_virtualpage"               => "cut",
+                "atk_admin_tabs_tabssubview_3_virtualpage_console_jssse" => "ajax",
+                "__atk_callback"                                         => 1,
+                "event"                                                  => "sse",
+            ],
+        ];
+
+        return $files;
     }
 }

--- a/tests/DemoTest.php
+++ b/tests/DemoTest.php
@@ -31,7 +31,7 @@ class DemoTest extends TestCase
     {
         $app = null;
 
-        $_SERVER['REQUEST_URI'] = '/ui/' . $file;
+        $_SERVER['REQUEST_URI'] = '/ui/'.$file;
 
         $_GET = $get ?? [];
         $_POST = $post ?? [];
@@ -101,145 +101,145 @@ class DemoTest extends TestCase
     {
         $files = [];
 
-        $files[] = ["accordion.php"];
-        $files[] = ["accordion-nested.php"];
-        $files[] = ["autocomplete.php"];
-        $files[] = ["breadcrumb.php"];
-        $files[] = ["button.php"];
-        $files[] = ["card.php"];
-        $files[] = ["checkbox.php"];
-        $files[] = ["columns.php"];
-        $files[] = ["console.php"];
-        $files[] = ["crud.php"];
-        $files[] = ["crud2.php"];
-        $files[] = ["crud3.php"];
-        $files[] = ["dropdown-plus.php"];
-        $files[] = ["field.php"];
-        $files[] = ["field2.php"];
-        $files[] = ["form.php"];
-        $files[] = ["form2.php"];
-        $files[] = ["form3.php"];
-        $files[] = ["form4.php"];
-        $files[] = ["form5.php"];
-        $files[] = ["form6.php"];
-        $files[] = ["form-custom-layout.php"];
-        $files[] = ["form-section.php"];
-        $files[] = ["form-section-accordion.php"];
-        $files[] = ["grid.php"];
-        $files[] = ["grid-layout.php"];
-        $files[] = ["header.php"];
-        $files[] = ["index.php"];
-        $files[] = ["init.php"];
-        $files[] = ["js.php"];
-        $files[] = ["jscondform.php"];
-        $files[] = ["menu.php"];
-        $files[] = ["message.php"];
-        $files[] = ["modal.php"];
-        $files[] = ["multitable.php"];
-        $files[] = ["notify.php"];
-        $files[] = ["notify2.php"];
-        $files[] = ["paginator.php"];
-        $files[] = ["progress.php"];
-        $files[] = ["recursive.php"];
-        $files[] = ["reloading.php"];
-        $files[] = ["scroll-container.php"];
-        $files[] = ["scroll-grid.php"];
-        $files[] = ["scroll-grid-container.php"];
-        $files[] = ["scroll-lister.php"];
-        $files[] = ["scroll-table.php"];
+        $files[] = ['accordion.php'];
+        $files[] = ['accordion-nested.php'];
+        $files[] = ['autocomplete.php'];
+        $files[] = ['breadcrumb.php'];
+        $files[] = ['button.php'];
+        $files[] = ['card.php'];
+        $files[] = ['checkbox.php'];
+        $files[] = ['columns.php'];
+        $files[] = ['console.php'];
+        $files[] = ['crud.php'];
+        $files[] = ['crud2.php'];
+        $files[] = ['crud3.php'];
+        $files[] = ['dropdown-plus.php'];
+        $files[] = ['field.php'];
+        $files[] = ['field2.php'];
+        $files[] = ['form.php'];
+        $files[] = ['form2.php'];
+        $files[] = ['form3.php'];
+        $files[] = ['form4.php'];
+        $files[] = ['form5.php'];
+        $files[] = ['form6.php'];
+        $files[] = ['form-custom-layout.php'];
+        $files[] = ['form-section.php'];
+        $files[] = ['form-section-accordion.php'];
+        $files[] = ['grid.php'];
+        $files[] = ['grid-layout.php'];
+        $files[] = ['header.php'];
+        $files[] = ['index.php'];
+        $files[] = ['init.php'];
+        $files[] = ['js.php'];
+        $files[] = ['jscondform.php'];
+        $files[] = ['menu.php'];
+        $files[] = ['message.php'];
+        $files[] = ['modal.php'];
+        $files[] = ['multitable.php'];
+        $files[] = ['notify.php'];
+        $files[] = ['notify2.php'];
+        $files[] = ['paginator.php'];
+        $files[] = ['progress.php'];
+        $files[] = ['recursive.php'];
+        $files[] = ['reloading.php'];
+        $files[] = ['scroll-container.php'];
+        $files[] = ['scroll-grid.php'];
+        $files[] = ['scroll-grid-container.php'];
+        $files[] = ['scroll-lister.php'];
+        $files[] = ['scroll-table.php'];
 
-        $files[] = ["sse.php"];
+        $files[] = ['sse.php'];
 
-        $files[] = ["sticky.php"];
+        $files[] = ['sticky.php'];
         $files[] = [
-            "sticky.php",
+            'sticky.php',
             [
-                "c" => "OHO",
+                'c' => 'OHO',
             ],
         ];
 
-        $files[] = ["sticky2.php"];
+        $files[] = ['sticky2.php'];
 
-        $files[] = ["table.php"];
-        $files[] = ["table2.php"];
-        $files[] = ["tablecolumnmenu.php"];
-        $files[] = ["tablecolumns.php"];
-        $files[] = ["tabs.php"];
-        $files[] = ["toast.php"];
-        $files[] = ["upload.php"];
-        $files[] = ["view.php"];
+        $files[] = ['table.php'];
+        $files[] = ['table2.php'];
+        $files[] = ['tablecolumnmenu.php'];
+        $files[] = ['tablecolumns.php'];
+        $files[] = ['tabs.php'];
+        $files[] = ['toast.php'];
+        $files[] = ['upload.php'];
+        $files[] = ['view.php'];
 
-        $files[] = ["virtual.php"];
+        $files[] = ['virtual.php'];
 
         $files[] = [
-            "virtual.php",
+            'virtual.php',
             [
-                "atk_admin_virtualpage" => "callback",
-                "__atk_callback"        => 1,
+                'atk_admin_virtualpage' => 'callback',
+                '__atk_callback'        => 1,
             ],
         ];
 
-        $files[] = ["wizard.php"];
+        $files[] = ['wizard.php'];
 
         $files[] = [
-            "wizard.php",
+            'wizard.php',
             [
-                "atk_admin_wizard" => 1,
-                "__atk_callback"   => 1,
+                'atk_admin_wizard' => 1,
+                '__atk_callback'   => 1,
             ],
         ];
 
         $files[] = [
-            "wizard.php",
+            'wizard.php',
             [
-                "atk_admin_wizard" => 2,
-                "__atk_callback"   => 1,
+                'atk_admin_wizard' => 2,
+                '__atk_callback'   => 1,
             ],
         ];
 
         /* need session
-        $files[]=["wizard.php", [
-                "atk_admin_wizard"=>2,
-                "name" => "Country"
+        $files[]=['wizard.php', [
+                'atk_admin_wizard'=>2,
+                'name' => 'Country'
             ]
         ];
         */
 
         $files[] = [
-            "wizard.php",
+            'wizard.php',
             [
-                "atk_admin_wizard" => 3,
-                "__atk_callback"   => 1,
+                'atk_admin_wizard' => 3,
+                '__atk_callback'   => 1,
             ],
         ];
 
         $files[] = [
-            "wizard.php",
+            'wizard.php',
             [
-                "atk_admin_wizard" => 4,
-                "__atk_callback"   => 1,
+                'atk_admin_wizard' => 4,
+                '__atk_callback'   => 1,
             ],
         ];
 
-        //$files[]="jssearch.php"; // this call Method Grid->addJsSearch which not exists
+        //$files[]='jssearch.php'; // this call Method Grid->addJsSearch which not exists
 
-        $files[] = ["jssortable.php"];
-        $files[] = ["label.php"];
-        $files[] = ["layouts.php"];
-        $files[] = ["layouts_admin.php"];
+        $files[] = ['jssortable.php'];
+        $files[] = ['label.php'];
+        $files[] = ['layouts.php'];
+        $files[] = ['layouts_admin.php'];
 
-        //$files[]="layouts_error.php"; // intended to raise exception and display nicely
-        //$files[]="layouts_manual.php"; // doesn't use $app and gives error in DemoTest->inc
-        //$files[]="layouts_nolayout.php"; // doesn't use $app and gives error in DemoTest->inc
+        //$files[]='layouts_error.php'; // intended to raise exception and display nicely
+        //$files[]='layouts_manual.php'; // doesn't use $app and gives error in DemoTest->inc
+        //$files[]='layouts_nolayout.php'; // doesn't use $app and gives error in DemoTest->inc
 
-        $files[] = ["lister.php"];
-        $files[] = ["lister-ipp.php"];
-        $files[] = ["loader2.php"];
-        $files[] = ["loader.php"];
-        $files[] = ["modal2.php"];
-        $files[] = ["popup.php"];
-        $files[] = ["tablefilter.php"];
-        $files[] = ["vue-component.php"];
+        $files[] = ['lister.php'];
+        $files[] = ['lister-ipp.php'];
+        $files[] = ['loader2.php'];
+        $files[] = ['loader.php'];
+        $files[] = ['modal2.php'];
+        $files[] = ['popup.php'];
+        $files[] = ['tablefilter.php'];
+        $files[] = ['vue-component.php'];
 
         return $files;
     }
@@ -263,7 +263,7 @@ class DemoTest extends TestCase
     public function layoutDataProvider()
     {
         return [
-            ["layouts_manual.php"],
+            ['layouts_manual.php'],
         ];
     }
 
@@ -300,38 +300,38 @@ class DemoTest extends TestCase
         $files = [];
 
         $files[] = [
-            "sticky2.php",
+            'sticky2.php',
             [
-                "__atk_reload" => "atk_admin_button",
+                '__atk_reload' => 'atk_admin_button',
             ],
         ];
 
         $files[] = [
-            "sticky2.php",
+            'sticky2.php',
             [
-                "atk_admin_loader_callback" => "ajax",
-                "__atk_callback"            => "1",
+                'atk_admin_loader_callback' => 'ajax',
+                '__atk_callback'            => '1',
             ],
         ];
 
         $files[] = [
-            "virtual.php",
+            'virtual.php',
             [
-                "atk_admin_label_2_click" => "ajax",
-                "__atk_callback"          => "1",
+                'atk_admin_label_2_click' => 'ajax',
+                '__atk_callback'          => '1',
             ],
         ];
 
         $files[] = [
-            "wizard.php",
+            'wizard.php',
             [
-                "atk_admin_wizard"             => 1,
-                "atk_admin_wizard_form_submit" => "ajax",
-                "__atk_callback"               => 1,
+                'atk_admin_wizard'             => 1,
+                'atk_admin_wizard_form_submit' => 'ajax',
+                '__atk_callback'               => 1,
             ],
             [
-                "dsn"                          => "mysql://root:root@localhost/atk4",
-                "atk_admin_wizard_form_submit" => "submit",
+                'dsn'                          => 'mysql://root:root@localhost/atk4',
+                'atk_admin_wizard_form_submit' => 'submit',
             ],
         ];
 
@@ -390,52 +390,52 @@ class DemoTest extends TestCase
         $files = [];
 
         $files[] = [
-            "sse.php",
+            'sse.php',
             [
-                "atk_admin_jssse" => "ajax",
-                "__atk_callback"  => "1",
-                "event"           => "sse",
+                'atk_admin_jssse' => 'ajax',
+                '__atk_callback'  => '1',
+                'event'           => 'sse',
             ],
         ];
 
         /*
         // Cannot be done need previous steps
         // and session opened
-        $files[]=["wizard.php", [
-                "atk_admin_wizard"=>3,
-                "atk_admin_wizard_console_jssse"=>"ajax",
-                "__atk_callback"=>1,
-                "event"=>"sse"
+        $files[]=['wizard.php', [
+                'atk_admin_wizard'=>3,
+                'atk_admin_wizard_console_jssse'=>'ajax',
+                '__atk_callback'=>1,
+                'event'=>'sse'
             ]
         ];
         */
 
         $files[] = [
-            "console.php",
+            'console.php',
             [
-                "atk_admin_tabs_tabssubview_console_jssse" => "ajax",
-                "__atk_callback"                           => "1",
-                "event"                                    => "sse",
+                'atk_admin_tabs_tabssubview_console_jssse' => 'ajax',
+                '__atk_callback'                           => '1',
+                'event'                                    => 'sse',
             ],
         ];
 
         $files[] = [
-            "console.php",
+            'console.php',
             [
-                "atk_admin_tabs_tabssubview_2_virtualpage"               => "cut",
-                "atk_admin_tabs_tabssubview_2_virtualpage_console_jssse" => "ajax",
-                "__atk_callback"                                         => 1,
-                "event"                                                  => "sse",
+                'atk_admin_tabs_tabssubview_2_virtualpage'               => 'cut',
+                'atk_admin_tabs_tabssubview_2_virtualpage_console_jssse' => 'ajax',
+                '__atk_callback'                                         => 1,
+                'event'                                                  => 'sse',
             ],
         ];
 
         $files[] = [
-            "console.php",
+            'console.php',
             [
-                "atk_admin_tabs_tabssubview_3_virtualpage"               => "cut",
-                "atk_admin_tabs_tabssubview_3_virtualpage_console_jssse" => "ajax",
-                "__atk_callback"                                         => 1,
-                "event"                                                  => "sse",
+                'atk_admin_tabs_tabssubview_3_virtualpage'               => 'cut',
+                'atk_admin_tabs_tabssubview_3_virtualpage_console_jssse' => 'ajax',
+                '__atk_callback'                                         => 1,
+                'event'                                                  => 'sse',
             ],
         ];
 

--- a/tests/DemoTest.php
+++ b/tests/DemoTest.php
@@ -352,6 +352,7 @@ class DemoTest extends TestCase
         ob_start();
 
         $exit_correctly = false;
+
         try {
             $app = $this->inc($page, $get, $post);
             $app->run();


### PR DESCRIPTION
Hope this fixes #651, but probably it will solve strange issue of no feedback in other components of ui.

what i have done : 

- I need to remove some notice suppressor in code.
- i use php 7.2 syntax, because composer now require php >= 7.2
- i removed some code that is not need anymore.
- Now any error will be raised as an exception
- Error and Exception will be handled by $app->caughtException($e)

Sample case to compare with previous version :
```php

    require 'vendor/autoload.php';

    $app = new \atk4\ui\App();

    $app->initLayout('Centered');

    $modal = $app->add(['Modal']);

    $modal->set(function($m) use ($modal) {
        throw new \Exception("TEST!");
    });

    $button = $app->add(['Button', 'Test modal exception']);
    $button->on('click', $modal->show());

    $modal2 = $app->add(['Modal']);

    $modal2->set(function($m) use ($modal2) {
        trigger_error("error triggered");
    });

    $button2 = $app->add(['Button', 'Test modal error']);
    $button2->on('click', $modal2->show());
```
Now it will output the view, if an exception is raised, it will open a modal with the description of the exception, previous version loop for ever.

I think we need more test cases, like exception/error during SSE.

ATTENTION
This change, will catch any error, this means that any bad/old habits like use of @ for suppression of notice in place of *isset* or access to undefined will throw an error, PROBABLY good code will not notice any problem.

We can added a variable to define the level of error_reporting, but now i think is better to leave it on E_ALL

