### PR TITLE
Don't render Menu if it's empty

### DIFF
--- a/demos/menu.php
+++ b/demos/menu.php
@@ -48,3 +48,6 @@ $i->add(['View', 'element' => 'P'])->set('Check out our promotions');
 //$m = $app->add('Menu');
 //$i->addItem()->add('FormField/Input');
 //$i->add(['View', 'element'=>'P'])->set('Check out our promotions');
+
+// menu without any item should not show
+$app->add('Menu');

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -183,7 +183,21 @@ class Menu extends View
         foreach ($m as $m) {
         }
     }
+    */
+
+    /**
+     * {@inheritdoc}
      */
+    public function getHTML()
+    {
+        // if menu don't have a single element or content, then destroy it
+        if (empty($this->elements) && !$this->content) {
+            $this->destroy();
+            return '';
+        }
+
+        return parent::getHTML();
+    }
 
     /**
      * {@inheritdoc}

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -193,6 +193,7 @@ class Menu extends View
         // if menu don't have a single element or content, then destroy it
         if (empty($this->elements) && !$this->content) {
             $this->destroy();
+
             return '';
         }
 


### PR DESCRIPTION
This way we will no more see empty menu containers in our generated HTML including CRUD menu.
fix #908