### PR TITLE
Add SSE operation with user confirmation example

### DIFF
--- a/demos/sse.php
+++ b/demos/sse.php
@@ -2,7 +2,7 @@
 
 require 'init.php';
 
-$app->add(['ui' => 'divider']);
+$app->add(['Header', 'SSE with ProgressBar']);
 
 $bar = $app->add(['ProgressBar']);
 
@@ -30,3 +30,18 @@ $button->on('click', $sse->set(function () use ($button, $sse, $bar) {
         $button->js()->removeClass('disabled'),
     ];
 }));
+
+$app->add(['ui' => 'divider']);
+$app->add(['Header', 'SSE operation with user confirmation']);
+
+$sse = $app->add(['jsSSE']);
+$button = $app->add(['Button', 'Click me to change my text']);
+
+$button->on('click', $sse->set(function($jsChain) use($sse, $button) {
+
+    $sse->send($button->js()->text('Please wait for 2 seconds...'));
+    sleep(2);
+
+    return $button->js()->text($sse->args['newButtonText']);
+
+}, ['newButtonText'=>'This is my new text!']), ['confirm'=>'Please confirm that you wish to continue']);

--- a/demos/sse.php
+++ b/demos/sse.php
@@ -37,11 +37,9 @@ $app->add(['Header', 'SSE operation with user confirmation']);
 $sse = $app->add(['jsSSE']);
 $button = $app->add(['Button', 'Click me to change my text']);
 
-$button->on('click', $sse->set(function($jsChain) use($sse, $button) {
-
+$button->on('click', $sse->set(function ($jsChain) use ($sse, $button) {
     $sse->send($button->js()->text('Please wait for 2 seconds...'));
     sleep(2);
 
     return $button->js()->text($sse->args['newButtonText']);
-
 }, ['newButtonText'=>'This is my new text!']), ['confirm'=>'Please confirm that you wish to continue']);


### PR DESCRIPTION
This adds an example for triggering an SSE operation after asking confirmation from the user.