### PR TITLE
[fix] UserAction Modal Id

### DIFF
--- a/demos/crud.php
+++ b/demos/crud.php
@@ -3,9 +3,6 @@
 require_once __DIR__ . '/init.php';
 require_once __DIR__ . '/database.php';
 $m = new Country($db);
-$m->addAction('test', ['ui'=>['button'=>['icon'=>'pencil']]]);
-$m->addAction('test1');
-$m->addAction('test2');
 //$m->getAction('edit')->system =true;
 //$m->getAction('delete')->system =true;
 
@@ -93,9 +90,6 @@ $file = new File($db);
 $file->getAction('edit')->ui['executor'] = MyExecutor::class;
 
 $crud = \atk4\ui\CRUD::addTo($cc, [
-    'canCreate'       => false,
-    'canDelete'       => false,
-    //'pageUpdate'      => ['\MyVP'],
     'ipp'             => 5,
 ]);
 

--- a/src/ActionExecutor/UserAction.php
+++ b/src/ActionExecutor/UserAction.php
@@ -107,7 +107,7 @@ class UserAction extends Modal implements Interface_, jsInterface_
      */
     public function afterActionInit(Generic $action)
     {
-        $getTableName = function($arr) {
+        $getTableName = function ($arr) {
             foreach ($arr as $k => $v) {
                 return is_numeric($k) ? $v : $k;
             }

--- a/src/ActionExecutor/UserAction.php
+++ b/src/ActionExecutor/UserAction.php
@@ -1,6 +1,21 @@
 <?php
 /**
  * Modal executor for action.
+ * These are special modal that will divide a model action into steps
+ * and run each step accordingly via a loader setup in modal view.
+ * The step orders are Argument, Field and Preview, prior to execute the model action.
+ *
+ * It will first determine the number of step necessary to run the model
+ * action. When a step is running through the view loader, data collect for each step
+ * are store in browser session storage via javascript. Thus, each request to execute loader,
+ * include step data within the request.
+ *
+ * UserAction modal view may be generated via callbacks.
+ * These modal are added to app->html view if not already added
+ * and the api service take care of generating them when output
+ * in json via callback. It is important that these UserAction modals
+ * stay within the page html content for loader to run each steps properly.
+ *
  */
 
 namespace atk4\ui\ActionExecutor;

--- a/src/ActionExecutor/UserAction.php
+++ b/src/ActionExecutor/UserAction.php
@@ -91,6 +91,32 @@ class UserAction extends Modal implements Interface_, jsInterface_
     {
         parent::init();
         $this->observeChanges();
+    }
+
+    /**
+     * Make sure modal id is unique.
+     * Since User action can be added via callbacks, we need
+     * to make sure that view id is properly set for loader and button
+     * js action to run properly.
+     *
+     *
+     * @param Generic   $action
+     *
+     * @throws Exception
+     * @throws \atk4\core\Exception
+     */
+    public function afterActionInit(Generic $action)
+    {
+        $getTableName = function($arr) {
+            foreach ($arr as $k => $v) {
+                return is_numeric($k) ? $v : $k;
+            }
+        };
+
+        $table_name = is_array($action->getModel()->table) ? $getTableName($action->getModel()->table) : $action->getModel()->table;
+
+        $this->id = strtolower($this->name . '_' . $table_name . '_' . $action->short_name);
+        $this->name = $this->id;
 
         //Add buttons to modal for next and previous.
         $this->btns = (new View())->addStyle(['min-height' => '24px']);
@@ -117,6 +143,7 @@ class UserAction extends Modal implements Interface_, jsInterface_
     public function setAction(Generic $action): View
     {
         $this->action = $action;
+        $this->afterActionInit($action);
 
         // get necessary step need prior to execute action.
         if ($this->steps = $this->getSteps($action)) {

--- a/tests/DemoCallExitTest.php
+++ b/tests/DemoCallExitTest.php
@@ -132,7 +132,7 @@ class DemoCallExitTest extends BuiltInWebServerAbstract
         $files[] = ['sticky2.php?atk_admin_loader_callback=ajax&__atk_callback1'];
         $files[] = ['virtual.php?atk_admin_label_2_click=ajax&__atk_callback=1'];
         $files[] = ['actions.php?atk_admin_gridlayout_basic_button_click=ajax&__atk_callback=1']; // need to call this before calls other actions to fill model files
-        $files[] = ['actions.php?atk_useraction_loader_callback=ajax&__atk_callback=1&atk_useraction=1&step=fields'];
+        $files[] = ['actions.php?atk_useraction_file_edit_loader_callback=ajax&__atk_callback=1&atk_useraction_file_edit=1&step=fields'];
         $files[] = ['notify.php?__atk_m=atk_admin_modal&atk_admin_modal_view_callbacklater=ajax&__atk_callback=1&__atk_json=1'];
         $files[] = ['scroll-lister.php?atk_admin_view_2_view_lister_jspaginator=ajax&__atk_callback=1&page=2'];
 


### PR DESCRIPTION
Modal create by UserAction can be added via callback request. Therefore, we can not rely on regular element number id mechanism for generating their id. 

This will make sure HTML modal id are set properly.

