### PR TITLE
Prevent dropdown open on autofocus

### DIFF
--- a/src/Modal.php
+++ b/src/Modal.php
@@ -133,7 +133,7 @@ class Modal extends View
             $js_chain->data(['args' => $args]);
         }
 
-        return $js_chain->modal('show');
+        return $js_chain->modal(['autofocus' => false])->blur()->modal('show'); // show modal, but prevent autofocus, as it can open dropdown and cover a lot of controls
     }
 
     /**


### PR DESCRIPTION
Currently, when dropdown is the first control in modal windows, it opens by default and can cover a lot of controls/space.

fixes https://github.com/atk4/ui/issues/512