### PR TITLE
Fix #786 - Exception display in app and modals

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -241,10 +241,11 @@ class App
     {
         $this->catch_runaway_callbacks = false;
 
-        // must be static to support extended App
-        // if not the App will use default value
-        // e.g. Title = 'Agile UI - Untitled Application'
-        $l = new static();
+        // Use new App() instead of static() to prevent broken exception
+        // message display due to conflict with existing layout
+        $l = new App();
+        $l->title = 'L'.$exception->getLine().': '.$exception->getMessage();
+        $l->catch_runaway_callbacks = false; // Allow exceptions within modals
         $l->initLayout('Centered');
 
         // -- CHECK ERROR BY TYPE


### PR DESCRIPTION
Currently ATK UI uses static() in caughtException() in order to display the exception within the app's environment. However, this can lead to complications like those:

![127 0 0 1-20190731164610](https://user-images.githubusercontent.com/23142906/62218140-8b0ed100-b3b4-11e9-9ba6-97e5c760eb25.jpg)

And in modals:

![127 0 0 1-20190731164831](https://user-images.githubusercontent.com/23142906/62218161-96fa9300-b3b4-11e9-9d35-f7dad0364b93.jpg)

This PR addresses the issue by creating a new App() to display the exception and also adds the line and exception title in the page's title which can be practical when juggling with exceptions.