### PR TITLE
Update string quotes to make the code compatible with Netbeans

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -368,7 +368,7 @@ class App
                 }
                 if ($keys) {
                     $ids = implode(',', $keys);
-                    $remove_function = "$('.ui.dimmer.modals.page').find('${ids}').remove();";
+                    $remove_function = '$(\'.ui.dimmer.modals.page\').find(\''.$ids.'\').remove();';
                 }
                 $output = '<script>jQuery(function() {'.$remove_function.$output['atkjs'].'});</script>'.$output['html'];
                 $this->outputResponseHtml($output);


### PR DESCRIPTION
Change string quotes from double quotes to single quotes as the double quotes with current complex content is not parsed by Netbeans correctly. No functional change.

Before:
![image](https://user-images.githubusercontent.com/2228672/73607291-7229e700-45b4-11ea-855c-637afef7de76.png)

After:
![image](https://user-images.githubusercontent.com/2228672/73607295-8241c680-45b4-11ea-8853-3666f11a2a5a.png)

Also reporting to the Netbeans - https://issues.apache.org/jira/browse/NETBEANS-3782 . Please fix here too for cleaner code and to make autocomplete/refactoring working before it is fixed in Netbeans.

PS: I also checked other files matching `^[^"\n]*("[^"\n]*"[^"\n]*)*"[^"\n]*\$[^"\n]*"` regex but this seems to be the only issue.