### PR TITLE
Disable caching by default

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -113,7 +113,9 @@ class App
     public $db = null;
 
     /** @var string[] Extra HTTP headers to send on exit. */
-    protected $response_headers = [];
+    protected $response_headers = [
+        'cache-control' => 'no-store', // disable caching by default
+    ];
 
     /**
      * @var bool Whether or not semantic-ui vue has been initialised.

--- a/src/jsSSE.php
+++ b/src/jsSSE.php
@@ -131,9 +131,7 @@ class jsSSE extends jsCallback
 
         $this->app->setResponseHeader('content-type', 'text/event-stream');
 
-        // disable caching
-        $this->app->setResponseHeader('cache-control', 'no-store');
-        // for nginx, see http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffers
+        // disable buffering for nginx, see http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffers
         $this->app->setResponseHeader('x-accel-buffering', 'no');
 
         // disable compression


### PR DESCRIPTION
Dynamic responses from Atk can not be of course cached.

Fix it for webservers configured to cache responses by default.

Reference: https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching#defining_optimal_cache-control_policy