### PR TITLE
Fix/Enable Callback argument to stick at application

### DIFF
--- a/src/ActionExecutor/UserAction.php
+++ b/src/ActionExecutor/UserAction.php
@@ -96,7 +96,7 @@ class UserAction extends Modal implements Interface_, jsInterface_
         $this->nextStepBtn = $this->btns->add(new Button(['Next', 'blue']));
         $this->addButtonAction($this->btns);
 
-        $this->loader = $this->add(['Loader', 'ui'   => $this->loaderUi, 'shim' => $this->loaderShim]);
+        $this->loader = $this->add(['Loader', 'ui'   => $this->loaderUi, 'shim' => $this->loaderShim, 'appStickyCb' => true]);
         $this->loader->loadEvent = false;
         $this->loader->addClass('atk-hide-loading-content');
         $this->actionData = $this->loader->jsGetStoreData()['session'];

--- a/src/ActionExecutor/UserAction.php
+++ b/src/ActionExecutor/UserAction.php
@@ -96,7 +96,7 @@ class UserAction extends Modal implements Interface_, jsInterface_
         $this->nextStepBtn = $this->btns->add(new Button(['Next', 'blue']));
         $this->addButtonAction($this->btns);
 
-        $this->loader = $this->add(['Loader', 'ui'   => $this->loaderUi, 'shim' => $this->loaderShim, 'appStickyCb' => true]);
+        $this->loader = $this->add(['Loader', 'ui'   => $this->loaderUi, 'shim' => $this->loaderShim]);
         $this->loader->loadEvent = false;
         $this->loader->addClass('atk-hide-loading-content');
         $this->actionData = $this->loader->jsGetStoreData()['session'];

--- a/src/Callback.php
+++ b/src/Callback.php
@@ -55,6 +55,9 @@ class Callback
      */
     public $urlTrigger = null;
 
+    /** @var bool stick callback url argument to view or application. */
+    public $appSticky = false;
+
     /**
      * Initialize object and set default properties.
      *
@@ -72,6 +75,10 @@ class Callback
     {
         $this->_init();
 
+        if (!$this->app) {
+            throw new Exception(['Call-back must be part of a RenderTree']);
+        }
+
         if (!$this->urlTrigger) {
             $this->urlTrigger = $this->name;
         }
@@ -80,11 +87,7 @@ class Callback
             $this->postTrigger = $this->name;
         }
 
-        $this->owner->stickyGet($this->urlTrigger);
-
-        if (!$this->app) {
-            throw new Exception(['Call-back must be part of a RenderTree']);
-        }
+        $this->appSticky ? $this->app->stickyGet($this->urlTrigger) : $this->owner->stickyGet($this->urlTrigger);
     }
 
     /**

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -29,7 +29,11 @@ class Loader extends View
      */
     public $loadEvent = true;
 
+    /** @var string defautl css class */
     public $ui = 'ui segment';
+
+    /** @var bool Make callback url argument stick to application or view. */
+    public $appStickyCb = false;
 
     /** @var callable for triggering */
     protected $cb;
@@ -42,7 +46,7 @@ class Loader extends View
             $this->shim = ['View', 'class' => ['padded segment'], 'style' => ['min-height' => '7em']];
         }
 
-        $this->cb = $this->add('Callback');
+        $this->cb = $this->add(['Callback', 'appSticky' => $this->appStickyCb]);
     }
 
     /**


### PR DESCRIPTION
Sometimes, callback argument need to stick application-wide, not just in View.
This is especially true for ActionExecutor using application modal.

This PR allows us to create a URL argument that stick to application.
