### PR TITLE
Do not fail-fast PHP test matrix

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,6 +10,7 @@ jobs:
     container:
       image: atk4/image:latest # https://github.com/atk4/image
     strategy:
+      fail-fast: false
       matrix:
         php: ['7.2', '7.3', 'latest']
     services:


### PR DESCRIPTION
Currently, if test for one PHP version fail, see https://github.com/atk4/ui/actions/runs/36201430 , other tests are cancelled. This PR fixes GH Actions to behave like TravisCI.