### PR TITLE
Fix getRenderedModals

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -1143,7 +1143,7 @@ class App
     public function getRenderedModals()
     {
         $modals = [];
-        foreach ($this->html->elements as $view) {
+        foreach ($this->html->elements ?? [] as $view) {
             if ($view instanceof Modal) {
                 $modals[$view->name]['html'] = $view->getHTML();
                 $modals[$view->name]['js'] = $view->getJsRenderActions();

--- a/src/App.php
+++ b/src/App.php
@@ -1143,7 +1143,7 @@ class App
     public function getRenderedModals()
     {
         $modals = [];
-        foreach ($this->html->elements ?? [] as $view) {
+        foreach ($this->html !== null ? $this->html->elements : [] as $view) {
             if ($view instanceof Modal) {
                 $modals[$view->name]['html'] = $view->getHTML();
                 $modals[$view->name]['js'] = $view->getJsRenderActions();


### PR DESCRIPTION
If App layout is not defined and use terminateJSON to output a response, in method getRenderedModals foreach over $this->html->elements not exists and raise error
