### PR TITLE
Fix atk init

### DIFF
--- a/demos/atk-init.php
+++ b/demos/atk-init.php
@@ -13,8 +13,8 @@ require_once __DIR__ . '/database.php';
 require_once __DIR__ . '/_includes/somedatadef.php';
 
 $app = new \atk4\ui\App([
-    'call_exit' => (bool) ($_GET['APP_CALL_EXIT'] ?? ''),
-    'catch_exceptions' => (bool) ($_GET['APP_CATCH_EXCEPTIONS'] ?? ''),
+    'call_exit' => (bool) ($_GET['APP_CALL_EXIT'] ?? true),
+    'catch_exceptions' => (bool) ($_GET['APP_CATCH_EXCEPTIONS'] ?? true),
 ]);
 
 if ($app->call_exit !== true) {


### PR DESCRIPTION
fix #1150

@ibelar Does this solve the issue?

Originally there was:
```
    'call_exit'        => isset($_GET['APP_CALL_EXIT']) && $_GET['APP_CALL_EXIT'] == 0 ? false : true,
    'catch_exceptions' => isset($_GET['APP_CATCH_EXCEPTIONS']) && $_GET['APP_CATCH_EXCEPTIONS'] == 0 ? false : true,
```

now it should behave 1:1