### PR TITLE
fix/Js Package Dependencies

### DIFF
--- a/js/Release.md
+++ b/js/Release.md
@@ -8,6 +8,7 @@
     - @babel/preset-env from 7.8.3 to 7.8.7
     - @babel/polyfill from 7.8.3 to 7.8.7
     - webpack from 4.35.3 to 4.42.0
+- Update Babel config in order to use corejs v3
 
 ### version 1.12.3 (2020-02-11)
 

--- a/js/Release.md
+++ b/js/Release.md
@@ -1,5 +1,14 @@
 ## Release note
 
+### version 1.12.4 (2020-03-18)
+
+- Update dependencie package
+    - @babel/cli from 7.8.3 to 7.8.7
+    - @bable/core from 7.8.3 to 7.8.7
+    - @babel/preset-env from 7.8.3 to 7.8.7
+    - @babel/polyfill from 7.8.3 to 7.8.7
+    - webpack from 4.35.3 to 4.42.0
+
 ### version 1.12.3 (2020-02-11)
 
 - Fix duplicate url encoding for reload-view and ajaxec plugins.

--- a/js/babel.config.js
+++ b/js/babel.config.js
@@ -9,7 +9,7 @@ const presets = [
     "@babel/env",
     {
       targets: "> 1% , not dead",
-      "corejs": "2",
+      "corejs": { version: 3, proposals: true },
       "useBuiltIns": "usage"
     },
   ],

--- a/js/package.json
+++ b/js/package.json
@@ -24,13 +24,14 @@
     "@babel/preset-env": "^7.8.7",
     "babel-loader": "^8.0.6",
     "eslint": "^5.16.0",
-    "uglifyjs-webpack-plugin": "^2.1.3",
+    "serialize-javascript": "^3.0.0",
+    "uglifyjs-webpack-plugin": "^2.2.0",
     "webpack": "^4.42.0",
     "webpack-cli": "^3.3.6"
   },
   "dependencies": {
-    "@babel/polyfill": "^7.8.7",
     "column-resizer": "^1.3.2",
+    "core-js": "^3.6.4",
     "debounce": "^1.1.0",
     "locutus": "^2.0.11",
     "lodash.throttle": "^4.1.1",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atkjs-ui",
-  "version": "1.12.3",
+  "version": "1.12.4",
   "description": "Agile Toolkit Javascript library.",
   "main": "lib/atkjs-ui.js",
   "scripts": {
@@ -20,16 +20,16 @@
   "homepage": "http://www.agiletoolkit.org/",
   "devDependencies": {
     "@babel/cli": "^7.8.3",
-    "@babel/core": "^7.8.3",
-    "@babel/preset-env": "^7.8.3",
+    "@babel/core": "^7.8.7",
+    "@babel/preset-env": "^7.8.7",
     "babel-loader": "^8.0.6",
     "eslint": "^5.16.0",
     "uglifyjs-webpack-plugin": "^2.1.3",
-    "webpack": "^4.35.3",
+    "webpack": "^4.42.0",
     "webpack-cli": "^3.3.6"
   },
   "dependencies": {
-    "@babel/polyfill": "^7.8.3",
+    "@babel/polyfill": "^7.8.7",
     "column-resizer": "^1.3.2",
     "debounce": "^1.1.0",
     "locutus": "^2.0.11",

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -70,8 +70,8 @@ module.exports = env => {
     resolve: {
       alias: {'vue$' : 'vue/dist/vue.esm.js'},
       modules: [
-        path.resolve('./src'),
-        path.join(__dirname, 'node_modules')
+        path.resolve(__dirname, 'src/'),
+        'node_modules'
       ],
       extensions: [
         '.json',


### PR DESCRIPTION
Update dependencies
 - update Babel  which rely on Minimist
├─┬ @babel/core@7.8.7
│ └─┬ json5@2.1.2
│   └── minimist@1.2.5 

- update Babel configuration to use corejs 3
Fix: #994 