### PR TITLE
Fix admin left menu dynamic visibility

### DIFF
--- a/src/Layout/Admin.php
+++ b/src/Layout/Admin.php
@@ -108,7 +108,7 @@ class Admin extends Generic implements Navigable
                 $this->menuLeft->addItem(['Dashboard', 'icon' => 'dashboard'], ['index']);
             }
             if ($this->isMenuLeftVisible) {
-                $this->menuLeft->addClass('visible');
+                $this->menuLeft->js(true)->parent()->addClass('visible');
             }
         }
 

--- a/template/semantic-ui/layout/admin.html
+++ b/template/semantic-ui/layout/admin.html
@@ -1,6 +1,6 @@
 
 <div class="atk-layout">
-  <div class="ui left vertical menu visible inverted labeled sidebar atk-sidenav">{$LeftMenu}</div>
+  <div class="ui left vertical menu inverted labeled sidebar atk-sidenav">{$LeftMenu}</div>
   <main class="atk-mainContainer atk-admin-layout">{$TopMenu}
     <div class="atk-mainContainerWrapper">{$Content}</div>
   </main>

--- a/template/semantic-ui/layout/admin.pug
+++ b/template/semantic-ui/layout/admin.pug
@@ -1,5 +1,5 @@
 .atk-layout
-  .ui.left.vertical.menu.visible.inverted.labeled.sidebar.atk-sidenav
+  .ui.left.vertical.menu.inverted.labeled.sidebar.atk-sidenav
     | {$LeftMenu}
   main.atk-mainContainer.atk-admin-layout
     | {$TopMenu}


### PR DESCRIPTION
Fix issue intoduced in #1112. Visibility is controlled by `isMenuLeftVisible` prop and needs to be not always forced to visible.