### PR TITLE
[fix] CRUD::addModalAction to use appSticky argument on Modal callback

### DIFF
--- a/src/Modal.php
+++ b/src/Modal.php
@@ -39,6 +39,9 @@ class Modal extends View
     public $cb_view = null;
     public $args = [];
 
+    /** @var bool Make callback url argument stick to application or view. */
+    public $appStickyCb = false;
+
     /** @var string Currently only "json" response type is supported. */
     public $type = 'json';
 
@@ -88,7 +91,7 @@ class Modal extends View
     {
         $this->cb_view = View::addTo($this);
         $this->cb_view->stickyGet('__atk_m', $this->name);
-        $this->cb = CallbackLater::addTo($this->cb_view);
+        $this->cb = CallbackLater::addTo($this->cb_view, ['appSticky' => $this->appStickyCb]);
 
         $this->cb->set(function () {
             if ($this->cb->triggered() && $this->fx) {

--- a/src/TableColumn/ActionButtons.php
+++ b/src/TableColumn/ActionButtons.php
@@ -111,7 +111,7 @@ class ActionButtons extends Generic
     {
         $owner = $owner ?: $this->owner->owner;
 
-        $modal = \atk4\ui\Modal::addTo($owner, [compact('title')]);
+        $modal = \atk4\ui\Modal::addTo($owner, [compact('title'), 'appStickyCb' => true]);
 
         $modal->observeChanges(); // adds scrollbar if needed
 


### PR DESCRIPTION
Make CRUD::addModalAction() method to use app stickyCallback by default.

It will enable CRUD inside a modal callback function, when add via addModalAction, to being able to run by default:

````
$crud->addModalAction(['', 'icon'=>'eye'], 'Detail', function ($page, $id) use($crud, $app) {
    $container = $page->add(['ui' => 'basic segment']);
    $card = $container->add(new \atk4\ui\Card);
    $card->setModel($crud->model->load($id), ['name']);
    $children = $crud->model->ref( 'Children');

    $child_crud = $container->add('CRUD', ['paginator' => false]);
    $child_crud->setModel($children);
});
````
