### PR TITLE
[Feature] Dropdown Cascade Form Field

### DIFF
--- a/demos/cascade-dropdown.php
+++ b/demos/cascade-dropdown.php
@@ -29,7 +29,6 @@ class SubCategory extends \atk4\data\Model
 
         $this->hasOne('category_id', new Category());
         $this->hasMany('Products', new Product());
-
     }
 }
 

--- a/demos/cascade-dropdown.php
+++ b/demos/cascade-dropdown.php
@@ -1,0 +1,58 @@
+<?php
+require_once __DIR__ . '/init.php';
+require_once __DIR__ . '/database.php';
+
+/*********** MODEL ***************/
+
+class Category extends \atk4\data\Model
+{
+    public $table = 'category';
+
+    public function init()
+    {
+        parent::init();
+        $this->addField('name');
+
+        $this->hasMany('SubCategories', new SubCategory());
+        $this->hasMany('Products', new Product());
+    }
+}
+
+class SubCategory extends \atk4\data\Model
+{
+    public $table = 'sub_category';
+
+    public function init()
+    {
+        parent::init();
+        $this->addField('name');
+
+        $this->hasOne('category_id', new Category());
+        $this->hasMany('Products', new Product());
+
+    }
+}
+
+class Product extends \atk4\data\Model
+{
+    public $table = 'product';
+
+    public function init()
+    {
+        parent::init();
+        $this->addField('name');
+        $this->addField('brand');
+        $this->hasOne('category_id', [new Category()])->addTitle();
+        $this->hasOne('sub_category_id', [new SubCategory()])->addTitle();
+    }
+}
+
+$f = \atk4\ui\Form::addTo($app);
+
+$f->addField('category_id', [\atk4\ui\FormField\DropDown::class, 'model' => new Category($db)]);
+$f->addField('sub_category_id', [\atk4\ui\FormField\DropDownCascade::class, 'cascadeFrom' => 'category_id', 'reference' => 'SubCategories']);
+$f->addField('product_id', [\atk4\ui\FormField\DropDownCascade::class, 'cascadeFrom' => 'sub_category_id', 'reference' => 'Products']);
+
+$f->onSubmit(function($f){
+    echo print_r($f->model->get());
+});

--- a/demos/cascade-dropdown.php
+++ b/demos/cascade-dropdown.php
@@ -53,6 +53,6 @@ $f->addField('category_id', [\atk4\ui\FormField\DropDown::class, 'model' => new 
 $f->addField('sub_category_id', [\atk4\ui\FormField\DropDownCascade::class, 'cascadeFrom' => 'category_id', 'reference' => 'SubCategories']);
 $f->addField('product_id', [\atk4\ui\FormField\DropDownCascade::class, 'cascadeFrom' => 'sub_category_id', 'reference' => 'Products']);
 
-$f->onSubmit(function($f){
+$f->onSubmit(function ($f) {
     echo print_r($f->model->get(), true);
 });

--- a/demos/cascade-dropdown.php
+++ b/demos/cascade-dropdown.php
@@ -54,5 +54,5 @@ $f->addField('sub_category_id', [\atk4\ui\FormField\DropDownCascade::class, 'cas
 $f->addField('product_id', [\atk4\ui\FormField\DropDownCascade::class, 'cascadeFrom' => 'sub_category_id', 'reference' => 'Products']);
 
 $f->onSubmit(function($f){
-    echo print_r($f->model->get());
+    echo print_r($f->model->get(), true);
 });

--- a/docs/field.rst
+++ b/docs/field.rst
@@ -447,6 +447,33 @@ See this example from Model class init method::
         ],
     ]);
 
+DropDownCascade
+===============
+
+DropDownCascade input are extend from DropDown input. They rely on `cascadeFrom` and `reference` property.
+For example, it could be useful when you need to narrow a product selection base on a category and a sub category.
+User will select a Category from a list, then sub category input will automatically load sub category values based on
+user category selection. Same with product list values based on sub category selection and etc.
+
+.. php:attr:: cascadeFrom
+
+This property represent an input field, mostly another DropDown or DropDownCascade field.
+The list values of this field will be build base off the selected value of cascadeFrom input.
+
+.. php:attr:: reference
+
+This property represent a model hasMany reference and should be an hasMany reference of the cascadeFrom input model.
+In other word, the model that will generated list value for this dropdown input is an hasMany reference of the cascadeFrom
+input model.
+
+Assume that each data model are defined and model Category has many Sub-Category and Sub-Category has many Product::
+
+    $f = \atk4\ui\Form::addTo($app);
+    $f->addField('category_id', [DropDown::class, 'model' => new Category($db)]);
+    $f->addField('sub_category_id', [DropDownCascade::class, 'cascadeFrom' => 'category_id', 'reference' => 'SubCategories']);
+    $f->addField('product_id', [DropDownCascade::class, 'cascadeFrom' => 'sub_category_id', 'reference' => 'Products']);
+
+
 AutoComplete
 ============
 

--- a/src/FormField/DropDownCascade.php
+++ b/src/FormField/DropDownCascade.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Dropdown form field that will based it's list value
+ * according to another input value.
+ * Also possible to cascade value from another cascade field.
+ * For example:
+ *  - you need to narrow product base on Category and sub category
+ *       $f = Form::addTo($app);
+ *       $f->addField('category_id', [DropDown::class, 'model' => new Category($db)])->set(3);
+ *       $f->addField('sub_category_id', [DropDownCascade::class, 'cascadeFrom' => 'category_id', 'reference' => 'SubCategories']);
+ *       $f->addField('product_id', [DropDownCascade::class, 'cascadeFrom' => 'sub_category_id', 'reference' => 'Products']);
+ */
+
+namespace atk4\ui\FormField;
+
+use atk4\data\Model;
+use atk4\ui\Exception;
+
+class DropDownCascade extends DropDown
+{
+    /** @var null|string|Generic the form input to use for setting to base this dropdown list values from. */
+    public $cascadeFrom = null;
+
+    /** @var null|string|Model the reference model that will generated value for this dropdown list. Should be a model hasMany reference of cascadeInput model*/
+    public $reference = null;
+
+    /** @var null The form input create by cascadeFrom field*/
+    protected $cascadeInput = null;
+
+    /** @var null The casacade input value. */
+    protected $cascadeInputValue = null;
+
+    public function init()
+    {
+        parent::init();
+
+        if (!$this->cascadeFrom) {
+            throw new Exception('cascadeFrom property is not set.');
+        }
+
+        $this->cascadeInput = is_string($this->cascadeFrom) ? $this->form->getField($this->cascadeFrom) : $this->cascadeFrom;
+
+        if (!$this->cascadeInput instanceof Generic) {
+            throw new Exception('cascadeFrom property should be an instance of atk4/ui/FormField/Generic');
+        }
+
+        $this->cascadeInputValue = $_POST[$this->cascadeInput->name] ?? $this->cascadeInput->field->get('value');
+
+        $this->model = $this->cascadeInput->model ? $this->cascadeInput->model->ref($this->reference) : null;
+
+        $expr = [
+            function($t) {
+                return [
+                    $this->js()->dropdown('change values', $this->getNewValues($this->cascadeInputValue)),
+                    $this->js()->removeClass('loading')
+                ];
+            },
+            $this->js()->dropdown('clear'),
+            $this->js()->addClass('loading'),
+        ];
+
+        $this->cascadeInput->onChange($expr, ['args' => [$this->cascadeInput->name => $this->cascadeInput->jsInput()->val()]]);
+    }
+
+    /**
+     * Generate new dropdown values based on cascadeInput model selected id.
+     * Return an empty value set if id is null.
+     *
+     * @param $id
+     *
+     * @return array
+     */
+    public function getNewValues($id)
+    {
+        if (!$id) {
+            return [['value' => '', 'text' => '...', 'name' => '...']];
+        }
+
+        $mapValue = function($a) {
+            return ['value'=>$a['id'], 'text'=>$a['name'], 'name'=>$a['name']];
+        };
+
+        return array_map($mapValue, $this->cascadeInput->model->load($id)->ref($this->reference)->export());
+    }
+
+    public function renderView()
+    {
+        parent::renderView();
+        // set value on initial load if cascadeInput model is not loaded.
+        if (!$this->cascadeInput->model->loaded()) {
+            $this->js(true)->dropdown('change values', $this->getNewValues($this->cascadeInputValue));
+        }
+    }
+}

--- a/src/FormField/DropDownCascade.php
+++ b/src/FormField/DropDownCascade.php
@@ -49,7 +49,7 @@ class DropDownCascade extends DropDown
         $this->model = $this->cascadeInput->model ? $this->cascadeInput->model->ref($this->reference) : null;
 
         $expr = [
-            function($t) {
+            function ($t) {
                 return [
                     $this->js()->dropdown('change values', $this->getNewValues($this->cascadeInputValue)),
                     $this->js()->removeClass('loading')
@@ -76,7 +76,7 @@ class DropDownCascade extends DropDown
             return [['value' => '', 'text' => '...', 'name' => '...']];
         }
 
-        $mapValue = function($a) {
+        $mapValue = function ($a) {
             return ['value'=>$a['id'], 'text'=>$a['name'], 'name'=>$a['name']];
         };
 


### PR DESCRIPTION
Implementation of DropDownCascade Form field:

Will load it's list value according to the value set in another Dropdown. 

For example, showing a list of products based on selected Category and subcategory.

``` php
$f = \atk4\ui\Form::addTo($app);

$f->addField('category_id', [\atk4\ui\FormField\DropDown::class, 'model' => new Category($db)]);
$f->addField('sub_category_id', [\atk4\ui\FormField\DropDownCascade::class, 'cascadeFrom' => 'category_id', 'reference' => 'SubCategories']);
$f->addField('product_id', [\atk4\ui\FormField\DropDownCascade::class, 'cascadeFrom' => 'sub_category_id', 'reference' => 'Products']);

```

<img width="769" alt="Screen Shot 2020-03-25 at 2 18 21 PM" src="https://user-images.githubusercontent.com/2204478/77571959-92836d00-6ea4-11ea-8d00-57f9a8086511.png">
