### PR TITLE
Add target parameter to link() function

### DIFF
--- a/docs/icon.rst
+++ b/docs/icon.rst
@@ -165,11 +165,6 @@ Here is the code with comments::
             // Add icon into render tree
             $this->add($this->icon, 'Icon');
         }
-
-        function link($url) {
-            $this->setAttr('target', '_blank');
-            return parent::link($url);
-        }
     }
 
     // Usage Examples. Start with the most basic usage
@@ -180,4 +175,4 @@ Here is the code with comments::
 
     // Finally provide custom icon and make the button clickable.
     $app->add(new SocialAdd(['facebook', 'icon'=>'facebook f']))
-        ->link('https://facebook.com');
+        ->link('https://facebook.com', '_blank');

--- a/src/View.php
+++ b/src/View.php
@@ -276,18 +276,22 @@ class View implements jsExpressionable
      * Makes view into a "<a>" element with a link.
      *
      * @param string|array $url
+     * @param string $target
      *
      * @return $this
      */
-    public function link($url)
+    public function link($url, $target = null)
     {
         $this->element = 'a';
         if (is_string($url)) {
             $this->setAttr('href', $url);
-
-            return $this;
+        } else {
+            $this->setAttr('href', $this->url($url));
         }
-        $this->setAttr('href', $this->url($url));
+
+        if ($target !== null) {
+            $this->setAttr('target', $target);
+        }
 
         return $this;
     }

--- a/src/jsSearch.php
+++ b/src/jsSearch.php
@@ -54,9 +54,9 @@ class jsSearch extends View
      */
     public $useAjax = true;
 
-    public function link($url)
+    public function link($url, $target = null)
     {
-        return parent::link($url);
+        return parent::link($url, $target);
     }
 
     public $defaultTemplate = 'js-search.html';


### PR DESCRIPTION
This PR adds the ability to specify a `target` attribute within the `link()` function, which allows the opening of the page in a new tab.

*Note: This shouldn't break any existing code as the argument is optional.*

For example:
```
// Open in new tab
$app->add(['Label', 'Open page in a new tab'])->link(['my-page'], '_blank');

// Open in same tab as before
$app->add(['Label', 'Open page in a new tab'])->link(['my-page']);
```