### PR TITLE
[FEATURE] enable use of existing menu for Grid

### DIFF
--- a/src/Grid.php
+++ b/src/Grid.php
@@ -131,7 +131,8 @@ class Grid extends View
             $this->sortTrigger = $this->name.'_sort';
         }
 
-        if ($this->menu !== false) {
+        // if menu not disabled ot not already assigned as existing object
+        if ($this->menu !== false && !is_object($this->menu)) {
             $this->menu = $this->add($this->factory(['Menu', 'activate_on_click' => false], $this->menu, 'atk4\ui'), 'Menu');
         }
 


### PR DESCRIPTION
Grid will use the Menu passed to `$menu` property directly if it is already an object

As example is the use of common Menu for the page. Then it can be assigned to accept items from the Grid instead of Grid creating its own menu.

Without feature:
![before](https://user-images.githubusercontent.com/8128250/74691976-79243c80-51e5-11ea-84ef-d83b72af0fbd.png)

With feature:
![after](https://user-images.githubusercontent.com/8128250/74691987-83463b00-51e5-11ea-8bf0-073cf7c7e7cb.png)

