### PR TITLE
Use ::addTo() method in View::add()

### DIFF
--- a/demos/accordion-nested.php
+++ b/demos/accordion-nested.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/init.php';
 /*
 $app->add(['Button', 'View Form input split in Accordion section', 'small right floated basic blue', 'iconRight' => 'right arrow'])
     ->link(['accordion-in-form']);
-$app->add(['ui' => 'clearing divider']);
+$app->add(['View', 'ui' => 'clearing divider']);
 */
 
 $app->add(['Header', 'Nested accordions']);

--- a/demos/accordion.php
+++ b/demos/accordion.php
@@ -4,12 +4,12 @@ require_once __DIR__ . '/init.php';
 
 $app->add(['Button', 'Nested accordions', 'small right floated basic blue', 'iconRight' => 'right arrow'])
     ->link(['accordion-nested']);
-$app->add(['ui' => 'clearing divider']);
+$app->add(['View', 'ui' => 'clearing divider']);
 
 $app->add(['Header', 'Accordion\'s section can be control programmatically.']);
 
 // toggle menu
-$bar = $app->add(['ui' => 'buttons']);
+$bar = $app->add(['View', 'ui' => 'buttons']);
 $b1 = $bar->add(['Button', 'Toggle Section #1']);
 $b2 = $bar->add(['Button', 'Toggle Section #2']);
 $b3 = $bar->add(['Button', 'Toggle Section #3']);

--- a/demos/breadcrumb.php
+++ b/demos/breadcrumb.php
@@ -9,7 +9,7 @@ $crumb = $app->add('BreadCrumb');
 $crumb->addCrumb('UI Demo', ['index']);
 $crumb->addCrumb('BreadCrumb Demo', ['breadcrumb']);
 
-$app->add(['ui'=>'divider']);
+$app->add(['View', 'ui'=>'divider']);
 
 $crumb->addCrumb('Countries', []);
 

--- a/demos/button.php
+++ b/demos/button.php
@@ -34,13 +34,13 @@ $app->add(['Button', 'No', 'negative basic']);
 
 $app->add(['Header', 'Combining Buttons', 'size' => 2]);
 
-$bar = $app->add(['ui' => 'vertical buttons']);
+$bar = $app->add(['View', 'ui' => 'vertical buttons']);
 $bar->add(['Button', 'Play', 'icon' => 'play']);
 $bar->add(['Button', 'Pause', 'icon' => 'pause']);
 $bar->add(['Button', 'Shuffle', 'icon' => 'shuffle']);
 
 $app->add(['Header', 'Icon Bar', 'size' => 2]);
-$bar = $app->add(['ui' => 'big blue buttons']);
+$bar = $app->add(['View', 'ui' => 'big blue buttons']);
 $bar->add(['Button', 'icon'=>'file']);
 $bar->add(['Button', 'icon'=>'yellow save']);
 $bar->add(['Button', 'icon'=>'upload', 'disabled'=>true]);
@@ -62,7 +62,7 @@ $app->add(new ForkButton(1234 + rand(1, 100)));
 
 $app->add(['Header', 'Custom Template', 'size' => 2]);
 
-$view = $app->add(['template' => new Template('Hello, {$tag1}, my name is {$tag2}')]);
+$view = $app->add(['View', 'template' => new Template('Hello, {$tag1}, my name is {$tag2}')]);
 
 $view->add(new Button('World'), 'tag1');
 $view->add(new Button(['Agile UI', 'blue']), 'tag2');

--- a/demos/card.php
+++ b/demos/card.php
@@ -40,7 +40,7 @@ $card->addDescription('Friend of Bob');
 
 $app->add(['Header', 'Card can display model label in a table or in line.', 'size' => 3]);
 
-$deck = $app->add(['ui' => 'cards']);
+$deck = $app->add(['View', 'ui' => 'cards']);
 
 $card_s = $deck->add(['Card', 'useTable' => true]);
 $card_s->addContent(new \atk4\ui\Header(['Project Info']));

--- a/demos/crud.php
+++ b/demos/crud.php
@@ -32,7 +32,7 @@ $g->setModel($m);
 
 $g->addDecorator($m->title_field, ['Link', ['test' => false, 'path' => 'interfaces/page'], ['_id'=>'id']]);
 
-$app->add(['ui'=>'divider']);
+$app->add(['View', 'ui'=>'divider']);
 
 $c = $app->add('Columns');
 $cc = $c->addColumn(0, 'ui blue segment');

--- a/demos/field2.php
+++ b/demos/field2.php
@@ -109,7 +109,7 @@ $field = $form->addField('name', ['Line', 'hint'=>'this is sample hint that esca
 $field->set('value in a form');
 
 $field = $form->addField('surname', new \atk4\ui\FormField\Line([
-    'hint'=> ['template'=> new \atk4\ui\Template(
+    'hint'=> ['View', 'template'=> new \atk4\ui\Template(
         'Click <a href="http://example.com/" target="_blank">here</a>'
     )],
 ]));

--- a/demos/field2.php
+++ b/demos/field2.php
@@ -122,7 +122,7 @@ $app->add(['Header', 'Multiple Form Layouts']);
 
 $form = $app->add('Form');
 $tabs = $form->add('Tabs', 'AboveFields');
-$form->add(['ui' => 'divider'], 'AboveFields');
+$form->add(['View', 'ui' => 'divider'], 'AboveFields');
 
 $form_page = $tabs->addTab('Basic Info')->add(['FormLayout/Generic', 'form' => $form]);
 $form_page->addField('name', new \atk4\ui\FormField\Line());

--- a/demos/form-section.php
+++ b/demos/form-section.php
@@ -42,7 +42,7 @@ $f->addField('phonecode');
 
 $f->onSubmit($noSave);
 
-$app->add(['ui' => 'divider']);
+$app->add(['View', 'ui' => 'divider']);
 
 ////////////////////////////////
 
@@ -64,7 +64,7 @@ $a2->setModel($m, ['numcode', 'phonecode']);
 
 $f->onSubmit($noSave);
 
-$app->add(['ui' => 'divider']);
+$app->add(['View', 'ui' => 'divider']);
 
 ////////////////////////////////
 
@@ -86,7 +86,7 @@ $t2->setModel($m, ['numcode', 'phonecode']);
 
 $f->onSubmit($noSave);
 
-$app->add(['ui' => 'divider']);
+$app->add(['View', 'ui' => 'divider']);
 
 /////////////////////////////////////////
 
@@ -111,4 +111,4 @@ $c2->setModel($m, ['numcode', 'phonecode']);
 
 $f->onSubmit($noSave);
 
-$app->add(['ui' => 'divider']);
+$app->add(['View', 'ui' => 'divider']);

--- a/demos/index.php
+++ b/demos/index.php
@@ -74,7 +74,7 @@ $wizard->addStep('Interactivity', function ($page) {
     /** @var \atk4\ui\Text $t */
     $t = $page->add('Text');
     $t->addParagraph(<<< 'EOF'
-PHP is a server-side language. That prompted us to implement server-side UI actions. They are very easy to define - 
+PHP is a server-side language. That prompted us to implement server-side UI actions. They are very easy to define -
 no need to create any routes or custom routines, simply define a PHP closure like this:
 EOF
     );
@@ -96,19 +96,19 @@ EOF
     );
 
     $page->add(new Demo())->setCode(<<<'CODE'
-    
-$seg = $app->add(['ui'=>'segment']);
+
+$seg = $app->add(['View', 'ui'=>'segment']);
 
 $seg->add('Text')->set('Number of buttons: ');
 
 $paginator = $seg->add([
-    'Paginator', 
-    'total'=>5, 
+    'Paginator',
+    'total'=>5,
     'reload'=>$seg,
     'urlTrigger'=>'count'
 ]);
 
-$seg->add(['ui'=>'divider']);
+$seg->add(['View', 'ui'=>'divider']);
 
 for($i=1; $i <= ($_GET['count'] ?? 1); $i++) {
     $seg->add(['Button', $i]);
@@ -141,7 +141,7 @@ class Invoice extends \atk4\data\Model {
     public $title_field = 'reference';
     function init() {
         parent::init();
-        
+
         $this->addField('reference');
         $this->addField('date', ['type'=>'date']);
     }
@@ -154,7 +154,7 @@ $form = $app->add('Form');
 $form->setModel(new Invoice($session))
     ->tryLoad(1);
 
-$app->add(['ui'=>'divider']);
+$app->add(['View', 'ui'=>'divider']);
 $app->add(['Button', 'Refresh', 'icon'=>'refresh'])
     ->on('click', $app->jsReload());
 
@@ -163,7 +163,7 @@ CODE
 
     $t = $page->add('Text');
     $t->addParagraph(<<< 'EOF'
-This code shows you a combination of 3 objects: 
+This code shows you a combination of 3 objects:
 EOF
     );
     $t->addHTML(<<< 'HTML'
@@ -253,7 +253,7 @@ HTML
     $wizard->add(['Button', 'Exit demo', 'primary', 'icon'=>'left arrow'], 'Left')
         ->link(['begin'=>false, 'layout'=>false]);
 
-    $page->add(['ui'=>'divider']);
+    $page->add(['View', 'ui'=>'divider']);
 
     $page->add(['Message', 'Cool fact!', 'info', 'icon'=>'book'])->text
         ->addParagraph('This entire demo is coded in Agile Toolkit and takes up less than 300 lines of very simple code code!');

--- a/demos/init.php
+++ b/demos/init.php
@@ -28,7 +28,7 @@ class Demo extends \atk4\ui\Columns
     public function setCode($code, $lang = 'php')
     {
         $this->highLightCode();
-        $this->left->add(['element'=>'pre'])->add(['element' => 'code'])->addClass($lang)->set($code);
+        $this->left->add(['View', 'element'=>'pre'])->add(['View', 'element' => 'code'])->addClass($lang)->set($code);
         $app = $this->right;
         $app->db = $this->app->db;
         eval($code);

--- a/demos/jsactions2.php
+++ b/demos/jsactions2.php
@@ -20,7 +20,7 @@ $c = $gl->add(['Card', 'useLabel' => true], 'r1c1');
 $c->addContent(new \atk4\ui\Header(['Using country: ']));
 $c->setModel($country, ['iso', 'iso3', 'phonecode']);
 
-$buttons = $gl->add(['ui'=>'vertical basic buttons'], 'r1c2');
+$buttons = $gl->add(['View', 'ui'=>'vertical basic buttons'], 'r1c2');
 
 $country->unload();
 

--- a/demos/lister.php
+++ b/demos/lister.php
@@ -11,7 +11,7 @@ $app->add(['Lister', 'defaultTemplate'=>'lister.html'])->setSource([
     ['icon'=> 'map marker', 'title'=>'Xian Famous Foods', 'descr'=>'A taste of Shaanxi\'s delicious culinary traditions, with delights like spicy cold noodles and lamb burgers.'],
     ['icon'=> 'check', 'title'=>'Sapporo Haru', 'descr'=>'Greenpoint\'s best choice for quick and delicious sushi'],
 ]);
-$app->add(['ui' => 'clearing divider']);
+$app->add(['View', 'ui' => 'clearing divider']);
 
 // lister with custom template
 $view = $app->add(['View', 'template' => new \atk4\ui\Template('<div>
@@ -26,12 +26,12 @@ $view->add('Lister', 'List')
     ->setModel(new Country($db))
     ->setLimit(20);
 
-$app->add(['ui' => 'clearing divider']);
+$app->add(['View', 'ui' => 'clearing divider']);
 
 // empty lister with default template
 $app->add('Header')->set('Empty default lister');
 $app->add(['Lister', 'defaultTemplate'=>'lister.html'])->setSource([]);
-$app->add(['ui' => 'clearing divider']);
+$app->add(['View', 'ui' => 'clearing divider']);
 
 // empty lister with custom template
 $view = $app->add(['View', 'template' => new \atk4\ui\Template('<div>

--- a/demos/loader.php
+++ b/demos/loader.php
@@ -28,7 +28,7 @@ $app->add('Loader')->set(function ($p) {
         // You may pass arguments to the loader, in this case it's "color"
         sleep(3);
         $p->add(['Header', 'Loader #1b - '.$_GET['color']]);
-        $p->add(['ui' => $_GET['color'].' segment'])->add(new \atk4\ui\LoremIpsum(['size' => 1]));
+        $p->add(['View', 'ui' => $_GET['color'].' segment'])->add(new \atk4\ui\LoremIpsum(['size' => 1]));
 
         // don't forget to make your own argument sticky so that Components can communicate with themselves:
         $p->app->stickyGet('color');

--- a/demos/message.php
+++ b/demos/message.php
@@ -6,9 +6,9 @@ $img = 'https://github.com/atk4/ui/raw/07208a0af84109f0d6e3553e242720d8aeedb784/
 
 $app->add(['Header', 'Message Types']);
 
-$seg = $app->add(['ui' => 'raised segment']);
+$seg = $app->add(['View', 'ui' => 'raised segment']);
 
-$bar_type = $seg->add(['ui' => ' basic buttons']);
+$bar_type = $seg->add(['View', 'ui' => ' basic buttons']);
 
 $msg = $seg->add([
     'Message',

--- a/demos/paginator.php
+++ b/demos/paginator.php
@@ -24,9 +24,9 @@ $day = $seg->stickyGet('day') ?: 1;
 
 // we intentionally left 31 days here and do not calculate number of days in particular month to keep example simple
 $month_paginator = $seg->add(['Paginator', 'total' => 12, 'range' => 3, 'urlTrigger' => 'month']);
-$seg->add(['ui'=>'hidden divider']);
+$seg->add(['View', 'ui'=>'hidden divider']);
 $day_paginator = $seg->add(['Paginator', 'total' => 31, 'range' => 3, 'urlTrigger' => 'day']);
-$seg->add(['ui'=>'hidden divider']);
+$seg->add(['View', 'ui'=>'hidden divider']);
 
 $label = $seg->add(['Label']);
 $label->addClass('orange');

--- a/demos/recursive.php
+++ b/demos/recursive.php
@@ -10,7 +10,7 @@ class MySwitcher extends \atk4\ui\View
 
         $this->add(['Header', 'My name is '.$this->name, 'red']);
 
-        $buttons = $this->add(['ui' => 'basic buttons']);
+        $buttons = $this->add(['View', 'ui' => 'basic buttons']);
         $buttons->add(['Button', 'Yellow'])->setAttr('data-id', 'yellow');
         $buttons->add(['Button', 'Blue'])->setAttr('data-id', 'blue');
         $buttons->add(['Button', 'Button'])->setAttr('data-id', 'button');
@@ -19,16 +19,16 @@ class MySwitcher extends \atk4\ui\View
 
         switch ($this->app->stickyGet($this->name)) {
         case 'yellow':
-            $this->add(['ui' => 'yellow segment'])->add(new self());
+            $this->add(['View', 'ui' => 'yellow segment'])->add(new self());
             break;
         case 'blue':
-            $this->add(['ui' => 'blue segment'])->add(new self());
+            $this->add(['View', 'ui' => 'blue segment'])->add(new self());
             break;
         case 'button':
-            $this->add(['ui' => 'green segment'])->add(['Button', 'Refresh page'])->link([]);
+            $this->add(['View', 'ui' => 'green segment'])->add(['Button', 'Refresh page'])->link([]);
             break;
         }
     }
 }
 
-$app->add(['ui' => 'segment'])->add(new MySwitcher());
+$app->add(['View', 'ui' => 'segment'])->add(new MySwitcher());

--- a/demos/sse.php
+++ b/demos/sse.php
@@ -31,7 +31,7 @@ $button->on('click', $sse->set(function () use ($button, $sse, $bar) {
     ];
 }));
 
-$app->add(['ui' => 'divider']);
+$app->add(['View', 'ui' => 'divider']);
 $app->add(['Header', 'SSE operation with user confirmation']);
 
 $sse = $app->add(['jsSSE']);

--- a/demos/sticky2.php
+++ b/demos/sticky2.php
@@ -8,7 +8,7 @@ if (isset($_GET['name'])) {
 
     // IMPORTANT: because this is an optional frame, I have to specify it's unique short_name explicitly, othrewise
     // the name for a second frame will be affected by presence of GET['name'] parameter
-    $frame = $app->add(['ui'=>'red segment', 'short_name'=>'fr1']);
+    $frame = $app->add(['View', 'ui'=>'red segment', 'short_name'=>'fr1']);
     $frame->stickyGet('name');
 
     // frame will generate URL with sticky parameter
@@ -16,7 +16,7 @@ if (isset($_GET['name'])) {
 
     // app still generates URL without localized sticky
     $frame->add(['Label', 'Reset', 'iconRight'=>'close', 'black'])->link($app->url());
-    $frame->add(['ui'=>'hidden divider']);
+    $frame->add(['View', 'ui'=>'hidden divider']);
 
     // nested interractive elemetns will respect lockal sticky get
     $frame->add(['Button', 'Triggering callback here will inherit color'])->on('click', function () {
@@ -35,7 +35,7 @@ $t = $app->add(['Table']);
 $t->setSource(['Red', 'Green', 'Blue']);
 $t->addDecorator('name', ['Link', [], ['name']]);
 
-$frame = $app->add(['ui'=>'green segment']);
+$frame = $app->add(['View', 'ui'=>'green segment']);
 $frame->add(['Button', 'does not inherit sticky get'])->on('click', function () {
     return new \atk4\ui\jsNotify('$_GET = '.json_encode($_GET));
 });

--- a/demos/tablecolumnmenu.php
+++ b/demos/tablecolumnmenu.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/database.php';
 $app->add(['Header', 'Table column may contains popup or dropdown menu.']);
 
 // Better Popup positionning when Popup are inside a container.
-$container = $app->add(['ui' => 'vertical segment']);
+$container = $app->add(['View', 'ui' => 'vertical segment']);
 $table = $container->add(['Table', 'celled' => true]);
 $table->setModel(new SomeData(), false);
 

--- a/demos/tutorial_actions.php
+++ b/demos/tutorial_actions.php
@@ -21,7 +21,7 @@ $country = new Country($app->app->db);
 
 $country->addAction('send_message');
 
-$app->add(['element'=>'pre'])
+$app->add(['View', 'element'=>'pre'])
     // todo: add dumping!
     ->set(get_class($country->getAction('send_message')));
 CODE
@@ -53,8 +53,8 @@ $model->getAction('delete')->enabled = false;
 $model->addAction('soft_delete', [
     'scope' => \atk4\data\UserAction\Generic::SINGLE_RECORD,
     'ui'    => [
-        'icon'=>'trash', 
-        'button'=>[null, 'icon'=>'red trash'], 
+        'icon'=>'trash',
+        'button'=>[null, 'icon'=>'red trash'],
         'confirm'=>'Are you sure?'
     ],
     'callback' => function ($m) {
@@ -62,7 +62,7 @@ $model->addAction('soft_delete', [
         $m->saveAndUnload();
     },
 ]);
-$app->add(['element'=>'pre'])
+$app->add(['View', 'element'=>'pre'])
     ->set(json_encode(array_keys($model->getActions())));
 CODE
     );
@@ -114,10 +114,10 @@ $model = new \atk4\data\Model($app->db, 'test');
 $model->addAction('greet', [
     'args'=> [
         'age'=>[
-            'type'=>'integer', 
+            'type'=>'integer',
             'required' => true
         ]
-    ], 
+    ],
     'callback'=>function ($m, $age) {
         return 'Age is '.$age;
     }
@@ -127,7 +127,7 @@ $app->add(new \atk4\ui\FormField\Line([
     'action' => $model->getAction('greet'),
 ]));
 
-$app->add(['ui'=>'divider']);
+$app->add(['View', 'ui'=>'divider']);
 
 $app->add(['Button', 'Greet without Age argument'])
     ->on('click', $model->getAction('greet'));

--- a/demos/vue-component.php
+++ b/demos/vue-component.php
@@ -4,7 +4,7 @@ require_once __DIR__ . '/init.php';
 require_once __DIR__ . '/database.php';
 
 $app->add(['Header', 'Component', 'size' => 2, 'icon' => 'vuejs', 'subHeader' => 'UI view handle by Vue.js']);
-$app->add(['ui' => 'divider']);
+$app->add(['View', 'ui' => 'divider']);
 
 //****** Inline Edit *****************************
 
@@ -25,7 +25,7 @@ $inline_edit->onChange(function ($value) {
     return $view;
 });
 
-$app->add(['ui' => 'divider']);
+$app->add(['View', 'ui' => 'divider']);
 
 //****** ITEM SEARCH *****************************
 
@@ -52,7 +52,7 @@ $lister = $lister_container->add('Lister', 'List')
 $search->reload = $lister_container;
 $lister->setModel($search->setModelCondition($m))->setLimit(50);
 
-$app->add(['ui' => 'divider']);
+$app->add(['View', 'ui' => 'divider']);
 
 //****** CREATING CUSTOM VUE USING EXTERNAL COMPONENT *****************************
 $app->add(['Header', 'External Component', 'subHeader' => 'Creating component using an external component definition.']);
@@ -112,7 +112,7 @@ $clock_script = "
               }
             }
           },
-        } 
+        }
     </script>";
 
 // Creating the clock view and injecting js.

--- a/docs/button.rst
+++ b/docs/button.rst
@@ -67,7 +67,7 @@ Button Bar
 Buttons can be aranged into a bar. You would need to create a :php:class:`View` component
 with property ``ui='buttons'`` and add your other buttons inside::
 
-    $bar = $app->add(['ui'=>'vertical buttons']);
+    $bar = $app->add(['View', 'ui'=>'vertical buttons']);
 
     $bar->add(['Button', 'Play', 'icon'=>'play']);
     $bar->add(['Button', 'Pause', 'icon'=>'pause']);

--- a/docs/callbacks.rst
+++ b/docs/callbacks.rst
@@ -163,7 +163,7 @@ know about :php:class:`jsReload` already?
 
 Here is example of jsReload::
 
-    $view = $app->add(['ui'=>'tertiary green inverted segment']);
+    $view = $app->add(['View', 'ui'=>'tertiary green inverted segment']);
     $button = $app->add(['Button', 'Reload Lorem']);
 
     $button->on('click', new \atk4\ui\jsReload($view));

--- a/docs/core.rst
+++ b/docs/core.rst
@@ -134,7 +134,7 @@ have to worry over the details::
     $user = new User($db);
     $user->load(1);
 
-    $view = $app->add(['template'=>'Hello, {$name}, your balance is {$balance}']);
+    $view = $app->add(['View', 'template'=>'Hello, {$name}, your balance is {$balance}']);
     $view->setModel($user);
 
 Next section will explain you how the Agile UI interacts with the data layer and how it outputs or

--- a/docs/field.rst
+++ b/docs/field.rst
@@ -73,7 +73,7 @@ into multiple Tabs or detach field groups or even create nested layouts::
 
     $form = $app->add('Form');
     $tabs = $form->add('Tabs', 'AboveFields');
-    $form->add(['ui'=>'divider'], 'AboveFields');
+    $form->add(['View', 'ui'=>'divider'], 'AboveFields');
 
     $form_page = $tabs->addTab('Basic Info')->add(['FormLayout\Generic', 'form'=>$form]);
     $form_page->addField('name', new \atk4\ui\FormField\Line());

--- a/docs/form.rst
+++ b/docs/form.rst
@@ -169,7 +169,7 @@ specific field type::
 Field Decorator does not have to be added directly into the form. You can use a separate
 :php:class:`FormLayout` or even a regular view. Simply specify property :php:meth:`FormField\Generic::$form`::
 
-    $myview = $form->add(['defaultTemplate'=>'./mytemplate.html']);
+    $myview = $form->add(['View', 'defaultTemplate'=>'./mytemplate.html']);
     $myview->add(['FormField\Dropdown', 'form'=>$form]);
 
 .. php:method:: addFields($fields)

--- a/docs/icon.rst
+++ b/docs/icon.rst
@@ -75,7 +75,7 @@ exclusive to Icon, but I'm adding a few examples here, just for your convenience
 
 Let's start with a View that contains your custom HTML loaded from file or embedded like this::
 
-    $view = $app->add(['template'=>new \atk4\ui\Template('<div>Hello my {Icon}<i class="huge icons">
+    $view = $app->add(['View', 'template'=>new \atk4\ui\Template('<div>Hello my {Icon}<i class="huge icons">
       <i class="big thin circle icon"></i>
       <i class="{Content}user{/} icon"></i>
     </i>{/}, It is me</div>')]);

--- a/docs/lister.rst
+++ b/docs/lister.rst
@@ -27,7 +27,7 @@ items. If your HTML looks like this::
 
 you should put that into file `myview.html` then use it with a view::
 
-    $view = $app->add(['template'=>'myview.html']);
+    $view = $app->add(['View', 'template'=>'myview.html']);
 
 Now your application should contain list of 3 sample countires as you have specified in HTML, but next
 we need to add some tags into your template::

--- a/docs/view.rst
+++ b/docs/view.rst
@@ -336,20 +336,20 @@ to do something before child render, override method :php:meth:`View::recursiveR
 Template of a current view. This attribute contains an object of a class :php:class:`Template`.
 You may secify this value explicitly::
 
-    $app->add(['template'=>new \atk4\ui\Template('<b>hello</b>')]);
+    $app->add(['View', 'template'=>new \atk4\ui\Template('<b>hello</b>')]);
 
 .. php:attr:: defaultTemplate
 
 By default, if value of :php:attr:`View::$template` is not set, then it is loaded from class
 specified in `defaultTemplate`::
 
-    $app->add(['defaultTemplate'=>'./mytpl.html']);
+    $app->add(['View', 'defaultTemplate'=>'./mytpl.html']);
 
 You should specify defaultTemplate using relative path to your project root or, for add-ons,
 relative to a current file::
 
     // in Add-on
-    $app->add(['defaultTemplate'=>__DIR__.'/../templates/mytpl.httml']);
+    $app->add(['View', 'defaultTemplate'=>__DIR__.'/../templates/mytpl.httml']);
 
 Agile UI does not currently provide advanced search path for templates, by default the
 template is loaded from folder `vendor/atk4/ui/template/semantic-ui/`. To change this

--- a/docs/virtualpage.rst
+++ b/docs/virtualpage.rst
@@ -219,7 +219,7 @@ Inline Editing Example
 Next example will display DataTable, but will allow you to repalce data with a form temporarily::
 
 
-    $box = $app->add(['ui'=>'segment']);
+    $box = $app->add(['View', 'ui'=>'segment']);
 
     $loader = $box->add(['Loader', 'loadEvent'=>'edit']);
     $loader->add('Table')

--- a/src/ActionExecutor/Preview.php
+++ b/src/ActionExecutor/Preview.php
@@ -26,15 +26,15 @@ class Preview extends Basic
 
         switch ($this->previewType) {
             case 'console':
-                $this->preview = $this->add(['ui'=>'inverted black segment', 'element'=>'pre']);
+                $this->preview = $this->add(['View', 'ui'=>'inverted black segment', 'element'=>'pre']);
                 $this->preview->set($text);
                 break;
             case 'text':
-                $this->preview = $this->add(['ui'=>'segment']);
+                $this->preview = $this->add(['View', 'ui'=>'segment']);
                 $this->preview->set($text);
                 break;
             case 'html':
-                $this->preview = $this->add(['ui'=>'segment']);
+                $this->preview = $this->add(['View', 'ui'=>'segment']);
                 $this->preview->template->setHTML('Content', $text);
                 break;
         }

--- a/src/ActionExecutor/UserAction.php
+++ b/src/ActionExecutor/UserAction.php
@@ -358,15 +358,15 @@ class UserAction extends Modal implements Interface_, jsInterface_
 
         switch ($this->previewType) {
             case 'console':
-                $preview = $modal->add(['ui'=>'inverted black segment', 'element'=>'pre']);
+                $preview = $modal->add(['View', 'ui'=>'inverted black segment', 'element'=>'pre']);
                 $preview->set($text);
                 break;
             case 'text':
-                $preview = $modal->add(['ui'=>'basic segment']);
+                $preview = $modal->add(['View', 'ui'=>'basic segment']);
                 $preview->set($text);
                 break;
             case 'html':
-                $preview = $modal->add(['ui'=>'basic segment']);
+                $preview = $modal->add(['View', 'ui'=>'basic segment']);
                 $preview->template->setHTML('Content', $text);
                 break;
         }

--- a/src/App.php
+++ b/src/App.php
@@ -464,13 +464,12 @@ class App
     /**
      * Add a new object into the app. You will need to have Layout first.
      *
-     * @param mixed  $seed   New object to add
-     * @param string $region
+     * @param View|string|array $seed   New object to add
+     * @param string|array|null $region
      *
-     * @throws Exception
      * @throws \atk4\core\Exception
      *
-     * @return object
+     * @return View
      */
     public function add($seed, $region = null)
     {

--- a/src/Callback.php
+++ b/src/Callback.php
@@ -5,6 +5,7 @@ namespace atk4\ui;
 use atk4\core\AppScopeTrait;
 use atk4\core\DIContainerTrait;
 use atk4\core\InitializerTrait;
+use atk4\core\StaticAddToTrait;
 use atk4\core\TrackableTrait;
 
 /**
@@ -29,6 +30,7 @@ class Callback
     use InitializerTrait {
         init as _init;
     }
+    use StaticAddToTrait;
 
     /**
      * Will look for trigger in the POST data. Will not care about URL, but

--- a/src/CardDeck.php
+++ b/src/CardDeck.php
@@ -119,10 +119,10 @@ class CardDeck extends View
     {
         $this->menu = $this->add($this->factory(View::class, $this->menu), 'Menu');
 
-        $left = $this->menu->add(['ui' => $this->search !== false ? 'twelve wide column' : 'sixteen wide column']);
-        $this->btns = $left->add(['ui' => 'buttons']);
+        $left = $this->menu->add(['View', 'ui' => $this->search !== false ? 'twelve wide column' : 'sixteen wide column']);
+        $this->btns = $left->add(['View', 'ui' => 'buttons']);
         if ($this->search !== false) {
-            $right = $this->menu->add(['ui' => 'four wide column']);
+            $right = $this->menu->add(['View', 'ui' => 'four wide column']);
             $this->search = $right->add($this->factory(ItemSearch::class, array_merge($this->search, ['context' => '#'.$this->container->name])));
             $this->search->reload = $this->container;
             $this->query = $this->app->stickyGet($this->search->queryArg);
@@ -460,7 +460,7 @@ class CardDeck extends View
     public function renderView()
     {
         if (($this->menu && count($this->menuActions) > 0) || $this->search !== false) {
-            $this->add(['ui' => 'divider'], 'Divider');
+            $this->add(['View', 'ui' => 'divider'], 'Divider');
         }
 
         if (($_GET['__atk_reload'] ?? null) === $this->container->name) {

--- a/src/CardDeck.php
+++ b/src/CardDeck.php
@@ -35,10 +35,10 @@ class CardDeck extends View
     public $useAction = true;
 
     /** @var null|View The container view. The view that is reload when page or data changed. */
-    public $container = ['ui'=> 'basic segment'];
+    public $container = ['View', 'ui'=> 'basic segment'];
 
     /** @var View The view containing Cards. */
-    public $cardHolder = ['ui' => 'cards'];
+    public $cardHolder = ['View', 'ui' => 'cards'];
 
     /** @var null|View The paginator view. */
     public $paginator = null;
@@ -47,10 +47,10 @@ class CardDeck extends View
     public $ipp = 8;
 
     /** @var null|array A menu seed for displaying button inside. */
-    public $menu = ['ui' => 'stackable grid'];
+    public $menu = ['View', 'ui' => 'stackable grid'];
 
     /** @var array|ItemSearch */
-    public $search = ['ui' => 'ui compact basic segment'];
+    public $search = ['View', 'ui' => 'ui compact basic segment'];
 
     /** @var null A view container for buttons. Added into menu when menu is set. */
     private $btns = null;

--- a/src/FormLayout/Columns.php
+++ b/src/FormLayout/Columns.php
@@ -67,7 +67,7 @@ class Columns extends Generic
             $cc->add(['FormLayout/Generic', 'form' => $this->form])->setModel($model, $chunk);
         }
 
-        $this->add(['ui' => 'clearing hidden divider']);
+        $this->add(['View', 'ui' => 'clearing hidden divider']);
 
         return $model;
     }

--- a/src/FormLayout/Generic.php
+++ b/src/FormLayout/Generic.php
@@ -107,7 +107,7 @@ class Generic extends _Abstract
         }
 
         if ($addDivider) {
-            $this->add(['ui' => 'hidden divider']);
+            $this->add(['View', 'ui' => 'hidden divider']);
         }
 
         return $v;

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -168,7 +168,7 @@ class Menu extends View
      */
     public function addDivider()
     {
-        return parent::add(['class' => ['divider']]);
+        return parent::add(['View', 'class' => ['divider']]);
     }
 
     /*

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -151,14 +151,14 @@ class Menu extends View
     /**
      * Add Item.
      *
-     * @param View|string  $object New object to add
-     * @param string|array $region (or array for full set of defaults)
+     * @param View|string|array $seed   New object to add
+     * @param string|array|null $region
      *
      * @return View
      */
-    public function add($object, $region = null)
+    public function add($seed, $region = null)
     {
-        return parent::add($object, $region)->addClass('item');
+        return parent::add($seed, $region)->addClass('item');
     }
 
     /**

--- a/src/View.php
+++ b/src/View.php
@@ -10,6 +10,7 @@ use atk4\core\DIContainerTrait;
 use atk4\core\Exception;
 use atk4\core\FactoryTrait;
 use atk4\core\InitializerTrait;
+use atk4\core\StaticAddToTrait;
 use atk4\core\TrackableTrait;
 use atk4\data\Model;
 use atk4\data\Persistence\Static_;
@@ -37,6 +38,7 @@ class View implements jsExpressionable
     use DIContainerTrait {
         setMissingProperty as _setMissingProperty;
     }
+    use StaticAddToTrait;
 
     // {{{ Properties of the class
 
@@ -400,9 +402,14 @@ class View implements jsExpressionable
      */
     public function add($seed, $region = null)
     {
+        if (func_num_args() > 2) { // prevent bad usage
+            throw new \Error(['Too many method arguments']);
+        }
+
         if ($this->_rendered) {
             throw new Exception('You cannot add anything into the view after it was rendered');
         }
+
         if (!$this->app) {
             $this->_add_later[] = [$seed, $region];
 

--- a/src/View.php
+++ b/src/View.php
@@ -391,10 +391,9 @@ class View implements jsExpressionable
      * In addition to adding a child object, sets up it's template
      * and associate it's output with the region in our template.
      *
-     * @param mixed  $seed   New object to add
-     * @param string $region
+     * @param View|string|array $seed   New object to add
+     * @param string|array|null $region
      *
-     * @throws Exception
      * @throws \atk4\core\Exception
      *
      * @return View


### PR DESCRIPTION
Fixes #907 , no BC break

Example usage:
```
$crud = \atk4\ui\CRUD::createAndAdd($app); // phpdoc return type = atk4\ui\CRUD
$crud->displayFields = ['name']; // type-hinting work
```

code is equivalent to:
```
$crud = $app->add(\atk4\ui\CRUD::class); // phpdoc return type = atk4\ui\View
$crud->displayFields = ['name']; // type-hinting does not work
```