### PR TITLE
fix/UserAction Title

### DIFF
--- a/src/ActionExecutor/UserAction.php
+++ b/src/ActionExecutor/UserAction.php
@@ -119,7 +119,7 @@ class UserAction extends Modal implements Interface_, jsInterface_
 
         // get necessary step need prior to execute action.
         if ($this->steps = $this->getSteps($action)) {
-            $this->title = trim($action->caption.' '.$this->action->owner->getModelCaption());
+            $this->title = $this->title ?? trim($action->caption.' '.$this->action->owner->getModelCaption());
 
             $this->btns->add($this->execActionBtn = $this->factory($this->action->ui['execButton'] ?? ['Button', $this->action->caption, 'blue'], [], 'atk4\ui'));
 

--- a/src/Modal.php
+++ b/src/Modal.php
@@ -29,12 +29,8 @@ class Modal extends View
 {
     public $defaultTemplate = 'modal.html';
 
-    /**
-     * Set to empty or false for no header.
-     *
-     * @var string
-     */
-    public $title = 'Modal title';
+    /** @var null|string Set null for no title  */
+    public $title = null;
     public $loading_label = 'Loading...';
     public $headerCSS = 'header';
     public $ui = 'modal';


### PR DESCRIPTION
Allow to customize the Modal title for UserAction via Modal:: title property.
 - if title property is null, then it will default to Action and Model caption.