### PR TITLE
Property currency_decimal added to Persistence UI (Money Type)

### DIFF
--- a/src/FormField/Money.php
+++ b/src/FormField/Money.php
@@ -17,7 +17,7 @@ class Money extends Input
             return;
         }
 
-        return number_format($v, 2);
+        return number_format($v, $this->app->ui_persistence->currency_decimals);
     }
 
     public function renderView()

--- a/src/Persistence/UI.php
+++ b/src/Persistence/UI.php
@@ -34,6 +34,14 @@ class UI extends \atk4\data\Persistence
 
     public $currency = '€';
 
+    /**
+     * Default decimal count for type 'money'
+     *  Used directly in number_format() second parameter
+     * 
+     * @var int
+     */
+    public $currency_decimals = 2;
+
     public $yes = 'Yes';
     public $no = 'No';
 
@@ -56,7 +64,7 @@ class UI extends \atk4\data\Persistence
         case 'boolean':
             return $v ? $this->yes : $this->no;
         case 'money':
-            return ($this->currency ? $this->currency.' ' : '').number_format($v, 2);
+            return ($this->currency ? $this->currency.' ' : '').number_format($v, $this->currency_decimals);
         case 'date':
         case 'datetime':
         case 'time':


### PR DESCRIPTION
Implementation of `currency_decimal property in UI persistence`. Simple use:

``` php
$app->ui_persistence->currency_decimals = 2; // default

// Typical US large or estimate type amount use:
$app->ui_persistence->currency = '$';
$app->ui_persistence->currency_decimals = 0; // no decimals

// When dealing in fractions of a penny type numbers
$app->ui_persistence->currency_decimals = 4; 
..
```

Displaying money type (currencies) with custom or zero decimal points. It is very common in business to chop off decimals for larger numbers.

Drag a SCREENSHOT here:
![image](https://user-images.githubusercontent.com/6198401/68731534-68d54380-059e-11ea-92de-c26d94543bd8.png)

