### PR TITLE
Fix TableColumn\Labels for null values

### DIFF
--- a/src/TableColumn/Labels.php
+++ b/src/TableColumn/Labels.php
@@ -32,7 +32,7 @@ class Labels extends Generic
         $v = is_string($v) ? explode(',', $v) : $v;
 
         $labels= [];
-        foreach ($v as $id) {
+        foreach ((Array) $v as $id) {
             $id = trim($id);
 
             // if field values is set, then use titles instead of IDs

--- a/src/TableColumn/Labels.php
+++ b/src/TableColumn/Labels.php
@@ -32,7 +32,7 @@ class Labels extends Generic
         $v = is_string($v) ? explode(',', $v) : $v;
 
         $labels= [];
-        foreach ((Array) $v as $id) {
+        foreach ((array) $v as $id) {
             $id = trim($id);
 
             // if field values is set, then use titles instead of IDs


### PR DESCRIPTION
Fix TableColumn\Labels for null values

if $v is null => cast to enpty array.
``` 
foreach ((Array) $v as $id) {
    $id = trim($id);...	         
```


![image](https://user-images.githubusercontent.com/23016360/77948640-a3294e00-72bd-11ea-8843-8fff6098ae4b.png)

