### PR TITLE
Feature/tablecol labels

### DIFF
--- a/src/TableColumn/Generic.php
+++ b/src/TableColumn/Generic.php
@@ -6,6 +6,8 @@ use atk4\ui\Exception;
 use atk4\ui\jQuery;
 use atk4\ui\jsExpression;
 use atk4\ui\Popup;
+use atk4\data\Field;
+use atk4\data\Model;
 
 /**
  * Implements Column helper for table.
@@ -292,11 +294,11 @@ class Generic
      * Provided with a field definition (from a model) will return a header
      * cell, fully formatted to be included in a Table. (<th>).
      *
-     * @param \atk4\data\Field $f
+     * @param Field $f
      *
      * @return string
      */
-    public function getHeaderCellHTML(\atk4\data\Field $f = null, $value = null)
+    public function getHeaderCellHTML(Field $f = null, $value = null)
     {
         $attr = [];
         if (!$this->table) {
@@ -352,12 +354,12 @@ class Generic
     /**
      * Return HTML for a total value of a specific field.
      *
-     * @param \atk4\data\Field $f
-     * @param mixed            $value
+     * @param Field $f
+     * @param mixed $value
      *
      * @return string
      */
-    public function getTotalsCellHTML(\atk4\data\Field $f, $value)
+    public function getTotalsCellHTML(Field $f, $value)
     {
         return $this->getTag('foot', $this->app->ui_persistence->typecastSaveField($f, $value));
     }
@@ -374,11 +376,11 @@ class Generic
      * This method will be executed only once per table rendering, if you need to format data manually,
      * you should use $this->table->addHook('formatRow');
      *
-     * @param \atk4\data\Field $f
+     * @param Field $f
      *
      * @return string
      */
-    public function getDataCellHTML(\atk4\data\Field $f = null, $extra_tags = [])
+    public function getDataCellHTML(Field $f = null, $extra_tags = [])
     {
         return $this->getTag('body', [$this->getDataCellTemplate($f)], $extra_tags);
     }
@@ -394,11 +396,11 @@ class Generic
      * applied to the same column. The first one to be applied is executed first, then
      * a subsequent ones are executed.
      *
-     * @param \atk4\data\Field $f
+     * @param Field $f
      *
      * @return string
      */
-    public function getDataCellTemplate(\atk4\data\Field $f = null)
+    public function getDataCellTemplate(Field $f = null)
     {
         if ($f) {
             return '{$'.$f->short_name.'}';
@@ -411,8 +413,8 @@ class Generic
      * Return associative array of tags to be filled with pre-rendered HTML on
      * a column-basis. Will not be invoked if html-output is turned off for the table.
      *
-     * @param array  $row   link to row data
-     * @param string $field field being rendered
+     * @param Model|array $row   link to row data
+     * @param Field|null  $field field being rendered
      *
      * @return array Associative array with tags and their HTML values.
      */

--- a/src/TableColumn/KeyValue.php
+++ b/src/TableColumn/KeyValue.php
@@ -12,11 +12,11 @@ use atk4\ui\Exception;
  * like a status or a coded state of a process
  * Ex :
  * Machine state :
- * 0 => off
- * 1 => powerup
- * 2 => on
- * 3 => resetting
- * 4 => error
+ *  0 => off
+ *  1 => powerup
+ *  2 => on
+ *  3 => resetting
+ *  4 => error
  *
  * we don't need a table to define this, cause are defined in project
  *
@@ -24,22 +24,18 @@ use atk4\ui\Exception;
  * need to be defined in field like this :
  *
  * $this->addField('course_payment_status', [
- * 'caption' => __('Payment Status'),
- * 'default' => 0,
- * 'values' => [
- * 0 => __('not invoiceable'),
- * 1 => __('ready to invoice'),
- * 2 => __('invoiced'),
- * 3 => __('paid'),
- * ],
- * 'ui'      => [
- * 'form' => [
- * 'DropDown'
- * ],
- * 'table' => [
- * 'KeyValue'
- * ]
- * ],
+ *  'caption' => __('Payment Status'),
+ *  'default' => 0,
+ *  'values' => [
+ *      0 => __('not invoiceable'),
+ *      1 => __('ready to invoice'),
+ *      2 => __('invoiced'),
+ *      3 => __('paid'),
+ *  ],
+ *  'ui'      => [
+ *      'form' => ['DropDown'],
+ *      'table' => ['KeyValue'],
+ *  ],
  * ]);
  */
 class KeyValue extends Generic
@@ -59,7 +55,7 @@ class KeyValue extends Generic
      *
      * @return array|void
      */
-    public function getHTMLTags($row, $field)
+    public function getHTMLTags(array $row, Field $field)
     {
         $values = $field->values;
 
@@ -75,13 +71,8 @@ class KeyValue extends Generic
             return;
         }
 
-        $keyValues = $values;
         $key = $field->get();
-
-        $value = '';
-        if (isset($keyValues[$key])) {
-            $value = $keyValues[$key];
-        }
+        $value = $values[$key] ?? '';
 
         return [$field->short_name => $value];
     }

--- a/src/TableColumn/KeyValue.php
+++ b/src/TableColumn/KeyValue.php
@@ -48,14 +48,14 @@ class KeyValue extends Generic
     }
 
     /**
-     * @param array $row
-     * @param Field $field
+     * @param Model|array $row
+     * @param Field|null  $field
      *
      * @throws Exception
      *
      * @return array|void
      */
-    public function getHTMLTags(array $row, Field $field)
+    public function getHTMLTags($row, $field)
     {
         $values = $field->values;
 

--- a/src/TableColumn/Labels.php
+++ b/src/TableColumn/Labels.php
@@ -15,28 +15,31 @@ use atk4\ui\Exception;
  */
 class Labels extends Generic
 {
+    /** @var array Array of allowed values. This have precedence over $field->values */
+    public $values;
+
     /**
-     * @param array $row
-     * @param Field $field
+     * @param Model|array $row
+     * @param Field|null  $field
      *
      * @return array|void
      */
-    public function getHTMLTags(array $row, Field $field)
+    public function getHTMLTags($row, $field)
     {
-        $values = $field->get();
-        $values = is_string($values) ? explode(',', $values) : $values;
+        $values = $this->values ?? $field->values;
+
+        $v = $field->get();
+        $v = is_string($v) ? explode(',', $v) : $v;
 
         $labels= [];
-        foreach ($values as $value) {
-            $value = trim($value);
+        foreach ($v as $id) {
+            $id = trim($id);
 
             // if field values is set, then use titles instead of IDs
-            if ($field->values && isset($field->values[$value])) {
-                $value = $field->values[$value];
-            }
+            $id = $values[$id] ?? $id;
 
-            if (!empty($value)) {
-                $labels[] = $this->app->getTag('div', ['class' => 'ui label'], $value);
+            if (!empty($id)) {
+                $labels[] = $this->app->getTag('div', ['class' => 'ui label'], $id);
             }
         }
 

--- a/src/TableColumn/Labels.php
+++ b/src/TableColumn/Labels.php
@@ -2,30 +2,46 @@
 
 namespace atk4\ui\TableColumn;
 
+use atk4\data\Field;
+use atk4\ui\Exception;
+
 /**
  * Class Labels.
  *
- * take the fieldValue separated by commas and transforms into SemanticUI labels
+ * Take the field value as string in CSV format or array of IDs and transforms into SemanticUI labels.
+ * If model field values property is set, then will use titles instead of IDs as label text.
  *
  * from => label1,label2 | to => div.ui.label[label1] div.ui.label[label2]
  */
 class Labels extends Generic
 {
-    public function getHTMLTags($row, $field)
+    /**
+     * @param array $row
+     * @param Field $field
+     *
+     * @return array|void
+     */
+    public function getHTMLTags(array $row, Field $field)
     {
-        $values = explode(',', $field->get());
+        $values = $field->get();
+        $values = is_string($values) ? explode(',', $values) : $values;
 
-        $processed = [];
+        $labels= [];
         foreach ($values as $value) {
             $value = trim($value);
 
+            // if field values is set, then use titles instead of IDs
+            if ($field->values && isset($field->values[$value])) {
+                $value = $field->values[$value];
+            }
+
             if (!empty($value)) {
-                $processed[] = $this->app->getTag('div', ['class' => 'ui label'], $value);
+                $labels[] = $this->app->getTag('div', ['class' => 'ui label'], $value);
             }
         }
 
-        $processed = implode('', $processed);
+        $labels = implode('', $labels);
 
-        return [$field->short_name => $processed];
+        return [$field->short_name => $labels];
     }
 }


### PR DESCRIPTION
Will use titles in `TableColumn\Labels` if possible.
Also now it will be aware of field->values property.

Example:
```
$v = [];
foreach($m = $this->ref('service_id')->ref('Expressions') as $junk) {
    $v[$m->id] = $m->getTitle();
}
$this->addField('expression_list', [ // in CSV format, encoded by UI FormField\DropDown
    'required'  => true,
    //'values' => $v, // can not use values here because it then will not allow selecting multiple values

    'ui' => [
        'form' => ['DropDown', 'isMultiple'=>true, 'model'=>$m],
        'table' => ['Labels', 'values'=>$v],
    ],
]);
```
