### PR TITLE
Formfields: Add ability to set attributes to <input> Tag

### DIFF
--- a/demos/field.php
+++ b/demos/field.php
@@ -93,3 +93,5 @@ $app->add(new \atk4\ui\FormField\Line(['icon' => 'search', 'mini' => true, 'plac
 $app->add(new \atk4\ui\Header(['Custom HTML attributes for <input> tag', 'size' => 2]));
 $l = $app->add(new \atk4\ui\FormField\Line(['placeholder' => 'maxlength attribute set to 10']));
 $l->setInputAttr('maxlength', '10');
+$l = $app->add(new \atk4\ui\FormField\Line(['fluid' => true, 'placeholder' => 'overwrite existing attribute (type="number")']));
+$l->setInputAttr(['type' => 'number']);

--- a/demos/field.php
+++ b/demos/field.php
@@ -89,3 +89,7 @@ $app->add(new \atk4\ui\FormField\Line(['icon' => 'search', 'transparent' => true
 $app->add(new \atk4\ui\FormField\Line(['icon' => 'search', 'fluid' => true, 'placeholder' => 'fluid']));
 
 $app->add(new \atk4\ui\FormField\Line(['icon' => 'search', 'mini' => true, 'placeholder' => 'mini']));
+
+$app->add(new \atk4\ui\Header(['Custom HTML attributes for <input> tag', 'size' => 2]));
+$l = $app->add(new \atk4\ui\FormField\Line(['placeholder' => 'maxlength attribute set to 10']));
+$l->setInputAttr('maxlength', '10');

--- a/src/FormField/AutoComplete.php
+++ b/src/FormField/AutoComplete.php
@@ -196,14 +196,14 @@ class AutoComplete extends Input
      */
     public function getInput()
     {
-        return $this->app->getTag('input', [
+        return $this->app->getTag('input', array_merge([
             'name'        => $this->short_name,
             'type'        => 'hidden',
             'id'          => $this->id.'_input',
             'value'       => $this->getValue(),
             'readonly'    => $this->readonly ? 'readonly' : false,
             'disabled'    => $this->disabled ? 'disabled' : false,
-        ]);
+        ], $this->inputAttr));
     }
 
     /**

--- a/src/FormField/DropDown.php
+++ b/src/FormField/DropDown.php
@@ -163,7 +163,7 @@ class DropDown extends Input
         $this->_tItem->del('Icon');
     }
 
-     /**
+    /**
      * returns <input .../> tag.
      *
      * @return string

--- a/src/FormField/DropDown.php
+++ b/src/FormField/DropDown.php
@@ -163,21 +163,21 @@ class DropDown extends Input
         $this->_tItem->del('Icon');
     }
 
-    /**
+     /**
      * returns <input .../> tag.
      *
      * @return string
      */
     public function getInput()
     {
-        return $this->app->getTag('input', [
+        return $this->app->getTag('input', array_merge([
             'name'        => $this->short_name,
             'type'        => $this->inputType,
             'id'          => $this->id.'_input',
             'value'       => $this->getValue(),
             'readonly'    => $this->readonly ? 'readonly' : false,
             'disabled'    => $this->disabled ? 'disabled' : false,
-        ]);
+        ], $this->inputAttr));
     }
 
     /**

--- a/src/FormField/Input.php
+++ b/src/FormField/Input.php
@@ -57,7 +57,7 @@ class Input extends Generic
     /**
      * here additional attributes directly for the <input> tag can be added:
      * ['attribute_name' => 'attribute_value'], e.g.
-     * ['autocomplete' => 'new-password']
+     * ['autocomplete' => 'new-password'].
      *
      * Use setInputAttr() to fill this array
      *
@@ -66,7 +66,7 @@ class Input extends Generic
     public $inputAttr = [];
 
     /**
-     * Set attribute which is added directly to the <input> tag, not the surrounding <div>
+     * Set attribute which is added directly to the <input> tag, not the surrounding <div>.
      *
      * @param string|array $attr  Attribute name or hash
      * @param string       $value Attribute value

--- a/src/FormField/Input.php
+++ b/src/FormField/Input.php
@@ -55,6 +55,38 @@ class Input extends Generic
     public $width = null;
 
     /**
+     * here additional attributes directly for the <input> tag can be added:
+     * ['attribute_name' => 'attribute_value'], e.g.
+     * ['autocomplete' => 'new-password']
+     *
+     * Use setInputAttr() to fill this array
+     *
+     * @var array
+     */
+    public $inputAttr = [];
+
+    /**
+     * Set attribute which is added directly to the <input> tag, not the surrounding <div>
+     *
+     * @param string|array $attr  Attribute name or hash
+     * @param string       $value Attribute value
+     *
+     * @return $this
+     */
+    public function setInputAttr($attr, $value = null)
+    {
+        if (is_array($attr)) {
+            $this->inputAttr = array_merge($this->inputAttr, $attr);
+
+            return $this;
+        }
+
+        $this->inputAttr[$attr] = $value;
+
+        return $this;
+    }
+
+    /**
      * Method similar to View::js() however will adjust selector
      * to target the "input" element.
      *
@@ -84,7 +116,7 @@ class Input extends Generic
      */
     public function getInput()
     {
-        return $this->app->getTag('input', [
+        return $this->app->getTag('input', array_merge([
             'name'        => $this->short_name,
             'type'        => $this->inputType,
             'placeholder' => $this->placeholder,
@@ -92,7 +124,7 @@ class Input extends Generic
             'value'       => $this->getValue(),
             'readonly'    => $this->readonly ? 'readonly' : false,
             'disabled'    => $this->disabled ? 'disabled' : false,
-        ]);
+        ], $this->inputAttr));
         //return '<input name="'.$this->short_name.'" type="'.$this->inputType.'" placeholder="'.$this->placeholder.'" id="'.$this->id.'_input"/>';
     }
 

--- a/src/FormField/Lookup.php
+++ b/src/FormField/Lookup.php
@@ -297,14 +297,14 @@ class Lookup extends Input
      */
     public function getInput()
     {
-        return $this->app->getTag('input', [
+        return $this->app->getTag('input', array_merge([
             'name'        => $this->short_name,
             'type'        => 'hidden',
             'id'          => $this->id.'_input',
             'value'       => $this->getValue(),
             'readonly'    => $this->readonly ? 'readonly' : false,
             'disabled'    => $this->disabled ? 'disabled' : false,
-        ]);
+        ], $this->inputAttr));
     }
 
     public function getFilterInput($name, $id, $value = null)

--- a/src/FormField/TextArea.php
+++ b/src/FormField/TextArea.php
@@ -19,7 +19,7 @@ class TextArea extends Input
      */
     public function getInput()
     {
-        return $this->app->getTag('textarea', [
+        return $this->app->getTag('textarea', array_merge([
             'name'        => $this->short_name,
             'type'        => $this->inputType,
             'rows'        => $this->rows,
@@ -27,7 +27,7 @@ class TextArea extends Input
             'id'          => $this->id.'_input',
             'readonly'    => $this->readonly ? 'readonly' : false,
             'disabled'    => $this->disabled ? 'disabled' : false,
-        ], (string) $this->getValue() // need to cast to string to avoid null values which break html markup
+        ], $this->inputAttr), (string) $this->getValue() // need to cast to string to avoid null values which break html markup
         );
     }
 }


### PR DESCRIPTION
Until now, only attributes could be set to the surrounding <div class="field"> using $formfield->setAttr(). This PR makes it possible to add attributes directly to the <input> tag: 


New property added: $this->inputAttr in which additional attributes are stored
New function added: setInputAttr() which is a clone of View->setAttr() which fills the $this->inputAttr array

Can also be used to overwrite existing attributes as $this->inputAttr is passed as second param to array_merge (at $this->app->getTag())