### PR TITLE
Add data field ui parameter for Money to override ui_persistence currency and currency_decimals

### DIFF
--- a/docs/core.rst
+++ b/docs/core.rst
@@ -106,6 +106,7 @@ by having the ability to introduce new types with consistent support throughout 
 
 .. toctree::
     type-presentation
+    ui_persistence
 
 
 

--- a/docs/ui_persistence.rst
+++ b/docs/ui_persistence.rst
@@ -19,59 +19,73 @@ a means of allowing data types and parameters within data models to be utilized 
 global properties affecting formatting and output.
 
 
-Global Properties
-=================
+Class Properties
+================
 
-.. php:attr:: $date_format = 'M d, Y'
+.. php:attr:: date_format
 
 Output format for date fields::
 
-    $this->ui_persistence->date_format = 'Y-m-d';
+    $this->ui_persistence->date_format = 'M d, Y'; // Default
+    $this->ui_persistence->date_format = 'Y-m-d';  // International Standard
 
-.. php:attr:: $time_format = 'H:i'
+
+.. php:attr:: time_format
 
 Output format for time fields::
 
-    $this->ui_persistence->time_format = 'h:ia';
+    $this->ui_persistence->time_format = 'H:i'; // Default
 
-.. php:attr:: $datetime_format = 'M d, Y H:i:s'
+
+.. php:attr:: datetime_format
 
 Output format for datetime fields::
 
+    $this->ui_persistence->datetime_format = 'M d, Y H:i:s' // Default
     $this->ui_persistence->datetime_format = 'Y-m-d h:ia';
 
-.. php:attr:: $firstDayOfWeek = 0
 
-For calendars, Monday is 1, Sunday is 0.
+.. php:attr:: firstDayOfWeek
 
-.. php:attr:: $currency = '€'
+For calendars, Monday is 1, Sunday is 0 (Default).
 
-Field type :php:class:`\\atk4\ui\Persistence\Money` use this as a prefix in output, or tag on
+
+.. php:attr:: currency
+
+Field type :php:class:`\\atk4\\ui\\Persistence\\Money` use this as a prefix in output, or tag on
 form input fields::
 
+    $this->ui_persistence->currency = '€';   // Default 
     $this->ui_persistence->currency = '';    // No prefix
-    $this->ui_persistence->currency = '$';   // Generic dollar prefix
-    $this->ui_persistence->currency = 'NOK'; // Currrency specific prefix
+    $this->ui_persistence->currency = '$';
+    $this->ui_persistence->currency = 'NOK';
 
-.. php:attr:: $currency_decimals = 2;
 
-Field type :php:class:`\\atk4\ui\Persistence\Money` use this value as decimal count for
+.. php:attr:: currency_decimals
+
+Field type :php:class:`\\atk4\\ui\\Persistence\\Money` use this value as decimal count for
 number_format() in forms and data output::
 
+    $this->ui_persistence->currency_decimals = 2;  // 2,000,000.43 (Default)
     $this->ui_persistence->currency_decimals = 0;  // 2,000,000
     $this->ui_persistence->currency_decimals = 4;  // 2,000,000.4321
 
 
-.. php:attr:: $yes = 'Yes';
+.. php:attr:: yes
 
+string 'Yes'
 Documentation Needed.
 
-.. php:attr:: $no = 'No';
 
+.. php:attr:: no
+
+string 'No'
 Documentation Needed.
 
-.. php:attr:: $calendar_options = [];
 
+.. php:attr:: calendar_options
+
+array []
 Documentation Needed.
 
 
@@ -100,7 +114,7 @@ in the data model::
     $data_model->addFields([
 
         // Local cost is exact and uses defaults
-        ['local_extact_cost', type => 'money'],
+        ['local_cost', type => 'money'],
 
         // Foreign cost is an estimate, uses no fractions and sets currency prefix
         [

--- a/docs/ui_persistence.rst
+++ b/docs/ui_persistence.rst
@@ -1,0 +1,121 @@
+
+.. _ui_persistence:
+
+==============
+UI Persistence
+==============
+
+.. php:namespace:: atk4\ui\Persistence
+
+.. php:class:: UI
+
+.. warning:: This documentation is incomplete, does NOT include all aspects
+    of Persistence UI, for now it is a simple listing of class properties,
+    and partial information related to :php:class:`\\atk4\\data\\Model` field
+    definitions, with a few usage examples.
+
+Persistence UI extends :php:class:`\\atk4\\data\\Persistence`, a simplified summary explains this class as
+a means of allowing data types and parameters within data models to be utilized in UI, it also contains
+global properties affecting formatting and output.
+
+
+Global Properties
+=================
+
+.. php:attr:: $date_format = 'M d, Y'
+
+Output format for date fields::
+
+    $this->ui_persistence->date_format = 'Y-m-d';
+
+.. php:attr:: $time_format = 'H:i'
+
+Output format for time fields::
+
+    $this->ui_persistence->time_format = 'h:ia';
+
+.. php:attr:: $datetime_format = 'M d, Y H:i:s'
+
+Output format for datetime fields::
+
+    $this->ui_persistence->datetime_format = 'Y-m-d h:ia';
+
+.. php:attr:: $firstDayOfWeek = 0
+
+For calendars, Monday is 1, Sunday is 0.
+
+.. php:attr:: $currency = '€'
+
+Field type :php:class:`\\atk4\ui\Persistence\Money` use this as a prefix in output, or tag on
+form input fields::
+
+    $this->ui_persistence->currency = '';    // No prefix
+    $this->ui_persistence->currency = '$';   // Generic dollar prefix
+    $this->ui_persistence->currency = 'NOK'; // Currrency specific prefix
+
+.. php:attr:: $currency_decimals = 2;
+
+Field type :php:class:`\\atk4\ui\Persistence\Money` use this value as decimal count for
+number_format() in forms and data output::
+
+    $this->ui_persistence->currency_decimals = 0;  // 2,000,000
+    $this->ui_persistence->currency_decimals = 4;  // 2,000,000.4321
+
+
+.. php:attr:: $yes = 'Yes';
+
+Documentation Needed.
+
+.. php:attr:: $no = 'No';
+
+Documentation Needed.
+
+.. php:attr:: $calendar_options = [];
+
+Documentation Needed.
+
+
+Using Data\Model parameters
+===========================
+
+When adding fields in :php:class:`\\atk4\\data\\Model` you can set the 'ui' property to
+an array containing values used in ui. To find more information on how the ui field
+property is typically used with forms and decorators, see :ref:`field`.
+
+.. warning:: This section is very incomplete, only includes a few examples, and it is
+    possible/likely that all or some of this may be moved elsewhere.
+
+
+
+Money/Currency Settings per Field
+---------------------------------
+
+The global properties for Currency Prefix and Currency Decimals may be overridden at the field level
+in the data model::
+
+    // Local cost quoting is US based - use that for global currency prefix
+    $this->ui_persistence->currency = 'USD';
+
+
+    $data_model->addFields([
+
+        // Local cost is exact and uses defaults
+        ['local_extact_cost', type => 'money'],
+
+        // Foreign cost is an estimate, uses no fractions and sets currency prefix
+        [
+            'estimated_cost_norway',
+            'type' => 'money',
+            'ui' => [
+                'persistence' => [
+                    'currency' => 'NOK',
+                    'currency_decimals' => 0
+                ]
+            ]
+        ],
+
+        // Energy unit cost is usually very accurate
+        ['energy_kw_price', 'type' => 'money', 'ui' => ['persistence' => ['currency_decimals' => 4 ]]]
+
+    ]);
+

--- a/src/FormField/Money.php
+++ b/src/FormField/Money.php
@@ -17,13 +17,23 @@ class Money extends Input
             return;
         }
 
-        return number_format($v, $this->app->ui_persistence->currency_decimals);
+        // Override global ui_persistence with value defined in data model field ui[persistence][currency_decimnals]
+        $currency_decimals = isset($this->field->ui['persistence']['currency_decimals'])
+            ? $this->field->ui['persistence']['currency_decimals']
+            : $this->app->ui_persistence->currency_decimals;
+
+        return number_format($v, $currency_decimals);
     }
 
     public function renderView()
     {
+        // Override global ui_persistence with value defined in data model field ui[persistence][currency]
+        $currency = isset($this->field->ui['persistence']['currency'])
+            ? $this->field->ui['persistence']['currency']
+            : $this->app->ui_persistence->currency;
+
         if ($this->label === null) {
-            $this->label = $this->app->ui_persistence->currency;
+            $this->label = $currency;
         }
 
         parent::renderView();

--- a/src/Persistence/UI.php
+++ b/src/Persistence/UI.php
@@ -71,6 +71,7 @@ class UI extends \atk4\data\Persistence
             $currency_decimals = isset($f->ui['persistence']['currency_decimals'])
                 ? $f->ui['persistence']['currency_decimals']
                 : $this->currency_decimals;
+
             return ($currency ? $currency.' ' : '').number_format($v, $currency_decimals);
         case 'date':
         case 'datetime':

--- a/src/Persistence/UI.php
+++ b/src/Persistence/UI.php
@@ -64,7 +64,14 @@ class UI extends \atk4\data\Persistence
         case 'boolean':
             return $v ? $this->yes : $this->no;
         case 'money':
-            return ($this->currency ? $this->currency.' ' : '').number_format($v, $this->currency_decimals);
+            // Override global ui_persistence with values defined in data model field ui[persistence]
+            $currency = isset($f->ui['persistence']['currency'])
+                ? $f->ui['persistence']['currency']
+                : $this->currency;
+            $currency_decimals = isset($f->ui['persistence']['currency_decimals'])
+                ? $f->ui['persistence']['currency_decimals']
+                : $this->currency_decimals;
+            return ($currency ? $currency.' ' : '').number_format($v, $currency_decimals);
         case 'date':
         case 'datetime':
         case 'time':


### PR DESCRIPTION
This allows using a parameter in Data Field ui property to override ui_persistence for currency and currency_decimals property, so that applications can use mixed currency presentations within the same rendering. 
Also added docs/ui_persistence.rst documentation, which is not complete, it lists all the properties of ui_persistence and explains most of them, and full example of the features in this enhancement. The rst file was added to toc in Core Concepts under Type Presentation

Simple use:

``` php
$model->addFields([

    // Local cost is exact and uses defaults
    ['local_cost', type => 'money'],

    // Foreign cost is an estimate, uses no fractions and sets currency prefix
    [
        'estimated_cost_norway',
        'type' => 'money',
        'ui' => [
            'persistence' => [
                'currency' => 'NOK',
                'currency_decimals' => 0
            ]
        ]
    ],

    // Energy unit cost is usually very accurate
    ['energy_kw_price', 'type' => 'money', 'ui' => ['persistence' => ['currency_decimals' => 4 ]]]

]);

```

Typical use case of new feature explained here.

Drag a SCREENSHOT here:
![image](https://user-images.githubusercontent.com/6198401/68916738-50e3f800-0735-11ea-9829-cdb5545261ad.png)


 - Documentation: [docs/ui_persistence.rst](docs/ui_persistence.rst)
 - I did not create a demo. I will do that another day.

I be happy to re-works some of this if a different structure is preferred in ui property or similar - i figured some documentation is better than none
