### PR TITLE
[fix] - Allow onDelete or onUpload callback to run within another callback

### DIFF
--- a/demos/upload.php
+++ b/demos/upload.php
@@ -4,7 +4,7 @@ require_once __DIR__ . '/init.php';
 
 $form = \atk4\ui\Form::addTo($app);
 $img = $form->addField('img', ['UploadImg', ['defaultSrc' => './images/default.png', 'placeholder' => 'Click to add an image.']]);
-
+$img->cb->appSticky = true;
 //$img->set('a_new_token', 'an-img-file-name');
 //$img->setThumbnailSrc('./images/logo.png');
 
@@ -16,11 +16,11 @@ $field = $form->addField('file', ['Upload', ['accept' => ['.png', '.jpg']]]);
 $img->onDelete(function ($fileId) use ($img) {
     $img->clearThumbnail('./images/default.png');
 
-    return new atk4\ui\jsNotify(['content' => $fileId . ' has been removed!', 'color' => 'green']);
-});
-
-$field->onDelete(function ($fileId) {
-    return new atk4\ui\jsNotify(['content' => $fileId . ' has been removed!', 'color' => 'green']);
+    return new \atk4\ui\jsToast([
+        'title'   => 'Delete successfully',
+        'message' =>  $fileId.' has been removed',
+        'class'   => 'success',
+    ]);
 });
 
 $img->onUpload(function ($files) use ($form, $img) {
@@ -41,7 +41,19 @@ $img->onUpload(function ($files) use ($form, $img) {
     //return $form->error('file', 'Unable to upload file.');
 
     // can also return a notifier.
-    return new atk4\ui\jsNotify(['content' => 'File is uploaded!', 'color' => 'green']);
+    return new \atk4\ui\jsToast([
+                                    'title'   => 'Upload success',
+                                    'message' => 'Image is uploaded!',
+                                    'class'   => 'success',
+                                ]);
+});
+
+$field->onDelete(function ($fileId) {
+    return new \atk4\ui\jsToast([
+        'title'   => 'Delete successfully',
+        'message' => $fileId.' has been removed',
+        'class'   => 'success',
+    ]);
 });
 
 $field->onUpload(function ($files) use ($form, $field) {
@@ -50,7 +62,11 @@ $field->onUpload(function ($files) use ($form, $field) {
     }
     $field->setFileId('a_token');
 
-    return new atk4\ui\jsNotify(['content' => 'File is uploaded!', 'color' => 'green']);
+    return new \atk4\ui\jsToast([
+        'title'   => 'Upload success',
+        'message' => 'File is uploaded!',
+        'class'   => 'success',
+    ]);
 });
 
 $form->onSubmit(function ($form) {


### PR DESCRIPTION
This fix will prevent throwing an error about onDelete or onUpload callback not been set when running within another callback.

Fix: #1029