### PR TITLE
Fix script/style escaping in App::getTag()

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -481,7 +481,7 @@ class App
         if (!$this->html) {
             throw new Exception(['App does not know how to add style']);
         }
-        $this->html->template->appendHTML('HEAD', $this->getTag('style', null, $style, false));
+        $this->html->template->appendHTML('HEAD', $this->getTag('style', $style));
     }
 
     /**
@@ -882,11 +882,10 @@ class App
      * @param string|array $tag
      * @param string       $attr
      * @param string|array $value
-     * @param bool         $encodeValue
      *
      * @return string
      */
-    public function getTag($tag = null, $attr = null, $value = null, bool $encodeValue = true)
+    public function getTag($tag = null, $attr = null, $value = null)
     {
         if ($tag === null) {
             $tag = 'div';
@@ -929,7 +928,7 @@ class App
         }
 
         if (is_string($value)) {
-            $value = $this->encodeHTML($encodeValue ? $value : strip_tags($value));
+            $value = $this->encodeHTML($value);
         } elseif (is_array($value)) {
             $result = [];
             foreach ($value as $v) {

--- a/src/App.php
+++ b/src/App.php
@@ -919,6 +919,9 @@ class App
 
             $attr = $tmp;
         }
+
+        $tag = strtolower($tag);
+
         if ($tag[0] === '<') {
             return $tag;
         }
@@ -927,12 +930,17 @@ class App
             $attr = null;
         }
 
-        if (is_string($value)) {
-            $value = $this->encodeHTML($value);
-        } elseif (is_array($value)) {
+        if ($value !== null) {
             $result = [];
-            foreach ($value as $v) {
-                $result[] = is_array($v) ? $this->getTag(...$v) : $v;
+            foreach ((array)$value as $v) {
+                if (is_array($v)) {
+                    $result[] = $this->getTag(...$v);
+                } elseif (in_array($tag, ['script', 'style'])) {
+                    // see https://mathiasbynens.be/notes/etago
+                    $result[] = preg_replace('~(?<=<)(?=/\s*' . preg_quote($tag, '~') . '|!--)~', '\\\\', $v);
+                } else {
+                    $result[] = $this->encodeHTML($v);
+                }
             }
             $value = implode('', $result);
         }

--- a/src/App.php
+++ b/src/App.php
@@ -938,6 +938,8 @@ class App
                 } elseif (in_array($tag, ['script', 'style'])) {
                     // see https://mathiasbynens.be/notes/etago
                     $result[] = preg_replace('~(?<=<)(?=/\s*' . preg_quote($tag, '~') . '|!--)~', '\\\\', $v);
+                } elseif (is_array($value)) { // todo, remove later and fix wrong usages, this is the original behaviour, only directly passed strings were escaped
+                    $result[] = $v;
                 } else {
                     $result[] = $this->encodeHTML($v);
                 }


### PR DESCRIPTION
Fix https://github.com/atk4/ui/issues/1136

@georgehristov , does it solve https://github.com/atk4/ui/issues/1110 ?

The important fact is that `style` and `script` elements can not have child elements by definition.