### PR TITLE
Do not append semicolon to statement when not needed

### DIFF
--- a/src/jsFunction.php
+++ b/src/jsFunction.php
@@ -92,7 +92,7 @@ class jsFunction implements jsExpressionable
                 throw new Exception(['Incorrect statement for jsFunction.', 'statement' => $statement]);
             }
 
-            $output .= "\n" . $this->indent . '  ' . $statement . ';';
+            $output .= "\n" . $this->indent . '  ' . $statement . (!preg_match('~;\s*$~', $statement) ? ';' : '');
         }
 
         $output .= "\n" . $this->indent . '}';

--- a/src/jsFunction.php
+++ b/src/jsFunction.php
@@ -92,7 +92,7 @@ class jsFunction implements jsExpressionable
                 throw new Exception(['Incorrect statement for jsFunction.', 'statement' => $statement]);
             }
 
-            $output .= "\n" . $this->indent . '  ' . $statement . (!preg_match('~;\s*$~', $statement) ? ';' : '');
+            $output .= "\n" . $this->indent . '  ' . $statement . (!preg_match('~[;}]\s*$~', $statement) ? ';' : '');
         }
 
         $output .= "\n" . $this->indent . '}';


### PR DESCRIPTION
Use cases:
```
// some long code typically from a file - end semicolon is almost always already presented
$code = <<<EOT
    long code here();
    long code here();
    long code here();
    EOT;
new \atk4\ui\jsExpression($code);
```

```
// statement that is surrounded with block brackets - end semicolon is not needed
new \atk4\ui\jsExpression('if (true) {}');
```