### PR TITLE
Add App->catch_error_types to define set_error_handler in App

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -134,6 +134,13 @@ class App
     public $call_exit = true;
 
     /**
+     * Error types to be in set_error_handler.
+     *
+     * @var int
+     */
+    protected $catch_error_types = E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_USER_DEPRECATED;
+
+    /**
      * Constructor.
      *
      * @param array $defaults
@@ -184,7 +191,7 @@ class App
                 function ($err_severity, $err_msg, $err_file, $err_line, array $err_context) {
                     throw new ErrorException($err_msg, 0, $err_severity, $err_file, $err_line);
                 },
-                E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_USER_DEPRECATED
+                $this->catch_error_types
             );
         }
 

--- a/src/App.php
+++ b/src/App.php
@@ -184,7 +184,7 @@ class App
                 function ($err_severity, $err_msg, $err_file, $err_line, array $err_context) {
                     throw new ErrorException($err_msg, 0, $err_severity, $err_file, $err_line);
                 },
-                E_ALL & ~E_NOTICE
+                E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_USER_DEPRECATED
             );
         }
 


### PR DESCRIPTION
add App->catch_error_types = E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_USER_DEPRECATED;

Can be used to define set_error_handler error types without overriding the construct of the App.
Previously was hardcoded and to change it you must extend App and override __construct.