### PR TITLE
Fix unclickable Autocomplete/Lookup fields

### DIFF
--- a/template/semantic-ui/formfield/autocomplete.html
+++ b/template/semantic-ui/formfield/autocomplete.html
@@ -5,7 +5,7 @@
 {Input}<input class={$input_class} type="{input_type}text{/}" {$input_attributes}/>{/}
 <i class="dropdown icon"></i>
 <div class="default text">{$place_holder}</div>
-<input class="search" value="{$value}" {$readonly} {$disabled}/>
+<input class="search" value="{$value}" {$readonly} {$disabled} style="width:100%"/>
 </div>
 {$AfterInput}{$AfterAfterInput}
 </div>

--- a/template/semantic-ui/formfield/autocomplete.pug
+++ b/template/semantic-ui/formfield/autocomplete.pug
@@ -4,7 +4,7 @@
 | {Input}<input class={$input_class} type="{input_type}text{/}" {$input_attributes}/>{/}
 | <i class="dropdown icon"></i>
 | <div class="default text">{$place_holder}</div>
-| <input class="search" value="{$value}" {$readonly} {$disabled}/>
+| <input class="search" value="{$value}" {$readonly} {$disabled} style="width:100%"/>
 | </div>
 | {$AfterInput}{$AfterAfterInput}
 | </div>

--- a/template/semantic-ui/formfield/lookup.html
+++ b/template/semantic-ui/formfield/lookup.html
@@ -13,7 +13,7 @@
 {Input}<input class={$input_class} type="{input_type}text{/}" {$input_attributes}/>{/}
 <i class="dropdown icon"></i>
 <div class="default text">{$place_holder}</div>
-<input class="search" value="{$value}" {$readonly} {$disabled}>
+<input class="search" value="{$value}" {$readonly} {$disabled} style="width:100%">
 </div>
 {$AfterInput}{$AfterAfterInput}
 </div>

--- a/template/semantic-ui/formfield/lookup.pug
+++ b/template/semantic-ui/formfield/lookup.pug
@@ -12,7 +12,7 @@
 | {Input}<input class={$input_class} type="{input_type}text{/}" {$input_attributes}/>{/}
 | <i class="dropdown icon"></i>
 | <div class="default text">{$place_holder}</div>
-| <input class="search" value="{$value}" {$readonly} {$disabled}>
+| <input class="search" value="{$value}" {$readonly} {$disabled} style="width:100%">
 | </div>
 | {$AfterInput}{$AfterAfterInput}
 | </div>


### PR DESCRIPTION
In Autocomplete and Lookup controls, a large area of the control is unclickable, showing a hand cursor. This makes those controls effectively unusable.

![image](https://user-images.githubusercontent.com/23142906/66076108-bf923b00-e565-11e9-9793-8090cc7d370f.png)

The issue is reproducible in the current demo (for example https://ui.agiletoolkit.org/demos/autocomplete.php - hovering over Country1/2/3 towards the right will produce the hand cursor and unclickable control).

This PR fixes the issue for both controls.

