### PR TITLE
Fix 5th parameter for set_error_handler() handler is deprecated

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -188,8 +188,8 @@ class App
         if ($this->catch_exceptions) {
             set_exception_handler(Closure::fromCallable([$this, 'caughtException']));
             set_error_handler(
-                function ($err_severity, $err_msg, $err_file, $err_line, array $err_context) {
-                    throw new ErrorException($err_msg, 0, $err_severity, $err_file, $err_line);
+                static function ($severity, $msg, $file, $line) {
+                    throw new ErrorException($msg, 0, $severity, $file, $line);
                 },
                 $this->catch_error_types
             );


### PR DESCRIPTION
See: https://www.php.net/manual/en/function.set-error-handler.php

Fix has no side effect, as the parameter was not used.

Important because: https://travis-ci.org/github/atk4/ui/jobs/670875954#L542