### PR TITLE
Implement conditional tags in template

### DIFF
--- a/docs/template.rst
+++ b/docs/template.rst
@@ -523,6 +523,7 @@ template will automatically render as::
 
     My  phone 123.
 
+Note that zero value is treated as not empty value!
 
 Views and Templates
 ===================

--- a/docs/template.rst
+++ b/docs/template.rst
@@ -442,7 +442,7 @@ have used my own View object with some more sophisticated presentation logic.
 The only affect on the example would be name of the class, the rest of
 presentation logic would be abstracted inside view's ``render()`` method.
 
-Other opreations with tags
+Other operations with tags
 --------------------------
 
 .. php:method:: del(tag)
@@ -504,6 +504,25 @@ your template::
 See also: :ref:`templates and views`
 
 .. todo:: fix this reference
+
+Conditional tags
+----------------
+
+Agile Toolkit template engine allows you to use socalled conditional tags
+which will automatically remove template regions if tag value is empty.
+Conditional tags notation is trailing question mark symbol.
+
+Consider this example::
+
+    My {email?}e-mail {$email}{/email?} {phone?}phone {$phone}{/?}.
+
+This will only show text "e-mail" and email address if email tag value is
+set to not empty value. Same for "phone" tag.
+So if you execute ``set('email',null)`` and ``set('phone',123)`` then this
+template will automatically render as::
+
+    My  phone 123.
+
 
 Views and Templates
 ===================

--- a/src/Template.php
+++ b/src/Template.php
@@ -336,6 +336,11 @@ class Template implements \ArrayAccess
         if ($encode) {
             $value = htmlspecialchars($value, ENT_NOQUOTES, 'UTF-8');
         }
+        
+        // remove conditional regions if any
+        if (!$value) {
+            $this->tryDel($tag.'?');
+        }
 
         // set or append value
         $template = $this->getTagRefList($tag);
@@ -802,7 +807,7 @@ class Template implements \ArrayAccess
      */
     protected function parseTemplate($str)
     {
-        $tag = '/{([\/$]?[-_:\w]*)}/';
+        $tag = '/{([\/$]?[-_:\w]*[\?]?)}/';
 
         $input = preg_split($tag, $str, -1, PREG_SPLIT_DELIM_CAPTURE);
 

--- a/src/Template.php
+++ b/src/Template.php
@@ -336,7 +336,7 @@ class Template implements \ArrayAccess
         if ($encode) {
             $value = htmlspecialchars($value, ENT_NOQUOTES, 'UTF-8');
         }
-        
+
         // remove conditional regions if any
         if (!$value) {
             $this->tryDel($tag.'?');

--- a/src/Template.php
+++ b/src/Template.php
@@ -321,7 +321,7 @@ class Template implements \ArrayAccess
         if (!$tag) {
             throw new Exception(['Tag is not set', 'tag' => $tag, 'value' => $value]);
         }
-        
+
         // check value
         if (!is_scalar($value) && $value !== null) {
             throw new Exception(['Value should be scalar', 'tag' => $tag, 'value' => $value]);
@@ -333,7 +333,7 @@ class Template implements \ArrayAccess
         }
 
         // if no value, then set respective conditional regions to empty string
-        if (substr($tag, -1) != '?' && ($value === false || !strlen((string)$value))) {
+        if (substr($tag, -1) != '?' && ($value === false || !strlen((string) $value))) {
             $this->trySet($tag.'?', '');
         }
 
@@ -849,7 +849,7 @@ class Template implements \ArrayAccess
     {
         $output = '';
         foreach ($template as $tag => $val) {
-//var_dump($tag,$val);
+            //var_dump($tag,$val);
             if (is_array($val)) {
                 $output .= $this->recursiveRender($val);
             } else {

--- a/src/Template.php
+++ b/src/Template.php
@@ -338,7 +338,7 @@ class Template implements \ArrayAccess
         }
 
         // remove conditional regions if any
-        if (!$value) {
+        if (strlen((string) $value) == 0) {
             $this->tryDel($tag.'?');
         }
 

--- a/src/Template.php
+++ b/src/Template.php
@@ -848,8 +848,7 @@ class Template implements \ArrayAccess
     protected function recursiveRender($template)
     {
         $output = '';
-        foreach ($template as $tag => $val) {
-            //var_dump($tag,$val);
+        foreach ($template as $val) {
             if (is_array($val)) {
                 $output .= $this->recursiveRender($val);
             } else {

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -89,7 +89,7 @@ class TemplateTest extends \atk4\core\PHPUnit_AgileTestCase
         $t = new \atk4\ui\Template($s);
         $t->set('email', false);
         $t->set('phone', 0);
-        $this->assertEquals('My  . Contact me!', $t->render());
+        $this->assertEquals('My  phone 0. Contact me!', $t->render());
 
         // nested conditional tags (renders comma only when both values are provided)
         $s = 'My {email?}e-mail {$email}{/email?}{email?}{phone?}, {/?}{/?}{phone?}phone {$phone}{/?}. Contact me!';
@@ -107,7 +107,7 @@ class TemplateTest extends \atk4\core\PHPUnit_AgileTestCase
         $t = new \atk4\ui\Template($s);
         $t->set('email', false);
         $t->set('phone', 0);
-        $this->assertEquals('My . Contact me!', $t->render());
+        $this->assertEquals('My phone 0. Contact me!', $t->render());
     }
 
     /**

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -46,7 +46,7 @@ class TemplateTest extends \atk4\core\PHPUnit_AgileTestCase
         $t2 = ['good bye']; // will change $t->template because it's by reference
         $this->assertEquals(['', 'foo#1'=>['good bye'], ', cruel ', 'bar#1'=>['world'], '. ', 'foo#2'=>['hello']], $t->template);
     }
-    
+
     /**
      * Test conditional tag.
      */
@@ -54,17 +54,17 @@ class TemplateTest extends \atk4\core\PHPUnit_AgileTestCase
     {
         $s = 'My {email?}e-mail {$email}{/email?} {phone?}phone {$phone}{/?}. Contact me!';
         $t = new \atk4\ui\Template($s);
-        
+
         $t1 = &$t->getTagRef('_top');
         $this->assertEquals([
-            0 => 'My ',
+            0          => 'My ',
             'email?#1' => [
-                0 => 'e-mail ',
+                0         => 'e-mail ',
                 'email#1' => [''],
             ],
-            1 => ' ',
+            1          => ' ',
             'phone?#1' => [
-                0 => 'phone ',
+                0         => 'phone ',
                 'phone#1' => [''],
             ],
             2 => '. Contact me!',

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -90,6 +90,24 @@ class TemplateTest extends \atk4\core\PHPUnit_AgileTestCase
         $t->set('email', false);
         $t->set('phone', 0);
         $this->assertEquals('My  . Contact me!', $t->render());
+
+        // nested conditional tags (renders comma only when both values are provided)
+        $s = 'My {email?}e-mail {$email}{/email?}{email?}{phone?}, {/?}{/?}{phone?}phone {$phone}{/?}. Contact me!';
+
+        $t = new \atk4\ui\Template($s);
+        $t->set('email', 'test@example.com');
+        $t->set('phone', 123);
+        $this->assertEquals('My e-mail test@example.com, phone 123. Contact me!', $t->render());
+
+        $t = new \atk4\ui\Template($s);
+        $t->set('email', null);
+        $t->set('phone', 123);
+        $this->assertEquals('My phone 123. Contact me!', $t->render());
+
+        $t = new \atk4\ui\Template($s);
+        $t->set('email', false);
+        $t->set('phone', 0);
+        $this->assertEquals('My . Contact me!', $t->render());
     }
 
     /**

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -121,10 +121,10 @@ class TemplateTest extends \atk4\core\PHPUnit_AgileTestCase
 
         $f = function ($vat) use ($s) {
             return (new \atk4\ui\Template($s))->set([
-                'vat_applied' => !empty($vat),
-                'vat_zero' => ($vat === 0),
-                'vat_not_applied' => ($vat===null),
-                'vat' => $vat,
+                'vat_applied'     => !empty($vat),
+                'vat_zero'        => ($vat === 0),
+                'vat_not_applied' => ($vat === null),
+                'vat'             => $vat,
             ]);
         };
 

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -111,6 +111,29 @@ class TemplateTest extends \atk4\core\PHPUnit_AgileTestCase
     }
 
     /**
+     * Conditional tag usage example - VAT usage.
+     */
+    public function testConditionalTagsVAT()
+    {
+        $s = '{vat_applied?}VAT is {$vat}%{/?}'.
+             '{vat_zero?}VAT is zero{/?}'.
+             '{vat_not_applied?}VAT is not applied{/?}';
+
+        $f = function ($vat) use ($s) {
+            return (new \atk4\ui\Template($s))->set([
+                'vat_applied' => !empty($vat),
+                'vat_zero' => ($vat === 0),
+                'vat_not_applied' => ($vat===null),
+                'vat' => $vat,
+            ]);
+        };
+
+        $this->assertEquals('VAT is 21%', $f(21)->render());
+        $this->assertEquals('VAT is zero', $f(0)->render());
+        $this->assertEquals('VAT is not applied', $f(null)->render());
+    }
+
+    /**
      * Exception in getTagRef().
      *
      * @expectedException Exception

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -46,6 +46,51 @@ class TemplateTest extends \atk4\core\PHPUnit_AgileTestCase
         $t2 = ['good bye']; // will change $t->template because it's by reference
         $this->assertEquals(['', 'foo#1'=>['good bye'], ', cruel ', 'bar#1'=>['world'], '. ', 'foo#2'=>['hello']], $t->template);
     }
+    
+    /**
+     * Test conditional tag.
+     */
+    public function testConditionalTags()
+    {
+        $s = 'My {email?}e-mail {$email}{/email?} {phone?}phone {$phone}{/?}. Contact me!';
+        $t = new \atk4\ui\Template($s);
+        
+        $t1 = &$t->getTagRef('_top');
+        $this->assertEquals([
+            0 => 'My ',
+            'email?#1' => [
+                0 => 'e-mail ',
+                'email#1' => [''],
+            ],
+            1 => ' ',
+            'phone?#1' => [
+                0 => 'phone ',
+                'phone#1' => [''],
+            ],
+            2 => '. Contact me!',
+        ], $t1);
+
+        // test filled values
+        $t = new \atk4\ui\Template($s);
+        $t->set('email', 'test@example.com');
+        $t->set('phone', 123);
+        $this->assertEquals('My e-mail test@example.com phone 123. Contact me!', $t->render());
+
+        $t = new \atk4\ui\Template($s);
+        $t->set('email', null);
+        $t->set('phone', 123);
+        $this->assertEquals('My  phone 123. Contact me!', $t->render());
+
+        $t = new \atk4\ui\Template($s);
+        $t->set('email', '');
+        $t->set('phone', 123);
+        $this->assertEquals('My  phone 123. Contact me!', $t->render());
+
+        $t = new \atk4\ui\Template($s);
+        $t->set('email', false);
+        $t->set('phone', 0);
+        $this->assertEquals('My  . Contact me!', $t->render());
+    }
 
     /**
      * Exception in getTagRef().

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -125,12 +125,12 @@ class TemplateTest extends \atk4\core\PHPUnit_AgileTestCase
                 'vat_zero'        => ($vat === 0),
                 'vat_not_applied' => ($vat === null),
                 'vat'             => $vat,
-            ]);
+            ])->render();
         };
 
-        $this->assertEquals('VAT is 21%', $f(21)->render());
-        $this->assertEquals('VAT is zero', $f(0)->render());
-        $this->assertEquals('VAT is not applied', $f(null)->render());
+        $this->assertEquals('VAT is 21%', $f(21));
+        $this->assertEquals('VAT is zero', $f(0));
+        $this->assertEquals('VAT is not applied', $f(null));
     }
 
     /**


### PR DESCRIPTION
Allows to use special _conditional_ tags `{tagname?}` in Template which will automatically remove respective template region in case `tagname` value is set to empty (string, false, null, 0).

For example,
```
$s = 'My {email?}e-mail {$email}{/email?} {phone?}phone {$phone}{/?}. Contact me!';
$t = new \atk4\ui\Template($s);
$t->set('email', null);
$t->set('phone', 123);
$this->assertEquals('My  phone 123. Contact me!', $t->render());
```
