### PR TITLE
Add ability to customize CSS of 'content' div

### DIFF
--- a/demos/modal.php
+++ b/demos/modal.php
@@ -15,8 +15,16 @@ $noTitle = $app->add(['Modal', 'title' => false]);
 $noTitle->add('LoremIpsum');
 $noTitle->add(['Button', 'Hide'])->on('click', $noTitle->hide());
 
+$scrolling = $app->add(['Modal', 'title' => 'Long Content that Scrolls inside Modal']);
+$scrolling->addScrolling();
+$scrolling->add('LoremIpsum');
+$scrolling->add('LoremIpsum');
+$scrolling->add('LoremIpsum');
+$scrolling->add(['Button', 'Hide'])->on('click', $scrolling->hide());
+
 $bar->add(['Button', 'Show'])->on('click', $modal->show());
 $bar->add(['Button', 'No Title'])->on('click', $noTitle->show());
+$bar->add(['Button', 'Scrolling Content'])->on('click', $scrolling->show());
 
 if (!class_exists('Counter')) {
     class Counter extends \atk4\ui\FormField\Line

--- a/docs/js.rst
+++ b/docs/js.rst
@@ -426,6 +426,10 @@ Modal
 .. php:method:: set(callback)
 .. php:method:: show()
 .. php:method:: hide()
+.. php:method:: addContentCss()
+.. php:method:: addScrolling()
+.. php:method:: setOption()
+.. php:method:: setOptions()
 
 This class allows you to open modal dialogs and close them easily. It's based around Fomantic UI
 `.modal(), <https://fomantic-ui.com/modules/modal.html>`_ but integrates PHP callback for dynamically
@@ -451,6 +455,8 @@ Modal will render as a `<div>` block but will be hidden. Alternatively you can u
 
 This way it's more convenient for holding static content, such as Terms of Service.
 
+You can customize the CSS classes of both header and content section of the modal using the properties `headerCss` or `contentCss` or use the method `addContentCss()`. See the Fomantic UI modal documentation for further information.
+
 
 jsModal
 =======
@@ -459,7 +465,7 @@ jsModal
 
 This is alternative implementation to :php:class:`Modal` and is convenient for situations
 when you do not know in advance that you migth need to open Dialog box. This class is not
-a component, but rathen an Action so you mustn't add it into Render Tree::
+a component, but rather an Action so you mustn't add it into Render Tree::
 
     $vp = $app->add('VirtualPage');
     $vp->add(['LoremIpsum', 'size' => 2]);

--- a/src/Modal.php
+++ b/src/Modal.php
@@ -2,7 +2,7 @@
 
 namespace atk4\ui;
 
-/**
+/**h
  * This class add modal dialog to a page.
  *
  * Modal are added to the layout but their content is hidden by default.
@@ -36,7 +36,7 @@ class Modal extends View
      */
     public $title = 'Modal title';
     public $loading_label = 'Loading...';
-    public $headerCss = 'header';
+    public $headerCSS = 'header';
     public $ui = 'modal';
     public $fx = [];
     public $cb = null;
@@ -51,7 +51,7 @@ class Modal extends View
      *
      * @var array
      */
-    public $contentCss = ['img', 'content', 'atk-dialog-content'];
+    public $contentCSS = ['img', 'content', 'atk-dialog-content'];
 
     /*
      * if true, the <div class="actions"> at the bottom of the modal is
@@ -108,12 +108,12 @@ class Modal extends View
     /**
      * Add CSS classes to "content" div
      */
-    public function addContentCss($class) {
+    public function addContentCSS($class) {
         if(is_string($class)) {
-            $this->contentCss = array_merge($this->contentCss, [$class]);
+            $this->contentCSS = array_merge($this->contentCSS, [$class]);
         }
         elseif(is_array($class)) {
-            $this->contentCss = array_merge($this->contentCss, $class);
+            $this->contentCSS = array_merge($this->contentCSS, $class);
         }
     }
 
@@ -199,7 +199,7 @@ class Modal extends View
      */
     public function addScrolling()
     {
-        $this->addContentCss('scrolling');
+        $this->addContentCSS('scrolling');
 
         return $this;
     }
@@ -313,11 +313,11 @@ class Modal extends View
 
         if (!empty($this->title)) {
             $this->template->trySet('title', $this->title);
-            $this->template->trySet('headerCss', $this->headerCss);
+            $this->template->trySet('headerCSS', $this->headerCSS);
         }
 
-        if($this->contentCss) {
-            $this->template->trySet('contentCss', implode(' ', $this->contentCss));
+        if($this->contentCSS) {
+            $this->template->trySet('contentCSS', implode(' ', $this->contentCSS));
         }
 
         if (!empty($this->fx)) {

--- a/src/Modal.php
+++ b/src/Modal.php
@@ -46,6 +46,13 @@ class Modal extends View
     //now only supported json type response.
     public $type = 'json';
 
+    /**
+     * Add ability to add css classes to "content" div
+     *
+     * @var array
+     */
+    public $contentCss = ['img', 'content', 'atk-dialog-content'];
+
     /*
      * if true, the <div class="actions"> at the bottom of the modal is
      * shown. Automatically set to true if any actions are added
@@ -96,6 +103,18 @@ class Modal extends View
                 $this->app->terminate($this->cb_view->renderJSON());
             }
         });
+    }
+
+    /**
+     * Add CSS classes to "content" div
+     */
+    public function addContentCss($class) {
+        if(is_string($class)) {
+            $this->contentCss = array_merge($this->contentCss, [$class]);
+        }
+        elseif(is_array($class)) {
+            $this->contentCss = array_merge($this->contentCss, $class);
+        }
     }
 
     /**
@@ -180,7 +199,7 @@ class Modal extends View
      */
     public function addScrolling()
     {
-        $this->addClass('scrolling');
+        $this->addContentCss('scrolling');
 
         return $this;
     }
@@ -295,6 +314,10 @@ class Modal extends View
         if (!empty($this->title)) {
             $this->template->trySet('title', $this->title);
             $this->template->trySet('headerCss', $this->headerCss);
+        }
+
+        if($this->contentCss) {
+            $this->template->trySet('contentCss', implode(' ', $this->contentCss));
         }
 
         if (!empty($this->fx)) {

--- a/template/semantic-ui/modal.html
+++ b/template/semantic-ui/modal.html
@@ -1,6 +1,6 @@
 <{_element}div{/} id="{$_id}" class="{_ui}ui {/} {$class} {_class}{/}" style="{$style}" {$attributes}><i class="{$close}"></i>
-<div class="{$headerCss}">{$title}</div>
-<div class="{$contentCss}">{$Content}</div>
+<div class="{$headerCSS}">{$title}</div>
+<div class="{$contentCSS}">{$Content}</div>
 {ActionContainer}
 <div class="actions">
   <div>{$actions}</div>

--- a/template/semantic-ui/modal.html
+++ b/template/semantic-ui/modal.html
@@ -1,6 +1,6 @@
 <{_element}div{/} id="{$_id}" class="{_ui}ui {/} {$class} {_class}{/}" style="{$style}" {$attributes}><i class="{$close}"></i>
 <div class="{$headerCss}">{$title}</div>
-<div class="img content atk-dialog-content">{$Content}</div>
+<div class="{$contentCss}">{$Content}</div>
 {ActionContainer}
 <div class="actions">
   <div>{$actions}</div>


### PR DESCRIPTION
**Attention:** Credit for this PR goes to @PhilippGrashoff who is the real contributor of this code. For more info see #793.

> This adds the ability to customize the CSS classes which are used for the `<div class="img content atk-dialog-content>"`. E.g. add 'scrolling' for scrolling content.
>
> Also fixes Method addScrolling, which added the 'scrolling' class to the main div instead of the content div.
>
> If you think defining an extra method for it is overkill, we could go the same way as $headerCss is.
