### PR TITLE
use trait for table tests

### DIFF
--- a/tests/Concerns/HandlesTable.php
+++ b/tests/Concerns/HandlesTable.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace atk4\ui\tests\Concerns;
+
+use atk4\ui\Table;
+
+trait HandlesTable
+{
+    /**
+     * Extract only <tr> out from an atk4\ui\Table given the <tr> data-id attribute value.
+     *
+     * @param Table  $table
+     * @param string $rowDataId
+     *
+     * @return string
+     */
+    protected function extractTableRow(Table $table, $rowDataId = '1')
+    {
+        $matches = [];
+
+        preg_match('/<.*data-id="'.$rowDataId.'".*/m', $table->render(), $matches);
+
+        return str_replace(["\r", "\n"], '', $matches[0]);
+    }
+}

--- a/tests/GridTest.php
+++ b/tests/GridTest.php
@@ -7,6 +7,8 @@ use atk4\ui\TableColumn\Template;
 
 class GridTest extends \atk4\core\PHPUnit_AgileTestCase
 {
+    use Concerns\HandlesTable;
+
     public $m;
 
     public function setUp()
@@ -15,7 +17,7 @@ class GridTest extends \atk4\core\PHPUnit_AgileTestCase
         $a[1] = ['id' => 1, 'email' => 'test@test.com', 'password' => 'abc123', 'xtra' => 'xtra'];
         $a[2] = ['id' => 2, 'email' => 'test@yahoo.com', 'password' => 'secret'];
 
-        $this->m = new MyModel(new \atk4\data\Persistence_Array($a));
+        $this->m = new MyModel(new \atk4\data\Persistence\Array_($a));
     }
 
     public function test1()
@@ -30,7 +32,7 @@ class GridTest extends \atk4\core\PHPUnit_AgileTestCase
         $this->assertEquals('<td>{$email}</td><td>password={$password}</td>', $t->getDataRowHTML());
         $this->assertEquals(
             '<tr data-id="1"><td>test@test.com</td><td>password=abc123</td></tr>',
-            $this->extract($t)
+            $this->extractTableRow($t)
         );
     }
 
@@ -46,7 +48,7 @@ class GridTest extends \atk4\core\PHPUnit_AgileTestCase
         $this->assertEquals('<td>{$email}</td><td>***</td>', $t->getDataRowHTML());
         $this->assertEquals(
             '<tr data-id="1"><td>test@test.com</td><td>***</td></tr>',
-            $this->extract($t)
+            $this->extractTableRow($t)
         );
     }
 
@@ -60,7 +62,7 @@ class GridTest extends \atk4\core\PHPUnit_AgileTestCase
         $this->assertEquals('<td>{$email}</td><td><a href="#" title="Delete {$email}?" class="delete"><i class="ui red trash icon"></i>Delete</a></td>', $t->getDataRowHTML());
         $this->assertEquals(
             '<tr data-id="1"><td>test@test.com</td><td><a href="#" title="Delete test@test.com?" class="delete"><i class="ui red trash icon"></i>Delete</a></td></tr>',
-            $this->extract($t)
+            $this->extractTableRow($t)
         );
     }
 
@@ -74,17 +76,8 @@ class GridTest extends \atk4\core\PHPUnit_AgileTestCase
         $this->assertEquals('<td>{$email}</td><td>***</td>', $t->getDataRowHTML());
         $this->assertEquals(
             '<tr data-id="1"><td>test@test.com</td><td>***</td></tr>',
-            $this->extract($t)
+            $this->extractTableRow($t)
         );
-    }
-
-    public function extract($t)
-    {
-        // extract only <tr> out
-        $val = $t->render();
-        preg_match('/<.*data-id="1".*/m', $val, $matches);
-
-        return $matches[0];
     }
 }
 

--- a/tests/TableColumnColorRatingTest.php
+++ b/tests/TableColumnColorRatingTest.php
@@ -6,18 +6,12 @@ use atk4\ui\Table;
 
 class TableColumnColorRatingTest extends \atk4\core\PHPUnit_AgileTestCase
 {
+    use Concerns\HandlesTable;
+
     public $db;
     /** @var Table */
     public $table;
     public $column;
-
-    protected function extract($val)
-    {
-        // extract only <tr> out
-        preg_match('/<.*data-id="1".*/m', $val, $matches);
-
-        return $matches[0];
-    }
 
     public function setUp()
     {
@@ -65,7 +59,7 @@ class TableColumnColorRatingTest extends \atk4\core\PHPUnit_AgileTestCase
 
         $this->assertEquals(
             '<tr data-id="1"><td>bar</td><td>ref123</td><td style="background-color:#00ff00;">3</td></tr>',
-            $this->extract($this->table->render())
+            $this->extractTableRow($this->table)
         );
     }
 
@@ -88,7 +82,7 @@ class TableColumnColorRatingTest extends \atk4\core\PHPUnit_AgileTestCase
 
         $this->assertEquals(
             '<tr data-id="1"><td>bar</td><td>ref123</td><td style="">3</td></tr>',
-            $this->extract($this->table->render())
+            $this->extractTableRow($this->table)
         );
     }
 
@@ -115,7 +109,7 @@ class TableColumnColorRatingTest extends \atk4\core\PHPUnit_AgileTestCase
 
         $this->assertEquals(
             '<tr data-id="1"><td>bar</td><td>ref123</td><td style="background-color:#ff0000;">3</td></tr>',
-            $this->extract($this->table->render())
+            $this->extractTableRow($this->table)
         );
     }
 
@@ -138,7 +132,7 @@ class TableColumnColorRatingTest extends \atk4\core\PHPUnit_AgileTestCase
 
         $this->assertEquals(
             '<tr data-id="1"><td>bar</td><td>ref123</td><td style="">3</td></tr>',
-            $this->extract($this->table->render())
+            $this->extractTableRow($this->table)
         );
     }
 

--- a/tests/TableColumnLinkTest.php
+++ b/tests/TableColumnLinkTest.php
@@ -4,6 +4,8 @@ namespace atk4\ui\tests;
 
 class TableColumnLinkTest extends \atk4\core\PHPUnit_AgileTestCase
 {
+    use Concerns\HandlesTable;
+
     public $db;
     public $table;
     public $column;
@@ -27,7 +29,7 @@ class TableColumnLinkTest extends \atk4\core\PHPUnit_AgileTestCase
 
         $this->assertEquals(
             '<tr data-id="1"><td>bar</td><td>ref123</td></tr>',
-            $this->extract($this->table->render())
+            $this->extractTableRow($this->table)
         );
     }
 
@@ -39,7 +41,7 @@ class TableColumnLinkTest extends \atk4\core\PHPUnit_AgileTestCase
 
         $this->assertEquals(
             '<tr data-id="1"><td><b>bar</b></td><td>ref123</td></tr>',
-            $this->extract($this->table->render())
+            $this->extractTableRow($this->table)
         );
     }
 
@@ -54,7 +56,7 @@ class TableColumnLinkTest extends \atk4\core\PHPUnit_AgileTestCase
 
         $this->assertEquals(
             '<tr data-id="1"><td>bar</td><td>ref123</td><td class="negative right aligned single line">-123</td></tr>',
-            $this->extract($this->table->render())
+            $this->extractTableRow($this->table)
         );
     }
 
@@ -70,7 +72,7 @@ class TableColumnLinkTest extends \atk4\core\PHPUnit_AgileTestCase
 
         $this->assertEquals(
             '<tr data-id="1"><td>bar</td><td>ref123</td><td class="negative right aligned single line"><b>-123</b></td></tr>',
-            $this->extract($this->table->render())
+            $this->extractTableRow($this->table)
         );
     }
 
@@ -87,7 +89,7 @@ class TableColumnLinkTest extends \atk4\core\PHPUnit_AgileTestCase
 
         $this->assertEquals(
             '<tr data-id="1"><td class=" right aligned single line">bar</td><td>ref123</td><td class="negative right aligned single line"><b>-123</b></td></tr>',
-            $this->extract($this->table->render())
+            $this->extractTableRow($this->table)
         );
     }
 
@@ -105,16 +107,8 @@ class TableColumnLinkTest extends \atk4\core\PHPUnit_AgileTestCase
 
         $this->assertEquals(
             '<tr data-id="1"><td><u><b>bar</b></u></td><td>ref123</td></tr>',
-            $this->extract($this->table->render())
+            $this->extractTableRow($this->table)
         );
-    }
-
-    public function extract($val)
-    {
-        // extract only <tr> out
-        preg_match('/<.*data-id="1".*/m', $val, $matches);
-
-        return $matches[0];
     }
 
     public function testRender1()
@@ -126,7 +120,7 @@ class TableColumnLinkTest extends \atk4\core\PHPUnit_AgileTestCase
 
         $this->assertEquals(
             '<tr data-id="1"><td><u><b>bar</b></u></td><td>ref123</td></tr>',
-            $this->extract($this->table->render())
+            $this->extractTableRow($this->table)
         );
     }
 
@@ -143,7 +137,7 @@ class TableColumnLinkTest extends \atk4\core\PHPUnit_AgileTestCase
 
         $this->assertEquals(
             '<tr data-id="1"><td>bar</td><td>ref123</td><td>hello<b>world</b></td></tr>',
-            $this->extract($this->table->render())
+            $this->extractTableRow($this->table)
         );
     }
 
@@ -158,7 +152,7 @@ class TableColumnLinkTest extends \atk4\core\PHPUnit_AgileTestCase
 
         $this->assertEquals(
             '<tr data-id="1"><td><a href="example.php?id=1">bar</a></td><td>ref123</td></tr>',
-            $this->extract($this->table->render())
+            $this->extractTableRow($this->table)
         );
     }
 
@@ -173,7 +167,7 @@ class TableColumnLinkTest extends \atk4\core\PHPUnit_AgileTestCase
 
         $this->assertEquals(
             '<tr data-id="1"><td><a href="example.php?id=1">bar</a></td><td>ref123</td></tr>',
-            $this->extract($this->table->render())
+            $this->extractTableRow($this->table)
         );
     }
 
@@ -185,7 +179,7 @@ class TableColumnLinkTest extends \atk4\core\PHPUnit_AgileTestCase
 
         $this->assertEquals(
             '<tr data-id="1"><td><a href="example.php?id=%7B%24id%7D">bar</a></td><td>ref123</td></tr>',
-            $this->extract($this->table->render())
+            $this->extractTableRow($this->table)
         );
     }
 
@@ -195,7 +189,7 @@ class TableColumnLinkTest extends \atk4\core\PHPUnit_AgileTestCase
 
         $this->assertEquals(
             '<tr data-id="1"><td><a href="example.php?id=1">bar</a></td><td>ref123</td></tr>',
-            $this->extract($this->table->render())
+            $this->extractTableRow($this->table)
         );
     }
 
@@ -205,7 +199,7 @@ class TableColumnLinkTest extends \atk4\core\PHPUnit_AgileTestCase
 
         $this->assertEquals(
             '<tr data-id="1"><td><a href="example.php?test=1">bar</a></td><td>ref123</td></tr>',
-            $this->extract($this->table->render())
+            $this->extractTableRow($this->table)
         );
     }
 
@@ -215,7 +209,7 @@ class TableColumnLinkTest extends \atk4\core\PHPUnit_AgileTestCase
 
         $this->assertEquals(
             '<tr data-id="1"><td><a href="example.php?test=1">bar</a></td><td>ref123</td></tr>',
-            $this->extract($this->table->render())
+            $this->extractTableRow($this->table)
         );
     }
 
@@ -225,7 +219,7 @@ class TableColumnLinkTest extends \atk4\core\PHPUnit_AgileTestCase
 
         $this->assertEquals(
             '<tr data-id="1"><td><a href="example.php?test=1" download="true" >bar</a></td><td>ref123</td></tr>',
-            $this->extract($this->table->render())
+            $this->extractTableRow($this->table)
         );
     }
 
@@ -235,7 +229,7 @@ class TableColumnLinkTest extends \atk4\core\PHPUnit_AgileTestCase
 
         $this->assertEquals(
             '<tr data-id="1"><td><a href="example.php?test=1" target="_blank" >bar</a></td><td>ref123</td></tr>',
-            $this->extract($this->table->render())
+            $this->extractTableRow($this->table)
         );
     }
 
@@ -245,7 +239,7 @@ class TableColumnLinkTest extends \atk4\core\PHPUnit_AgileTestCase
 
         $this->assertEquals(
             '<tr data-id="1"><td><a href="example.php?test=1"><i class="icon info"></i>bar</a></td><td>ref123</td></tr>',
-            $this->extract($this->table->render())
+            $this->extractTableRow($this->table)
         );
     }
 
@@ -255,7 +249,7 @@ class TableColumnLinkTest extends \atk4\core\PHPUnit_AgileTestCase
 
         $this->assertEquals(
             '<tr data-id="1"><td><a href="example.php?test=1"></a></td><td>ref123</td></tr>',
-            $this->extract($this->table->render())
+            $this->extractTableRow($this->table)
         );
     }
 
@@ -276,7 +270,7 @@ class TableColumnLinkTest extends \atk4\core\PHPUnit_AgileTestCase
 
         $this->assertEquals(
             '<tr data-id="1"><td> --- </td><td>ref123</td></tr>',
-            $this->extract($this->table->render())
+            $this->extractTableRow($this->table)
         );
     }
 
@@ -286,7 +280,7 @@ class TableColumnLinkTest extends \atk4\core\PHPUnit_AgileTestCase
 
         $this->assertEquals(
             '<tr data-id="1"><td class=""> bar<span class="ui icon link " data-tooltip="ref123"><i class="ui icon info circle"></span></td><td>ref123</td></tr>',
-            $this->extract($this->table->render())
+            $this->extractTableRow($this->table)
         );
     }
 


### PR DESCRIPTION
- separate common code in a trait
- rename method to a more intuitive name
- allow for selecting data-id of table row to extract
- strip newline to ensure string comparison passes
- use new array persistence class