### PR TITLE
[fix] Reload on Callback

### DIFF
--- a/demos/layout/layout-panel.php
+++ b/demos/layout/layout-panel.php
@@ -27,11 +27,28 @@ $btn = \atk4\ui\Button::addTo($app, ['Button 2']);
 $btn->js(true)->data('btn', '2');
 $btn->on('click', $panel_1->jsOpen(['btn'], 'orange'));
 
-$panel_1->onOpen(function ($p) {
-    $btn_number = $_GET['btn'] ?? null;
-    $text = 'You loaded panel content using button #' . $btn_number;
-    \atk4\ui\Message::addTo($p, ['Panel 1', 'text' => $text]);
+$view = \atk4\ui\View::addTo($app, ['ui' => 'segment']);
+$text = \atk4\ui\Text::addTo($view);
+$text->set($_GET['txt'] ?? 'Not Complete');
+
+$panel_1->onOpen(function ($p) use ($view) {
+    $panel = \atk4\ui\View::addTo($p, ['ui' => 'basic segment']);
+    $btn_number = $panel->stickyGet('btn');
+
+    $p_text = 'You loaded panel content using button #' . $btn_number;
+    \atk4\ui\Message::addTo($panel, ['Panel 1', 'text' => $p_text]);
+
+    $p_reload = \atk4\ui\Button::addTo($panel, ['Reload Myself']);
+    $p_reload->on('click', new \atk4\ui\jsReload($panel));
+
+    \atk4\ui\View::addTo($panel, ['ui' => 'divider']);
+    $p_btn = \atk4\ui\Button::addTo($panel, ['Complete']);
+    $p_btn->on('click', [
+        $p->owner->jsClose(),
+        new \atk4\ui\jsReload($view, ['txt' => 'Complete using button #' . $btn_number]),
+    ]);
 });
+
 \atk4\ui\View::addTo($app, ['ui' => 'divider']);
 
 // PANEL_2

--- a/features/rightpanel.feature
+++ b/features/rightpanel.feature
@@ -7,3 +7,8 @@ Feature: RightPanel
     And I press button "Button 1"
     And wait for callback
     Then I should see "button #1"
+    Then I press button "Reload Myself"
+    And wait for callback
+    Then I press button "Complete"
+    And wait for callback
+    Then I should see "Complete using button #1"

--- a/src/Callback.php
+++ b/src/Callback.php
@@ -133,6 +133,27 @@ class Callback
     }
 
     /**
+     * Terminate this callback
+     * by rendering the owner view.
+     */
+    public function terminate()
+    {
+        if ($this->canTerminate()) {
+            $this->app->terminateJSON($this->owner);
+        }
+    }
+
+    /**
+     * Prevent callback from terminating during a reload.
+     */
+    protected function canTerminate(): bool
+    {
+        $reload = $_GET['__atk_reload'] ?? null;
+
+        return !$reload || $this->owner->name === $reload;
+    }
+
+    /**
      * Is callback triggered?
      *
      * @return bool

--- a/src/Panel/Content.php
+++ b/src/Panel/Content.php
@@ -51,7 +51,7 @@ class Content extends View implements LoadableContent
         $this->cb->set(function () use ($callback) {
             if ($this->cb->triggered()) {
                 call_user_func($callback, $this);
-                $this->app->terminateJSON($this);
+                $this->cb->terminate();
             }
         });
     }

--- a/src/jsCallback.php
+++ b/src/jsCallback.php
@@ -105,13 +105,13 @@ class jsCallback extends Callback implements jsExpressionable
 
                 $ajaxec = $response ? $this->getAjaxec($response, $chain) : null;
 
-                $this->terminate($ajaxec);
+                $this->terminateAjax($ajaxec);
             } catch (\atk4\data\ValidationException $e) {
                 // Validation exceptions will be presented to user in a friendly way
                 $m = new Message($e->getMessage());
                 $m->addClass('error');
 
-                $this->terminate(null, $m->getHTML(), false);
+                $this->terminateAjax(null, $m->getHTML(), false);
             }
         });
 
@@ -129,9 +129,11 @@ class jsCallback extends Callback implements jsExpressionable
      * @throws Exception\ExitApplicationException
      * @throws \atk4\core\Exception
      */
-    public function terminate($ajaxec, $msg = null, $success = true)
+    public function terminateAjax($ajaxec, $msg = null, $success = true)
     {
-        $this->app->terminateJSON(['success' => $success, 'message' => $msg, 'atkjs' => $ajaxec]);
+        if ($this->canTerminate()) {
+            $this->app->terminateJSON(['success' => $success, 'message' => $msg, 'atkjs' => $ajaxec]);
+        }
     }
 
     /**

--- a/src/jsSSE.php
+++ b/src/jsSSE.php
@@ -72,7 +72,7 @@ class jsSSE extends jsCallback
         }
     }
 
-    public function terminate($ajaxec, $msg = null, $success = true)
+    public function terminateAjax($ajaxec, $msg = null, $success = true)
     {
         if ($this->browserSupport) {
             if ($ajaxec) {


### PR DESCRIPTION
Allow View to properly reload during a Callback.

Fix problem where an executing callback was to reload an external view but the view could not reload because the callback terminates first.

### Note
This might cause issue where user extends jsCallback and uses jsCallback::terminate() directly. It would need to be change to jsCallbakc::terminateAjax()