### PR TITLE
[feature] - Admin Layout

### DIFF
--- a/demos/breadcrumb.php
+++ b/demos/breadcrumb.php
@@ -14,6 +14,7 @@ $crumb->addCrumb('BreadCrumb Demo', ['breadcrumb']);
 $crumb->addCrumb('Countries', []);
 
 $m = new Country($db);
+$m->setLimit(25);
 
 if ($id = $app->stickyGet('country_id')) {
 

--- a/demos/database.php
+++ b/demos/database.php
@@ -146,27 +146,30 @@ if (!class_exists('Country')) {
         /**
          * Perform import from filesystem.
          */
-        public function importFromFilesystem($path)
+        public function importFromFilesystem($path, $isSub = false)
         {
             $dir = new DirectoryIterator($path);
             foreach ($dir as $fileinfo) {
+                $name = $fileinfo->getFilename();
+
+                if ($fileinfo->getFilename() === '.') {
+                    continue;
+                }
                 if ($fileinfo->getFilename()[0] === '.') {
                     continue;
                 }
-                if ($fileinfo->getFilename() === 'vendor') {
-                    continue;
-                }
 
-                $this->unload();
+                if ($fileinfo->getFilename() === 'src' || $fileinfo->getFilename() === 'demos' ||$isSub) {
+                    $this->unload();
+                    $this->save([
+                                    'name'      => $fileinfo->getFilename(),
+                                    'is_folder' => $fileinfo->isDir(),
+                                    'type'      => pathinfo($fileinfo->getFilename(), PATHINFO_EXTENSION),
+                                ]);
 
-                $this->save([
-                    'name'      => $fileinfo->getFilename(),
-                    'is_folder' => $fileinfo->isDir(),
-                    'type'      => pathinfo($fileinfo->getFilename(), PATHINFO_EXTENSION),
-                ]);
-
-                if ($fileinfo->isDir()) {
-                    $this->ref('SubFolder')->importFromFilesystem($path . '/' . $fileinfo->getFilename());
+                    if ($fileinfo->isDir()) {
+                        $this->ref('SubFolder')->importFromFilesystem($path . '/' . $fileinfo->getFilename(), true);
+                    }
                 }
             }
         }

--- a/demos/dropdown-plus.php
+++ b/demos/dropdown-plus.php
@@ -10,7 +10,7 @@ $form->addField(
     'withModel',
     ['DropDown',
                     'caption' => 'DropDown with data from Model',
-                    'model'   => new Country($db),
+                    'model'   => (new Country($db))->setLimit(25),
                 ]
 );
 
@@ -19,7 +19,7 @@ $form->addField(
     'withModel2',
     ['DropDown',
                     'caption'           => 'DropDown with data from Model',
-                    'model'             => new Country($db),
+                    'model'             => (new Country($db))->setLimit(25),
                     'renderRowFunction' => function ($row) {
                         return [
                             'value' => $row->id,
@@ -34,7 +34,7 @@ $form->addField(
     'withModel3',
     ['DropDown',
                     'caption'           => 'DropDown with data from Model',
-                    'model'             => new File($db),
+                    'model'             => (new File($db))->setLimit(25),
                     'renderRowFunction' => function ($row) {
                         return [
                             'value' => $row->id,

--- a/demos/field2.php
+++ b/demos/field2.php
@@ -170,7 +170,7 @@ $g = $form->addGroup('CheckBox');
 $b1 = $g->addField('b1', new \atk4\ui\FormField\CheckBox());
 $b1->onChange('console.log("b1 changed")');
 
-$g = $form->addGroup('DropDown');
+$g = $form->addGroup(['Dropdown', 'width' => 'three']);
 $d1 = $g->addField('d1', new \atk4\ui\FormField\DropDown(['values' => [
     'tag'        => ['Tag', 'icon' => 'tag icon'],
     'globe'      => ['Globe', 'icon' => 'globe icon'],
@@ -178,7 +178,7 @@ $d1 = $g->addField('d1', new \atk4\ui\FormField\DropDown(['values' => [
     'file'       => ['File', 'icon' => 'file icon'],
 ],
 ]));
-$d1->onChange('console.log("d1 changed")');
+$d1->onChange('console.log("Dropdown changed")');
 
 $g = $form->addGroup('Radio');
 $r1 = $g->addField('r1', new \atk4\ui\FormField\Radio(['values' => [
@@ -188,7 +188,7 @@ $r1 = $g->addField('r1', new \atk4\ui\FormField\Radio(['values' => [
     'File',
 ],
 ]));
-$r1->onChange('console.log("r1 changed")');
+$r1->onChange('console.log("radio changed")');
 
 \atk4\ui\Header::addTo($app, ['Line ends of TextArea']);
 

--- a/demos/init.php
+++ b/demos/init.php
@@ -115,6 +115,7 @@ if (file_exists('coverage.php')) {
 $app->title = 'Agile UI Demo v' . $app->version;
 
 if (file_exists('../public/atkjs-ui.min.js')) {
+    $test = __DIR__ . '/public';
     $app->cdn['atk'] = '../public';
 }
 
@@ -122,38 +123,42 @@ $app->initLayout($app->stickyGET('layout') ?: 'Admin');
 
 $layout = $app->layout;
 
-if (isset($layout->leftMenu)) {
-    $layout->leftMenu->addItem(['Welcome to Agile Toolkit', 'icon' => 'gift'], ['index']);
-    $layout->leftMenu->addItem(['Layouts', 'icon' => 'object group'], ['layouts']);
+if (isset($layout->menuLeft)) {
+    $layout->menuLeft->addItem(['Welcome to Agile Toolkit', 'icon' => 'gift'], ['index']);
 
-    $form = $layout->leftMenu->addGroup(['Form', 'icon' => 'edit']);
+    $ly = $layout->menuLeft->addGroup(['Layout', 'icon' => 'object group']);
+    $ly->addItem(['Layouts'], ['layouts']);
+    $ly->addItem(['Panel'], ['layout-panel']);
+
+    $form = $layout->menuLeft->addGroup(['Form', 'icon' => 'edit']);
     $form->addItem('Basics and Layouting', ['form']);
-    $form->addItem(['Form Sections', 'icon'=>'yellow star'], ['form-section']);
-    $form->addItem(['Input Fields', 'icon'=>'yellow star'], ['field2']);
-    $form->addItem('Input Field Decoration', ['field']);
-    $form->addItem(['File Uploading'], ['upload']);
-    $form->addItem(['Checkboxes'], ['checkbox']);
+    $form->addItem(['Form Sections'], ['form-section']);
     $form->addItem('Data Integration', ['form2']);
     $form->addItem('Form Multi-column layout', ['form3']);
     $form->addItem(['Integration with Columns'], ['form5']);
-    $form->addItem(['Lookup Field', 'icon'=>'yellow star'], ['lookup']);
-    $form->addItem(['DropDown Field'], ['dropdown-plus']);
-    $form->addItem(['Value Selectors'], ['form6']);
     $form->addItem(['Conditional Fields'], ['jscondform']);
 
-    $form = $layout->leftMenu->addGroup(['Grid and Table', 'icon' => 'table']);
-    $form->addItem('Data table with formatted columns', ['table']);
-    $form->addItem(['Advanced table examples', 'icon'=>'yellow star'], ['table2']);
-    $form->addItem('Table interractions', ['multitable']);
-    $form->addItem(['Column Menus'], ['tablecolumnmenu']);
-    $form->addItem(['Column Filters'], ['tablefilter']);
-    $form->addItem('Grid - Table+Bar+Search+Paginator', ['grid']);
-    $form->addItem('CRUD - Full editing solution', ['crud']);
-    $form->addItem(['CRUD with Array Persistence', 'icon' => 'yellow star'], ['crud3']);
-    $form->addItem(['Grid Layout', 'icon' => 'yellow star'], ['grid-layout']);
-    $form->addItem(['Actions - Integration Examples', 'icon'=>'yellow star'], ['actions']);
+    $in = $layout->menuLeft->addGroup(['Input', 'icon' => 'keyboard outline']);
+    $in->addItem(['Input Fields'], ['field2']);
+    $in->addItem('Input Field Decoration', ['field']);
+    $in->addItem(['File Uploading'], ['upload']);
+    $in->addItem(['Checkboxes'], ['checkbox']);
+    $in->addItem(['Lookup Field'], ['lookup']);
+    $in->addItem(['DropDown Field'], ['dropdown-plus']);
+    $in->addItem(['Value Selectors'], ['form6']);
 
-    $basic = $layout->leftMenu->addGroup(['Basics', 'icon' => 'cubes']);
+    $g_t = $layout->menuLeft->addGroup(['Grid and Table', 'icon' => 'table']);
+    $g_t->addItem('Data table with formatted columns', ['table']);
+    $g_t->addItem(['Advanced table examples'], ['table2']);
+    $g_t->addItem('Table interractions', ['multitable']);
+    $g_t->addItem(['Column Menus'], ['tablecolumnmenu']);
+    $g_t->addItem(['Column Filters'], ['tablefilter']);
+    $g_t->addItem('Grid - Table+Bar+Search+Paginator', ['grid']);
+    $g_t->addItem('CRUD - Full editing solution', ['crud']);
+    $g_t->addItem(['CRUD with Array Persistence'], ['crud3']);
+    $g_t->addItem(['Actions - Integration Examples'], ['actions']);
+
+    $basic = $layout->menuLeft->addGroup(['Basics', 'icon' => 'cubes']);
     $basic->addItem('View', ['view']);
     $basic->addItem('Lister', ['lister']);
     $basic->addItem('Button', ['button']);
@@ -162,27 +167,33 @@ if (isset($layout->leftMenu)) {
     $basic->addItem('Labels', ['label']);
     $basic->addItem('Menu', ['menu']);
     $basic->addItem('BreadCrumb', ['breadcrumb']);
-    $basic->addItem('Tabs', ['tabs']);
-    $basic->addItem(['Accordion', 'icon'=>'yellow star'], ['accordion']);
     $basic->addItem(['Columns'], ['columns']);
-    $basic->addItem('Paginator', ['paginator']);
+    $basic->addItem(['Grid Layout'], ['grid-layout']);
 
-    $basic = $layout->leftMenu->addGroup(['Interactivity', 'icon' => 'talk']);
-    $basic->addItem(['Wizard'], ['wizard']);
-    $basic->addItem('JavaScript Events', ['js']);
-    $basic->addItem('Element Reloading', ['reloading']);
-    $basic->addItem(['Background PHP Jobs (SSE)'], ['sse']);
-    $basic->addItem(['Progress Bar'], ['progress']);
-    $basic->addItem(['Loader'], ['loader']);
-    $basic->addItem(['Console'], ['console']);
-    $basic->addItem('Notifier', ['notify']);
-    $basic->addItem(['Toast', 'icon'=>'yellow star'], ['toast']);
-    $basic->addItem(['Pop-up'], ['popup']);
-    $basic->addItem(['Modal View'], ['modal2']);
-    $basic->addItem('Dynamic jsModal', ['modal']);
-    $basic->addItem(['Dynamic scroll', 'icon'=>'yellow star'], ['scroll-lister']);
-    $basic->addItem('Sticky GET', ['sticky']);
-    $basic->addItem('Recursive Views', ['recursive']);
+    $adv = $layout->menuLeft->addGroup(['Interactive', 'icon' => 'talk']);
+    $adv->addItem('Tabs', ['tabs']);
+    $adv->addItem(['Accordion'], ['accordion']);
+    $adv->addItem(['Wizard'], ['wizard']);
+    $adv->addItem(['Modal'], ['modal2']);
+    $adv->addItem('Dynamic Modal', ['modal']);
+    $adv->addItem(['Loader'], ['loader']);
+    $adv->addItem(['Console'], ['console']);
+    $adv->addItem(['Dynamic scroll'], ['scroll-lister']);
+    $adv->addItem(['Background PHP Jobs (SSE)'], ['sse']);
+    $adv->addItem(['Progress Bar'], ['progress']);
+    $adv->addItem(['Pop-up'], ['popup']);
+    $adv->addItem(['Toast'], ['toast']);
+    $adv->addItem('Paginator', ['paginator']);
+
+
+    $js = $layout->menuLeft->addGroup(['Javascript', 'icon' => 'code']);
+    $js->addItem('Events', ['js']);
+    $js->addItem('Element Reloading', ['reloading']);
+    $js->addItem('Vue Integration', ['vue-component']);
+
+    $other = $layout->menuLeft->addGroup(['Others', 'icon' => 'plus']);
+    $other->addItem('Sticky GET', ['sticky']);
+    $other->addItem('Recursive Views', ['recursive']);
 
     //$basic->addItem('Virtual Page', ['virtual']);
 
@@ -192,7 +203,7 @@ if (isset($layout->leftMenu)) {
     $url = 'https://github.com/atk4/ui/blob/develop/demos/';
 
     // Would be nice if this would be a link.
-    \atk4\ui\Button::addTo($layout->menu->addItem(), ['View Source', 'teal', 'icon' => 'github'])
+    \atk4\ui\Button::addTo($layout->menu->addItem()->addClass('aligned right'), ['View Source', 'teal', 'icon' => 'github'])
         ->setAttr('target', '_blank')->on('click', new \atk4\ui\jsExpression('document.location=[];', [$url . $f]));
 
     $img = 'https://raw.githubusercontent.com/atk4/ui/07208a0af84109f0d6e3553e242720d8aeedb784/public/logo.png';

--- a/demos/init.php
+++ b/demos/init.php
@@ -115,7 +115,6 @@ if (file_exists('coverage.php')) {
 $app->title = 'Agile UI Demo v' . $app->version;
 
 if (file_exists('../public/atkjs-ui.min.js')) {
-    $test = __DIR__ . '/public';
     $app->cdn['atk'] = '../public';
 }
 

--- a/demos/multitable.php
+++ b/demos/multitable.php
@@ -20,7 +20,7 @@ class Finder extends \atk4\ui\Columns
 
         $selections = explode(',', $_GET[$this->name] ?? '');
 
-        if ($selections) {
+        if (!empty($selections[0])) {
             $table->js(true)->find('tr[data-id=' . $selections[0] . ']')->addClass('active');
         }
 
@@ -49,7 +49,7 @@ class Finder extends \atk4\ui\Columns
             $model = $model->ref($ref);
 
             $table = \atk4\ui\Table::addTo($this->addColumn(), ['header' => false, 'very basic selectable'])->addStyle('cursor', 'pointer');
-            $table->setModel($model, [$model->title_field]);
+            $table->setModel($model->setLimit(25), [$model->title_field]);
 
             if ($selections) {
                 $table->js(true)->find('tr[data-id=' . $selections[0] . ']')->addClass('active');
@@ -83,4 +83,4 @@ $vp = \atk4\ui\VirtualPage::addTo($app)->set(function ($vp) use ($m) {
 
 Finder::addTo($app, 'bottom attached')
     ->addClass('top attached segment')
-    ->setModel($m, ['SubFolder']);
+    ->setModel($m->setLimit(5), ['SubFolder']);

--- a/public/agileui.css
+++ b/public/agileui.css
@@ -90,8 +90,8 @@ i.atk-panel-warning {
 i.atk-panel-warning.atk-visible {
   color: #F2711C;
 }
-.atk-admin-left-menu {
-  top: 47px !important;
+.ui.left.sidebar.atk-admin-left-menu {
+  top: 47px;
 }
 .atk-admin-left-menu-content {
   overflow: auto;

--- a/public/agileui.css
+++ b/public/agileui.css
@@ -10,6 +10,7 @@
 .ui.visible.left.sidebar ~ .atk-mainContainer,
 .ui.visible.left.sidebar ~ footer.atk-footer {
   padding-left: 260px;
+  height: 50px;
 }
 .atk-dialog-content {
   min-height: 100px;
@@ -39,6 +40,9 @@ header.atk-topMenu.ui.menu .item > .label {
 }
 .atk-mainContainer .atk-mainContainerWrapper {
   padding: 3em;
+}
+.atk-mainContainer.atk-admin-wp {
+  margin-top: 48px;
 }
 footer.atk-footer .ui.divider,
 footer.atk-footer .ui.segment {
@@ -85,6 +89,16 @@ i.atk-panel-warning {
 }
 i.atk-panel-warning.atk-visible {
   color: #F2711C;
+}
+.atk-admin-left-menu {
+  top: 47px !important;
+}
+.atk-admin-left-menu-content {
+  overflow: auto;
+  height: calc(100% -  98px );
+}
+.ui.left.sidebar.atk-admin-left-menu {
+  width: 260px;
 }
 .atk-table-dropdown {
   margin-top: -8px;
@@ -151,7 +165,7 @@ i.atk-panel-warning.atk-visible {
   opacity: 0;
   pointer-events: none;
   position: fixed;
-  top: 0;
+  top: 47px;
   width: 100%;
   z-index: 102;
 }
@@ -190,21 +204,17 @@ i.atk-panel-warning.atk-visible {
     display: block;
   }
 }
-@media (min-width: 768px) and (max-width: 991px) {
+@media (max-width: 991px) {
   body.atk-leftMenu-visible .atk-overlay.pushable {
     opacity: 1;
   }
+}
+@media (min-width: 768px) and (max-width: 991px) {
   .atk-right-panel {
     width: 65%;
   }
 }
 @media (max-width: 767px) {
-  body.atk-leftMenu-visible {
-    overflow: hidden;
-  }
-  .ui.left.sidebar {
-    width: 100%;
-  }
   .atk-right-panel {
     width: 95%;
   }

--- a/public/agileui.css
+++ b/public/agileui.css
@@ -41,7 +41,7 @@ header.atk-topMenu.ui.menu .item > .label {
 .atk-mainContainer .atk-mainContainerWrapper {
   padding: 3em;
 }
-.atk-mainContainer.atk-admin-wp {
+.atk-mainContainer.atk-admin-layout {
   margin-top: 48px;
 }
 footer.atk-footer .ui.divider,

--- a/public/agileui.less
+++ b/public/agileui.less
@@ -44,6 +44,8 @@
 @leftMenuWidth: 260px;
 @desktopWidth: 992px;
 @tabletWidth: 768px;
+@adminMenuHeight: 48px;
+@atkFooterHeight : 50px;
 
 @atkSlidePanelColor: @offWhite;
 
@@ -56,6 +58,7 @@
 .ui.visible.left.sidebar ~ .atk-mainContainer,
 .ui.visible.left.sidebar ~ footer.atk-footer {
   padding-left: @leftMenuWidth;
+  height: @atkFooterHeight;
 }
 
 .atk-dialog-content {
@@ -83,10 +86,14 @@ header.atk-topMenu.ui.fixed.menu ~ .atk-topMenuGhost {
 header.atk-topMenu.ui.menu .item > .label {
   margin-left: 0;
 }
+
 .atk-mainContainer {
   flex: 1;
   .atk-mainContainerWrapper {
     padding: 3em;
+  }
+  &.atk-admin-wp {
+    margin-top: @adminMenuHeight;
   }
 }
 footer.atk-footer {
@@ -97,6 +104,7 @@ footer.atk-footer {
 
   }
 }
+
 .ui.left.sidebar {
   z-index: 103;
   .item.atk-leftMenuClose {
@@ -109,9 +117,9 @@ footer.atk-footer {
       margin-left: 0 !important;
     }
   }
-  &.visible {
-    // display: none;
-  }
+  //&.visible {
+  //  // display: none;
+  //}
 }
 
 .atk-right-panel {
@@ -144,6 +152,19 @@ i.atk-panel-warning {
   &.atk-visible {
     color: @orange;
   }
+}
+
+.atk-admin-left-menu {
+  top: @adminMenuHeight - 1 !important;
+}
+
+.atk-admin-left-menu-content {
+  overflow: auto;
+  height: ~'calc(100% - '@atkFooterHeight + @adminMenuHeight~')';
+}
+
+.ui.left.sidebar.atk-admin-left-menu {
+  width: @leftMenuWidth;
 }
 
 // table dropdown menu
@@ -231,7 +252,7 @@ i.atk-panel-warning {
   opacity: 0;
   pointer-events: none;
   position: fixed;
-  top: 0;
+  top: @adminMenuHeight - 1px;
   width: 100%;
   z-index: 102;
   .pusher {
@@ -278,26 +299,22 @@ i.atk-panel-warning {
     }
   }
 }
-@media (min-width: @tabletWidth) and (max-width: (@desktopWidth - 1px)) {
+@media (max-width: @desktopWidth - 1px) {
   body.atk-leftMenu-visible .atk-overlay.pushable {
     opacity: 1;
   }
+}
+
+@media (min-width: @tabletWidth) and (max-width: (@desktopWidth - 1px)) {
   .atk-right-panel {
     width: 65%;
   }
 }
 @media (max-width: (@tabletWidth - 1px)) {
-  body.atk-leftMenu-visible {
-    overflow: hidden;
-  }
-  .ui.left.sidebar {
-    width: 100%;
-  }
   .atk-right-panel {
     width: 95%;
   }
 }
-
 
 // Print
 

--- a/public/agileui.less
+++ b/public/agileui.less
@@ -92,7 +92,7 @@ header.atk-topMenu.ui.menu .item > .label {
   .atk-mainContainerWrapper {
     padding: 3em;
   }
-  &.atk-admin-wp {
+  &.atk-admin-layout {
     margin-top: @adminMenuHeight;
   }
 }

--- a/public/agileui.less
+++ b/public/agileui.less
@@ -154,8 +154,8 @@ i.atk-panel-warning {
   }
 }
 
-.atk-admin-left-menu {
-  top: @adminMenuHeight - 1 !important;
+.ui.left.sidebar.atk-admin-left-menu {
+  top: @adminMenuHeight - 1;
 }
 
 .atk-admin-left-menu-content {

--- a/src/Layout/Admin.php
+++ b/src/Layout/Admin.php
@@ -56,7 +56,7 @@ class Admin extends Generic
         parent::init();
 
         if ($this->menu === null) {
-            $this->menu = Menu::addTo($this, ['atk-admin-wp-top-menu-header inverted fixed horizontal', 'element' => 'header'], ['TopMenu']);
+            $this->menu = Menu::addTo($this, ['inverted fixed horizontal', 'element' => 'header'], ['TopMenu']);
             $this->burger = $this->menu->addItem(['class' => ['icon atk-leftMenuTrigger']]);
             $this->burger->on('click', [
                 (new jQuery('.atk-admin-left-menu'))->toggleClass('visible'),

--- a/src/Layout/Admin.php
+++ b/src/Layout/Admin.php
@@ -65,7 +65,6 @@ class Admin extends Generic
             Icon::addTo($this->burger, ['content']);
 
             Header::addTo($this->menu, [$this->app->title, 'size' => 4]);
-
         }
 
         if ($this->menuRight === null) {

--- a/src/Layout/Admin.php
+++ b/src/Layout/Admin.php
@@ -2,9 +2,10 @@
 
 namespace atk4\ui\Layout;
 
+use atk4\ui\Header;
+use atk4\ui\Icon;
 use atk4\ui\jQuery;
 use atk4\ui\Menu;
-use atk4\ui\Template;
 
 /**
  * Implements a classic 100% width admin layout.
@@ -55,28 +56,25 @@ class Admin extends Generic
         parent::init();
 
         if ($this->menu === null) {
-            $this->menu = Menu::addTo($this, ['atk-topMenu inverted fixed horizontal', 'element' => 'header'], ['TopMenu']);
+            $this->menu = Menu::addTo($this, ['atk-admin-wp-top-menu-header inverted fixed horizontal', 'element' => 'header'], ['TopMenu']);
             $this->burger = $this->menu->addItem(['class' => ['icon atk-leftMenuTrigger']]);
             $this->burger->on('click', [
-                (new jQuery('.ui.left.sidebar'))->toggleClass('visible'),
+                (new jQuery('.atk-admin-left-menu'))->toggleClass('visible'),
                 (new jQuery('body'))->toggleClass('atk-leftMenu-visible'),
             ]);
-            \atk4\ui\Icon::addTo($this->burger, ['content']);
+            Icon::addTo($this->burger, ['content']);
+
+            Header::addTo($this->menu, [$this->app->title, 'size' => 4]);
+
         }
 
         if ($this->menuRight === null) {
             $this->menuRight = Menu::addTo($this->menu, ['ui' => false], ['RightMenu'])
-                ->addClass('right menu')->removeClass('item');
+                                   ->addClass('right menu')->removeClass('item');
         }
 
         if ($this->menuLeft === null) {
-            $this->menuLeft = Menu::addTo($this, ['left vertical inverted labeled sidebar'], ['LeftMenu']);
-            $this->leftMenu = $this->menuLeft;
-
-            $closeIcon = \atk4\ui\View::addTo($this->menuLeft, ['template' => new Template('<a id="{$_id}" href="#" onclick="return false;" class="{$class} item atk-leftMenuClose"><i class="close icon"></i></a>')]);
-            $closeIcon->on('click', (new jQuery('body'))->removeClass('atk-leftMenu-visible'));
-
-            $this->menuLeft->addHeader($this->app->title);
+            $this->menuLeft = Menu::addTo($this, ['ui' => 'atk-admin-left-menu-content'], ['LeftMenu']);
         }
 
         $this->template->trySet('version', $this->app->version);
@@ -95,8 +93,8 @@ class Admin extends Generic
             if ($this->isMenuLeftVisible) {
                 $this->menuLeft->addClass('visible');
             }
-            //$this->leftMenu->addItem(['Logout', 'icon'=>'sign out'], ['logout']);
         }
+
         parent::renderView();
     }
 }

--- a/template/semantic-ui/layout/admin.html
+++ b/template/semantic-ui/layout/admin.html
@@ -1,14 +1,8 @@
 
 <div class="atk-layout">
-  {$LeftMenu}
-  {$TopMenu}
-  <div class="atk-topMenuGhost ui menu">
-    <div class="item">
-      <div class="ui button">&nbsp;</div>
-    </div>
-  </div>
-  <main class="atk-mainContainer">
-    <div class="atk-mainContainerWrapper">{$Content}</div>
+  <div class="ui left vertical menu visible inverted labeled sidebar atk-admin-left-menu">{$LeftMenu}</div>
+  <main class="atk-mainContainer atk-admin-wp">{$TopMenu}
+    <div class="atk-mainContainerWrapper atk-admin-wp">{$Content}</div>
   </main>
   <footer class="atk-footer">
     <div class="ui divider"></div>

--- a/template/semantic-ui/layout/admin.html
+++ b/template/semantic-ui/layout/admin.html
@@ -1,8 +1,8 @@
 
 <div class="atk-layout">
   <div class="ui left vertical menu visible inverted labeled sidebar atk-admin-left-menu">{$LeftMenu}</div>
-  <main class="atk-mainContainer atk-admin-wp">{$TopMenu}
-    <div class="atk-mainContainerWrapper atk-admin-wp">{$Content}</div>
+  <main class="atk-mainContainer atk-admin-layout">{$TopMenu}
+    <div class="atk-mainContainerWrapper">{$Content}</div>
   </main>
   <footer class="atk-footer">
     <div class="ui divider"></div>

--- a/template/semantic-ui/layout/admin.pug
+++ b/template/semantic-ui/layout/admin.pug
@@ -1,9 +1,9 @@
 .atk-layout
   .ui.left.vertical.menu.visible.inverted.labeled.sidebar.atk-admin-left-menu
     | {$LeftMenu}
-  main.atk-mainContainer.atk-admin-wp
+  main.atk-mainContainer.atk-admin-layout
     | {$TopMenu}
-    .atk-mainContainerWrapper.atk-admin-wp
+    .atk-mainContainerWrapper
       | {$Content}
   footer.atk-footer
     .ui.divider

--- a/template/semantic-ui/layout/admin.pug
+++ b/template/semantic-ui/layout/admin.pug
@@ -1,11 +1,9 @@
 .atk-layout
-  | {$LeftMenu}
-  | {$TopMenu}
-  .atk-topMenuGhost.ui.menu
-    .item
-      .ui.button &nbsp;
-  main.atk-mainContainer
-    .atk-mainContainerWrapper
+  .ui.left.vertical.menu.visible.inverted.labeled.sidebar.atk-admin-left-menu
+    | {$LeftMenu}
+  main.atk-mainContainer.atk-admin-wp
+    | {$TopMenu}
+    .atk-mainContainerWrapper.atk-admin-wp
       | {$Content}
   footer.atk-footer
     .ui.divider


### PR DESCRIPTION
Refactor Admin Layout
- Application name always visible;
- Left menu always same width;
- Width configurable via less;
- Reorganize demos menu and buttons

#### Note
Also refactor some demo file for faster loading.

Before: 
<img width="1100" alt="Screen Shot 2020-04-17 at 1 10 09 PM" src="https://user-images.githubusercontent.com/2204478/79595585-219f3180-80ad-11ea-9f5f-3df404365b46.png">

After:
<img width="1102" alt="Screen Shot 2020-04-17 at 1 10 23 PM" src="https://user-images.githubusercontent.com/2204478/79595609-2c59c680-80ad-11ea-8262-6c033b8236e4.png">
 
### App name always visible when menu scrolls up:

Before:
<img width="313" alt="Screen Shot 2020-04-17 at 1 14 07 PM" src="https://user-images.githubusercontent.com/2204478/79595743-62974600-80ad-11ea-8664-26350b4e1f5d.png">

After:
<img width="296" alt="Screen Shot 2020-04-17 at 1 14 23 PM" src="https://user-images.githubusercontent.com/2204478/79595762-6c20ae00-80ad-11ea-9a7b-daa598726eef.png">

### Menu width always the same

Before:
<img width="598" alt="Screen Shot 2020-04-17 at 1 15 55 PM" src="https://user-images.githubusercontent.com/2204478/79595963-c3268300-80ad-11ea-9f5d-374208c2ab67.png">

After:
<img width="599" alt="Screen Shot 2020-04-17 at 1 16 27 PM" src="https://user-images.githubusercontent.com/2204478/79595978-c9b4fa80-80ad-11ea-9d07-4d862f3cb6f2.png">
