### PR TITLE
Remove support of relative class names

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -102,7 +102,9 @@ jobs:
 
       - name: Check Coding Style (only for CodingStyle)
         if: matrix.type == 'CodingStyle'
-        run: vendor/bin/php-cs-fixer fix --dry-run --using-cache=no --diff --diff-format=udiff --verbose --show-progress=dots
+        run: |
+          if [ "$(find demos/ -name '*.php' -print0 | xargs -0 grep -L "namespace atk4\\\\ui\\\\demo;" | tee /dev/fd/2)" ]; then echo 'All demos/ files must have namespace declared' && (exit 1); fi
+          vendor/bin/php-cs-fixer fix --dry-run --using-cache=no --diff --diff-format=udiff --verbose --show-progress=dots
 
       - name: Upload coverage logs 1/2 (only for "latest" Phpunit)
         if: env.LOG_COVERAGE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ In 1.7 we now rely on VueJS for new components and the first component to make u
 $f = \atk4\ui\Form::addTo($app);
 
 // Add multiline field and set model.
-$ml = $f->addField('ml', ['MultiLine', 'options' => ['color' => 'blue']]);
+$ml = $f->addField('ml', [\atk4\ui\FormField\MultiLine::class, 'options' => ['color' => 'blue']]);
 $ml->setModel($inventory);
 ```
 
@@ -106,7 +106,7 @@ part of AutoComplete.
 $form = \atk4\ui\Form::addTo($app, ['segment']);
 \atk4\ui\Label::addTo($form, ['Add city', 'top attached'], ['AboveFields']);
 
-$l = $form->addField('city',['Lookup']);
+$l = $form->addField('city', [\atk4\ui\FormField\Lookup::class]);
 
 // will restraint possible city value in droddown base on country and/or language.
 $l->addFilter('country', 'Country');
@@ -165,7 +165,7 @@ and upgraded Fomantic-UI version.
 - Calendar form field on\('change'\) event handler not working [\#521](https://github.com/atk4/ui/issues/521)
 - Upload FormField: Setting placeholder via placeholder does not work [\#483](https://github.com/atk4/ui/issues/483)
 - Placeholder is not picked up from Model field ui\[placeholder\] property [\#468](https://github.com/atk4/ui/issues/468)
-- type='money' is no longer using 'Money' column decorarot [\#414](https://github.com/atk4/ui/issues/414)
+- type='money' is no longer using 'FormField\Money' column decorarot [\#414](https://github.com/atk4/ui/issues/414)
 
 **Merged pull requests:**
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Create "index.php" file with:
 require_once __DIR__ . '/vendor/autoload.php';
 
 $app = new \atk4\ui\App();   // That's your UI application
-$app->initLayout('Centered');
+$app->initLayout(\atk4\ui\Layout\Centered::class);
 
 $form = \atk4\ui\Form::addTo($app); // Yeah, that's a form!
 
@@ -91,7 +91,7 @@ To get most of ATK UI, use [ATK Data](https://github.com/atk4/data) to describe 
 
 ``` php
 $app = new \atk4\ui\App('hello world');
-$app->initLayout('Admin');
+$app->initLayout(\atk4\ui\Layout\Admin::class);
 $app->dbConnect('mysql://user:pass@localhost/atk')
 
 \atk4\ui\CRUD::addTo($app)->setModel(new User($app->db));
@@ -193,7 +193,7 @@ It's really easy to put together a complex Admin system. Add this code to a new 
 <?php
 
 $app = new \atk4\ui\App('My App');
-$app->initLayout('Admin');
+$app->initLayout(\atk4\ui\Layout\Admin::class);
 $app->dbConnect('mysql://user:pass@localhost/yourdb');
 
 class User extends \atk4\data\Model {

--- a/demos/_includes/demo-lookup.php
+++ b/demos/_includes/demo-lookup.php
@@ -24,7 +24,7 @@ $demoLookupClass = get_class(new class() extends \atk4\ui\FormField\Lookup {
 
         $buttonSeed = is_string($buttonSeed) ? ['content' => $buttonSeed] : $buttonSeed;
 
-        $defaultSeed = ['Button', 'disabled' => ($this->disabled || $this->readonly)];
+        $defaultSeed = [\atk4\ui\Button::class, 'disabled' => ($this->disabled || $this->readonly)];
 
         $this->action = $this->factory(array_merge($defaultSeed, (array) $buttonSeed), null, 'atk4\ui');
 

--- a/demos/_includes/demo-lookup.php
+++ b/demos/_includes/demo-lookup.php
@@ -26,7 +26,7 @@ $demoLookupClass = get_class(new class() extends \atk4\ui\FormField\Lookup {
 
         $defaultSeed = [\atk4\ui\Button::class, 'disabled' => ($this->disabled || $this->readonly)];
 
-        $this->action = $this->factory(array_merge($defaultSeed, (array) $buttonSeed), null, 'atk4\ui');
+        $this->action = $this->factory(array_merge($defaultSeed, (array) $buttonSeed));
 
         if ($this->form) {
             $vp = \atk4\ui\VirtualPage::addTo($this->form);

--- a/demos/_includes/flyers-form-demo.php
+++ b/demos/_includes/flyers-form-demo.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace atk4\ui\demo;
+
 use atk4\ui\Form;
 
 class Flyers extends \atk4\data\Model

--- a/demos/_includes/flyers-form-demo.php
+++ b/demos/_includes/flyers-form-demo.php
@@ -34,21 +34,21 @@ class FlyersForm extends Form
     {
         parent::init();
 
-        $this->addField('first_name', ['Line', 'caption' => 'Main passenger', 'placeholder' => 'First name'], ['required' => true]);
-        $this->addField('last_name', ['Line', 'renderLabel' => false, 'placeholder' => 'Last name'], ['required' => true]);
-        $this->addField('email', ['Line'], ['required' => true]);
+        $this->addField('first_name', [\atk4\ui\FormField\Line::class, 'caption' => 'Main passenger', 'placeholder' => 'First name'], ['required' => true]);
+        $this->addField('last_name', [\atk4\ui\FormField\Line::class, 'renderLabel' => false, 'placeholder' => 'Last name'], ['required' => true]);
+        $this->addField('email', [\atk4\ui\FormField\Line::class], ['required' => true]);
 
-        $this->addField('from', ['Calendar', 'caption' => 'Date:', 'placeholder' => 'From'], ['type' => 'date', 'required' => true]);
-        $this->addField('to', ['Calendar', 'renderLabel' => false, 'placeholder' => 'To'], ['type' => 'date', 'required' => true]);
+        $this->addField('from', [\atk4\ui\FormField\Calendar::class, 'caption' => 'Date:', 'placeholder' => 'From'], ['type' => 'date', 'required' => true]);
+        $this->addField('to', [\atk4\ui\FormField\Calendar::class, 'renderLabel' => false, 'placeholder' => 'To'], ['type' => 'date', 'required' => true]);
 
         $this->addField('contains', [
-            'Line',
+            \atk4\ui\FormField\Line::class,
             'placeholder' => 'Search for country containing ...',
             'renderLabel' => false,
         ]);
 
         $this->addField('country', [
-            'Lookup',
+            \atk4\ui\FormField\Lookup::class,
             'model' => new \atk4\ui\demo\Country($this->db),
             'dependency' => function ($model, $data) {
                 isset($data['contains']) ? $model->addCondition('name', 'like', '%' . $data['contains'] . '%') : null;
@@ -58,7 +58,7 @@ class FlyersForm extends Form
             'placeholder' => 'Select your destination',
         ], ['required' => true]);
 
-        $ml = $this->addField('multi', ['MultiLine', 'rowLimit' => 4, 'addOnTab' => true, 'caption' => 'Additional passengers:', 'renderLabel' => false]);
+        $ml = $this->addField('multi', [\atk4\ui\FormField\MultiLine::class, 'rowLimit' => 4, 'addOnTab' => true, 'caption' => 'Additional passengers:', 'renderLabel' => false]);
         $ml->setModel(new Flyers(new \atk4\data\Persistence\Array_($this->flyers)));
 
         $cards = $this->addField('cards', [new \atk4\ui\FormField\TreeItemSelector(['treeItems' => $this->cards]), 'caption' => 'Flyers program:'], ['type' => 'array', 'serialize' => 'json']);

--- a/demos/basic/breadcrumb.php
+++ b/demos/basic/breadcrumb.php
@@ -34,7 +34,7 @@ if ($id = $app->stickyGet('country_id')) {
     // display list of countries
     $table = \atk4\ui\Table::addTo($app);
     $table->setModel($m);
-    $table->addDecorator('name', ['Link', [], ['country_id' => 'id']]);
+    $table->addDecorator('name', [\atk4\ui\TableColumn\Link::class, [], ['country_id' => 'id']]);
 }
 
 $crumb->popTitle();

--- a/demos/collection/crud.php
+++ b/demos/collection/crud.php
@@ -27,7 +27,7 @@ $g->onFormAddEdit(function ($form, $ex) {
 
 $g->setModel($m);
 
-$g->addDecorator($m->title_field, ['Link', ['test' => false, 'path' => 'interfaces/page'], ['_id' => 'id']]);
+$g->addDecorator($m->title_field, [\atk4\ui\TableColumn\Link::class, ['test' => false, 'path' => 'interfaces/page'], ['_id' => 'id']]);
 
 \atk4\ui\View::addTo($app, ['ui' => 'divider']);
 

--- a/demos/collection/grid.php
+++ b/demos/collection/grid.php
@@ -29,7 +29,7 @@ $g->menu->addItem(['Add Country', 'icon' => 'add square'], new \atk4\ui\jsExpres
 $g->menu->addItem(['Re-Import', 'icon' => 'power'], new \atk4\ui\jsReload($g));
 $g->menu->addItem(['Delete All', 'icon' => 'trash', 'red active']);
 
-$g->addColumn(null, ['Template', 'hello<b>world</b>']);
+$g->addColumn(null, [\atk4\ui\TableColumn\Template::class, 'hello<b>world</b>']);
 
 $g->addActionButton('test');
 

--- a/demos/collection/jsactionsgrid.php
+++ b/demos/collection/jsactionsgrid.php
@@ -19,12 +19,12 @@ require_once __DIR__ . '/../_includes/country_actions.php';
 $g = \atk4\ui\Grid::addTo($app, ['menu' => false]);
 $g->setModel($country);
 
-$divider = $app->factory('View', ['id' => false, 'class' => ['divider'], 'content' => ''], 'atk4\ui');
+$divider = $app->factory(\atk4\ui\View::class, ['id' => false, 'class' => ['divider'], 'content' => '']);
 
-$model_header = $app->factory('View', ['id' => false, 'class' => ['header'], 'content' => 'Model Actions'], 'atk4\ui');
+$model_header = $app->factory(\atk4\ui\View::class, ['id' => false, 'class' => ['header'], 'content' => 'Model Actions']);
 \atk4\ui\Icon::addTo($model_header, ['content' => 'database']);
 
-$js_header = $app->factory('View', ['id' => false, 'class' => ['header'], 'content' => 'Js Actions'], 'atk4\ui');
+$js_header = $app->factory(\atk4\ui\View::class, ['id' => false, 'class' => ['header'], 'content' => 'Js Actions']);
 \atk4\ui\Icon::addTo($js_header, ['content' => 'file code']);
 
 $g->addActionMenuItem($js_header);
@@ -48,7 +48,7 @@ $g->addActionMenuItems(
     ]
 );
 
-$special_item = $app->factory('View', ['id' => false, 'class' => ['item'], 'content' => 'Multi Step'], 'atk4\ui');
+$special_item = $app->factory(\atk4\ui\View::class, ['id' => false, 'class' => ['item'], 'content' => 'Multi Step']);
 \atk4\ui\Icon::addTo($special_item, ['content' => 'window maximize outline']);
 
 $g->addActionMenuItem($special_item, $country->getAction('multi_step'));

--- a/demos/collection/table.php
+++ b/demos/collection/table.php
@@ -62,8 +62,8 @@ $table = \atk4\ui\Table::addTo($app);
 $table->setSource($my_array, ['name']);
 
 //$table->addColumn('name');
-$table->addColumn('surname', ['Link', 'url' => 'table.php?id={$surname}']);
+$table->addColumn('surname', [\atk4\ui\TableColumn\Link::class, 'url' => 'table.php?id={$surname}']);
 $table->addColumn('birthdate', null, ['type' => 'date']);
-$table->addColumn('cv', ['HTML']);
+$table->addColumn('cv', [\atk4\ui\TableColumn\HTML::class]);
 
 $table->getColumnDecorators('name')[0]->addClass('disabled');

--- a/demos/collection/table2.php
+++ b/demos/collection/table2.php
@@ -17,7 +17,7 @@ $m->getField('amount')->type = 'money';
 
 $table = \atk4\ui\Table::addTo($app);
 $table->setModel($m, ['action']);
-$table->addColumn('amount', ['Money']);
+$table->addColumn('amount', [\atk4\ui\TableColumn\Money::class]);
 
 // Table template can be tweaked directly
 $table->template->appendHTML('SubHead', '<tr class="center aligned"><th colspan=2>This is sub-header, goes inside "thead" tag</th></tr>');
@@ -50,25 +50,25 @@ $m->addExpression('amount_copy', [function (\atk4\data\Model $m) {
 }, 'type' => 'money']);
 
 // column with 2 decorators that stack. Money will use red ink and alignment, format will change text.
-$table->addColumn('amount', ['Money']);
-$table->addDecorator('amount', ['Template', 'Refunded: {$amount}']);
+$table->addColumn('amount', [\atk4\ui\TableColumn\Money::class]);
+$table->addDecorator('amount', [\atk4\ui\TableColumn\Template::class, 'Refunded: {$amount}']);
 
 // column which uses selective format depending on condition
-$table->addColumn('amount_copy', ['Multiformat', function ($a, $b) {
+$table->addColumn('amount_copy', [\atk4\ui\TableColumn\Multiformat::class, function ($a, $b) {
     if ($a->get('amount_copy') > 0) {
         // Two formatters together
-        return [\atk4\ui\TableColumn\Link::class, atk4\ui\TableColumn\Money::class];
+        return [\atk4\ui\TableColumn\Link::class, \atk4\ui\TableColumn\Money::class];
     } elseif (abs($a->get('amount_copy')) < 50) {
         // One formatter, but inject template and some attributes
         return [[
-            'Template',
+            \atk4\ui\TableColumn\Template::class,
             'too <b>little</b> to <u>matter</u>',
             'attr' => ['all' => ['class' => ['right aligned single line']]],
         ]];
     }
 
     // Short way is to simply return seed
-    return 'Money';
+    return \atk4\ui\TableColumn\Money::class;
 }, 'attr' => ['all' => ['class' => ['right aligned singel line']]]]);
 
 \atk4\ui\Header::addTo($app, ['Table with resizable columns', 'subHeader' => 'Just drag column header to resize', 'icon' => 'table']);

--- a/demos/collection/table2.php
+++ b/demos/collection/table2.php
@@ -57,7 +57,7 @@ $table->addDecorator('amount', ['Template', 'Refunded: {$amount}']);
 $table->addColumn('amount_copy', ['Multiformat', function ($a, $b) {
     if ($a->get('amount_copy') > 0) {
         // Two formatters together
-        return ['Link', 'Money'];
+        return [\atk4\ui\TableColumn\Link::class, atk4\ui\TableColumn\Money::class];
     } elseif (abs($a->get('amount_copy')) < 50) {
         // One formatter, but inject template and some attributes
         return [[

--- a/demos/collection/tablecolumns.php
+++ b/demos/collection/tablecolumns.php
@@ -13,7 +13,7 @@ $modelColorClass = get_class(new class() extends \atk4\data\Model {
             'type' => 'string',
             'ui' => [
                 'table' => [
-                    'Tooltip',
+                    atk4\ui\TableColumn\Tooltip::class,
                     [
                         'tooltip_field' => 'note',
                         'icon' => 'info circle blue',
@@ -26,7 +26,7 @@ $modelColorClass = get_class(new class() extends \atk4\data\Model {
             'type' => 'string',
             'ui' => [
                 'table' => [
-                    'NoValue',
+                    \atk4\ui\TableColumn\NoValue::class,
                     [
                         'no_value' => ' no value ',
                     ],
@@ -44,7 +44,7 @@ $modelColorClass = get_class(new class() extends \atk4\data\Model {
             ],
             'ui' => [
                 'table' => [
-                    'KeyValue',
+                    atk4\ui\TableColumn\KeyValue::class,
                 ],
             ],
         ]);
@@ -59,7 +59,7 @@ $modelColorClass = get_class(new class() extends \atk4\data\Model {
             ],
             'ui' => [
                 'table' => [
-                    'KeyValue',
+                    atk4\ui\TableColumn\KeyValue::class,
                 ],
             ],
         ]);
@@ -68,7 +68,7 @@ $modelColorClass = get_class(new class() extends \atk4\data\Model {
             'type' => 'string',
             'ui' => [
                 'table' => [
-                    'Labels',
+                    \atk4\ui\TableColumn\Labels::class,
                 ],
             ],
         ]);
@@ -77,7 +77,7 @@ $modelColorClass = get_class(new class() extends \atk4\data\Model {
             'type' => 'float',
             'ui' => [
                 'table' => [
-                    'ColorRating',
+                    atk4\ui\TableColumn\ColorRating::class,
                     [
                         'min' => 1,
                         'max' => 3,

--- a/demos/collection/tablecolumns.php
+++ b/demos/collection/tablecolumns.php
@@ -13,7 +13,7 @@ $modelColorClass = get_class(new class() extends \atk4\data\Model {
             'type' => 'string',
             'ui' => [
                 'table' => [
-                    atk4\ui\TableColumn\Tooltip::class,
+                    \atk4\ui\TableColumn\Tooltip::class,
                     [
                         'tooltip_field' => 'note',
                         'icon' => 'info circle blue',
@@ -44,7 +44,7 @@ $modelColorClass = get_class(new class() extends \atk4\data\Model {
             ],
             'ui' => [
                 'table' => [
-                    atk4\ui\TableColumn\KeyValue::class,
+                    \atk4\ui\TableColumn\KeyValue::class,
                 ],
             ],
         ]);
@@ -59,7 +59,7 @@ $modelColorClass = get_class(new class() extends \atk4\data\Model {
             ],
             'ui' => [
                 'table' => [
-                    atk4\ui\TableColumn\KeyValue::class,
+                    \atk4\ui\TableColumn\KeyValue::class,
                 ],
             ],
         ]);
@@ -77,7 +77,7 @@ $modelColorClass = get_class(new class() extends \atk4\data\Model {
             'type' => 'float',
             'ui' => [
                 'table' => [
-                    atk4\ui\TableColumn\ColorRating::class,
+                    \atk4\ui\TableColumn\ColorRating::class,
                     [
                         'min' => 1,
                         'max' => 3,

--- a/demos/database.php
+++ b/demos/database.php
@@ -115,7 +115,7 @@ class Stat extends \atk4\data\Model
             'their_field' => 'iso',
             'ui' => [
                 'display' => [
-                    'form' => 'Line',
+                    'form' => \atk4\ui\FormField\Line::class,
                 ],
             ],
         ])
@@ -146,7 +146,7 @@ class Stat extends \atk4\data\Model
         $this->addFields(['start_date', 'finish_date'], ['type' => 'date']);
         $this->addField('finish_time', ['type' => 'time']);
 
-        $this->addFields(['created', 'updated'], ['type' => 'datetime', 'ui' => ['form' => ['Line', 'disabled' => true]]]);
+        $this->addFields(['created', 'updated'], ['type' => 'datetime', 'ui' => ['form' => [\atk4\ui\FormField\Line::class, 'disabled' => true]]]);
     }
 }
 

--- a/demos/form/form-section-accordion.php
+++ b/demos/form/form-section-accordion.php
@@ -10,13 +10,13 @@ require_once __DIR__ . '/../atk-init.php';
 
 $f = \atk4\ui\Form::addTo($app);
 
-$sub_layout = $f->layout->addSubLayout('Generic');
+$sub_layout = $f->layout->addSubLayout(\atk4\ui\FormLayout\Section\Generic::class);
 \atk4\ui\Header::addTo($sub_layout, ['Please fill all form sections!', 'size' => 4]);
 
 $sub_layout->addField('company_name');
 
 // Accordion
-$accordion_layout = $f->layout->addSubLayout(['Accordion', 'type' => ['styled', 'fluid'], 'settings' => ['exclusive' => false]]);
+$accordion_layout = $f->layout->addSubLayout([\atk4\ui\FormLayout\Section\Accordion::class, 'type' => ['styled', 'fluid'], 'settings' => ['exclusive' => false]]);
 
 // Section #1
 $contact_section = $accordion_layout->addSection('Contact');
@@ -41,7 +41,7 @@ $gr->addField('country', ['width' => 'six']);
 $gr->addField('postal', ['width' => 'four']);
 
 // Sub-Accordion
-$sub_accordion_layout = $adr_section->addSubLayout(['Accordion', 'type' => ['styled', 'fluid'], 'settings' => ['exclusive' => false]]);
+$sub_accordion_layout = $adr_section->addSubLayout([\atk4\ui\FormLayout\Section\Accordion::class, 'type' => ['styled', 'fluid'], 'settings' => ['exclusive' => false]]);
 
 // Sub-Section #1
 $section_1 = $sub_accordion_layout->addSection('Business address');

--- a/demos/form/form-section-accordion.php
+++ b/demos/form/form-section-accordion.php
@@ -52,7 +52,7 @@ $section_2 = $sub_accordion_layout->addSection('Delivery address');
 $section_2->addField('delivery_address', []);
 
 // Terms field
-$f->addField('term', ['CheckBox', 'caption' => 'Accept terms and conditions', null, 'slider']);
+$f->addField('term', [\atk4\ui\FormField\CheckBox::class, 'caption' => 'Accept terms and conditions', null, 'slider']);
 
 $accordion_layout->activate($contact_section);
 

--- a/demos/form/form-section.php
+++ b/demos/form/form-section.php
@@ -26,12 +26,12 @@ $noSave = function (\atk4\ui\Form $form) {
 $f = \atk4\ui\Form::addTo($app);
 $f->setModel($m, false);
 
-$sub_layout = $f->layout->addSubLayout('Generic');
+$sub_layout = $f->layout->addSubLayout(\atk4\ui\FormLayout\Section\Generic::class);
 
 \atk4\ui\Header::addTo($sub_layout, ['Column Section in Form']);
 $sub_layout->setModel($m, ['name']);
 
-$cols_layout = $f->layout->addSubLayout('Columns');
+$cols_layout = $f->layout->addSubLayout(\atk4\ui\FormLayout\Section\Columns::class);
 
 $c1 = $cols_layout->addColumn();
 $c1->setModel($m, ['iso', 'iso3']);
@@ -50,12 +50,12 @@ $f->onSubmit($noSave);
 $f = \atk4\ui\Form::addTo($app);
 $f->setModel($m, false);
 
-$sub_layout = $f->layout->addSubLayout('Generic');
+$sub_layout = $f->layout->addSubLayout(\atk4\ui\FormLayout\Section\Generic::class);
 
 \atk4\ui\Header::addTo($sub_layout, ['Accordion Section in Form']);
 $sub_layout->setModel($m, ['name']);
 
-$accordion_layout = $f->layout->addSubLayout('Accordion');
+$accordion_layout = $f->layout->addSubLayout(\atk4\ui\FormLayout\Section\Accordion::class);
 
 $a1 = $accordion_layout->addSection('Section 1');
 $a1->setModel($m, ['iso', 'iso3']);
@@ -72,12 +72,12 @@ $f->onSubmit($noSave);
 $f = \atk4\ui\Form::addTo($app);
 $f->setModel($m, false);
 
-$sub_layout = $f->layout->addSubLayout('Generic');
+$sub_layout = $f->layout->addSubLayout(\atk4\ui\FormLayout\Section\Generic::class);
 
 \atk4\ui\Header::addTo($sub_layout, ['Tabs in Form']);
 $sub_layout->setModel($m, ['name']);
 
-$tabs_layout = $f->layout->addSubLayout('Tabs');
+$tabs_layout = $f->layout->addSubLayout(\atk4\ui\FormLayout\Section\Tabs::class);
 
 $t1 = $tabs_layout->addTab('Tab 1');
 $t1->addGroup('In Group')->setModel($m, ['iso', 'iso3']);
@@ -96,13 +96,13 @@ $f->onSubmit($noSave);
 $f = \atk4\ui\Form::addTo($app);
 $f->setModel($m, false);
 
-$sub_layout = $f->layout->addSubLayout(['Generic', 'ui' => 'segment red inverted'], false);
+$sub_layout = $f->layout->addSubLayout([\atk4\ui\FormLayout\Section\Generic::class, 'ui' => 'segment red inverted'], false);
 
 \atk4\ui\Header::addTo($sub_layout, ['This section in Red', 'ui' => 'dividing header', 'element' => 'h2']);
 $sub_layout->setModel($m, ['name']);
 
-$sub_layout = $f->layout->addSubLayout(['Generic', 'ui' => 'segment teal inverted']);
-$cols_layout = $sub_layout->addSubLayout('Columns');
+$sub_layout = $f->layout->addSubLayout([\atk4\ui\FormLayout\Section\Generic::class, 'ui' => 'segment teal inverted']);
+$cols_layout = $sub_layout->addSubLayout(\atk4\ui\FormLayout\Section\Columns::class);
 
 $c1 = $cols_layout->addColumn();
 $c1->setModel($m, ['iso', 'iso3']);

--- a/demos/form/form.php
+++ b/demos/form/form.php
@@ -39,17 +39,17 @@ $form = \atk4\ui\Form::addTo($tab);
 $g = $form->addGroup(['width' => 'three']);
 $g->addField('name');
 $g->addField('surname');
-$g->addField('gender', ['DropDown', 'values' => ['Female', 'Male']]);
+$g->addField('gender', [\atk4\ui\FormField\DropDown::class, 'values' => ['Female', 'Male']]);
 
 // testing 0 value
 $values = [0 => 'noob', 1 => 'pro', 2 => 'dev'];
-$form->addField('description', ['TextArea'])->set(0);
-$form->addField('no_description', ['TextArea'])->set(null);
-$form->addField('status_optional', ['DropDown', 'values' => $values]);
-$form->addField('status_string_required', ['DropDown'], ['type' => 'string', 'values' => $values, 'required' => true]);
-$form->addField('status_integer_required', ['DropDown'], ['type' => 'integer', 'values' => $values, 'required' => true]);
-$form->addField('status_string_mandatory', ['DropDown'], ['type' => 'string', 'values' => $values, 'mandatory' => true]);
-$form->addField('status_integer_mandatory', ['DropDown'], ['type' => 'integer', 'values' => $values, 'mandatory' => true]);
+$form->addField('description', [\atk4\ui\FormField\TextArea::class])->set(0);
+$form->addField('no_description', [\atk4\ui\FormField\TextArea::class])->set(null);
+$form->addField('status_optional', [\atk4\ui\FormField\DropDown::class, 'values' => $values]);
+$form->addField('status_string_required', [\atk4\ui\FormField\DropDown::class], ['type' => 'string', 'values' => $values, 'required' => true]);
+$form->addField('status_integer_required', [\atk4\ui\FormField\DropDown::class], ['type' => 'integer', 'values' => $values, 'required' => true]);
+$form->addField('status_string_mandatory', [\atk4\ui\FormField\DropDown::class], ['type' => 'string', 'values' => $values, 'mandatory' => true]);
+$form->addField('status_integer_mandatory', [\atk4\ui\FormField\DropDown::class], ['type' => 'integer', 'values' => $values, 'mandatory' => true]);
 
 $form->onSubmit(function (\atk4\ui\Form $form) {
     return (new \atk4\ui\jsNotify(json_encode($form->model->get())))->setDuration(0);
@@ -58,7 +58,7 @@ $form->onSubmit(function (\atk4\ui\Form $form) {
 \atk4\ui\Header::addTo($tab, ['Comparing Field type vs Decorator class']);
 $form = \atk4\ui\Form::addTo($tab);
 $form->addField('date1', null, ['type' => 'date']);
-$form->addField('date2', ['Calendar', 'type' => 'date']);
+$form->addField('date2', [\atk4\ui\FormField\Calendar::class, 'type' => 'date']);
 $form->buttonSave->set('Compare Date');
 
 $form->onSubmit(function (\atk4\ui\Form $form) {

--- a/demos/form/form3.php
+++ b/demos/form/form3.php
@@ -21,7 +21,7 @@ $seg = \atk4\ui\View::addTo($app, ['ui' => 'raised segment']);
 \atk4\ui\Button::addTo($buttons, ['Use Stat Model', 'icon' => 'arrow down'])
     ->on('click', new jsReload($seg, ['m' => 'stat']));
 
-$form = \atk4\ui\Form::addTo($seg, ['layout' => 'Columns']);
+$form = \atk4\ui\Form::addTo($seg, ['layout' => \atk4\ui\FormLayout\Columns::class]);
 $form->setModel(
     isset($_GET['m']) ? (
         $_GET['m'] === 'country' ? new Country($db) : (

--- a/demos/form/form5.php
+++ b/demos/form/form5.php
@@ -22,7 +22,7 @@ $f->addField('two', 'Caption');
 $f->addField('three', ['caption' => 'Caption2']);
 
 // Use zeroth argument of the seed to specify standard class
-$f->addField('four', ['CheckBox', 'caption' => 'Caption2']);
+$f->addField('four', [\atk4\ui\FormField\CheckBox::class, 'caption' => 'Caption2']);
 
 // Use explicit object for user-defined or 3rd party field
 $f->addField('five', new \atk4\ui\FormField\CheckBox())->set(true);
@@ -46,7 +46,7 @@ $m->addField('three', ['ui' => ['form' => ['caption' => 'Caption']]]);
 $m->addField('four', ['type' => 'boolean', 'ui' => ['form' => ['caption' => 'Caption2']]]);
 
 // Can specify class for a checkbox explicitly
-$m->addField('five', ['ui' => ['form' => ['CheckBox', 'caption' => 'Caption3']]]);
+$m->addField('five', ['ui' => ['form' => [\atk4\ui\FormField\CheckBox::class, 'caption' => 'Caption3']]]);
 
 // Form-specific caption overrides general caption of a field. Also you can specify object instead of seed
 $m->addField('six', ['caption' => 'badcaption', 'ui' => ['form' => new \atk4\ui\FormField\CheckBox(['caption' => 'Caption4'])]]);
@@ -65,10 +65,10 @@ $f->addField('one', ['caption' => 'Caption0']);
 $f->addField('two', 'Caption2');
 
 // We can override type, but seed from model will still be respected
-$f->addField('three', ['CheckBox']);
+$f->addField('three', [\atk4\ui\FormField\CheckBox::class]);
 
 // We override type and caption here
-$f->addField('four', ['Line', 'caption' => 'CaptionX']);
+$f->addField('four', [\atk4\ui\FormField\Line::class, 'caption' => 'CaptionX']);
 
 // We can specify form field object. It's still seeded with caption from model.
 $f->addField('five', new \atk4\ui\FormField\CheckBox());

--- a/demos/form/html-layout.php
+++ b/demos/form/html-layout.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace atk4\ui\demo;
+
 use atk4\ui\Form;
 use atk4\ui\FormLayout\Custom;
 use atk4\ui\FormLayout\Generic;

--- a/demos/form/jscondform.php
+++ b/demos/form/jscondform.php
@@ -97,7 +97,7 @@ $f_acc = \atk4\ui\Form::addTo($app, ['segment']);
 \atk4\ui\Label::addTo($f_acc, ['Work on section layouts too.', 'top attached'], ['AboveFields']);
 
 // Accordion
-$accordion_layout = $f_acc->layout->addSubLayout(['Accordion', 'type' => ['styled', 'fluid'], 'settings' => ['exclusive' => false]]);
+$accordion_layout = $f_acc->layout->addSubLayout([\atk4\ui\FormLayout\Section\Accordion::class, 'type' => ['styled', 'fluid'], 'settings' => ['exclusive' => false]]);
 
 // Section - business address
 $adr_section = $accordion_layout->addSection('Business Address');

--- a/demos/form/jscondform.php
+++ b/demos/form/jscondform.php
@@ -29,11 +29,11 @@ $f_sub = \atk4\ui\Form::addTo($app, ['segment']);
 \atk4\ui\Label::addTo($f_sub, ['Click on subscribe and add email to receive your gift.', 'top attached'], ['AboveFields']);
 
 $f_sub->addField('name');
-$f_sub->addField('subscribe', ['CheckBox', 'Subscribe to weekly newsletter', 'toggle']);
+$f_sub->addField('subscribe', [\atk4\ui\FormField\CheckBox::class, 'Subscribe to weekly newsletter', 'toggle']);
 $f_sub->addField('email');
-$f_sub->addField('gender', ['Radio'], ['enum' => ['Female', 'Male']])->set('Female');
-$f_sub->addField('m_gift', ['DropDown', 'caption' => 'Gift for Men', 'values' => ['Beer Glass', 'Swiss Knife']]);
-$f_sub->addField('f_gift', ['DropDown', 'caption' => 'Gift for Women', 'values' => ['Wine Glass', 'Lipstick']]);
+$f_sub->addField('gender', [\atk4\ui\FormField\Radio::class], ['enum' => ['Female', 'Male']])->set('Female');
+$f_sub->addField('m_gift', [\atk4\ui\FormField\DropDown::class, 'caption' => 'Gift for Men', 'values' => ['Beer Glass', 'Swiss Knife']]);
+$f_sub->addField('f_gift', [\atk4\ui\FormField\DropDown::class, 'caption' => 'Gift for Women', 'values' => ['Wine Glass', 'Lipstick']]);
 
 // Show email and gender when subscribe is checked.
 // Show m_gift when gender is exactly equal to 'male' and subscribe is checked.
@@ -50,9 +50,9 @@ $f_sub->setFieldsDisplayRules([
 
 $f_dog = \atk4\ui\Form::addTo($app, ['segment']);
 \atk4\ui\Label::addTo($f_dog, ['You can select type of hair cut only with race that contains "poodle" AND age no more than 5 year OR your dog race is exactly "bichon".', 'top attached'], ['AboveFields']);
-$f_dog->addField('race', ['Line']);
+$f_dog->addField('race', [\atk4\ui\FormField\Line::class]);
 $f_dog->addField('age');
-$f_dog->addField('hair_cut', ['DropDown', 'values' => ['Short', 'Long']]);
+$f_dog->addField('hair_cut', [\atk4\ui\FormField\DropDown::class, 'values' => ['Short', 'Long']]);
 
 // Show 'hair_cut' when race contains the word 'poodle' AND age is between 1 and 5
 // OR
@@ -72,13 +72,13 @@ $g_basic->addField('first_name', ['width' => 'eight']);
 $g_basic->addField('middle_name', ['width' => 'three']);
 $g_basic->addField('last_name', ['width' => 'five']);
 
-$f_group->addField('dev', ['CheckBox', 'caption' => 'I am a developper']);
+$f_group->addField('dev', [\atk4\ui\FormField\CheckBox::class, 'caption' => 'I am a developper']);
 
 $g_code = $f_group->addGroup(['Check all language that apply']);
-$g_code->addField('php', ['CheckBox']);
-$g_code->addField('js', ['CheckBox']);
-$g_code->addField('html', ['CheckBox']);
-$g_code->addField('css', ['CheckBox']);
+$g_code->addField('php', [\atk4\ui\FormField\CheckBox::class]);
+$g_code->addField('js', [\atk4\ui\FormField\CheckBox::class]);
+$g_code->addField('html', [\atk4\ui\FormField\CheckBox::class]);
+$g_code->addField('css', [\atk4\ui\FormField\CheckBox::class]);
 
 $g_other = $f_group->addGroup(['Others']);
 $g_other->addField('language', ['width' => 'eight']);
@@ -111,7 +111,7 @@ $gr->addField('state1', ['width' => 'six']);
 $gr->addField('country1', ['width' => 'six']);
 $gr->addField('postal1', ['width' => 'four']);
 
-$adr_section->addField('custom_shipping', ['CheckBox', 'caption'=>'Different Shipping Address']);
+$adr_section->addField('custom_shipping', [\atk4\ui\FormField\CheckBox::class, 'caption'=>'Different Shipping Address']);
 
 // Section - shipping address
 $ship_section = $accordion_layout->addSection('Shipping address');

--- a/demos/input/checkbox.php
+++ b/demos/input/checkbox.php
@@ -27,8 +27,8 @@ require_once __DIR__ . '/../atk-init.php';
 
     \atk4\ui\Header::addTo($app, ['CheckBoxes in a form', 'size' => 2]);
 $form = \atk4\ui\Form::addTo($app);
-$form->addField('test', ['CheckBox']);
-$form->addField('test_checked', ['CheckBox'])->set(true);
+$form->addField('test', [\atk4\ui\FormField\CheckBox::class]);
+$form->addField('test_checked', [\atk4\ui\FormField\CheckBox::class])->set(true);
 $form->addField('also_checked', 'Hello World', 'boolean')->set(true);
 
     View::addTo($app, ['ui' => 'divider']);

--- a/demos/input/dropdown-plus.php
+++ b/demos/input/dropdown-plus.php
@@ -22,7 +22,7 @@ $form = \atk4\ui\Form::addTo($demo->left);
 //standard with model: use id_field as Value, title_field as Title for each DropDown option
 $form->addField(
     'withModel',
-    ['DropDown',
+    [\atk4\ui\FormField\DropDown::class,
         'caption' => 'DropDown with data from Model',
         'model' => (new Country($db))->setLimit(25),
     ]
@@ -31,7 +31,7 @@ $form->addField(
 //custom callback: alter title
 $form->addField(
     'withModel2',
-    ['DropDown',
+    [\atk4\ui\FormField\DropDown::class,
         'caption' => 'DropDown with data from Model',
         'model' => (new Country($db))->setLimit(25),
         'renderRowFunction' => function ($row) {
@@ -46,7 +46,7 @@ $form->addField(
 //custom callback: add icon
 $form->addField(
     'withModel3',
-    ['DropDown',
+    [\atk4\ui\FormField\DropDown::class,
         'caption' => 'DropDown with data from Model',
         'model' => (new File($db))->setLimit(25),
         'renderRowFunction' => function ($row) {
@@ -61,7 +61,7 @@ $form->addField(
 
 $form->addField(
     'enum',
-    ['DropDown',
+    [\atk4\ui\FormField\DropDown::class,
         'caption' => 'Using Single Values',
         'values' => ['default', 'option1', 'option2', 'option3'],
     ]
@@ -69,7 +69,7 @@ $form->addField(
 
 $form->addField(
     'values',
-    ['DropDown',
+    [\atk4\ui\FormField\DropDown::class,
         'caption' => 'Using values with default text',
         'empty' => 'Choose an option',
         'values' => ['default' => 'Default', 'option1' => 'Option 1', 'option2' => 'Option 2', 'option3' => 'Option 3'],
@@ -78,7 +78,7 @@ $form->addField(
 
 $form->addField(
     'icon',
-    ['DropDown',
+    [\atk4\ui\FormField\DropDown::class,
         'caption' => 'Using icon',
         'empty' => 'Choose an icon',
         'values' => ['tag' => ['Tag', 'icon' => 'tag icon'], 'globe' => ['Globe', 'icon' => 'globe icon'], 'registered' => ['Registered', 'icon' => 'registered icon'], 'file' => ['File', 'icon' => 'file icon']],
@@ -87,7 +87,7 @@ $form->addField(
 
 $form->addField(
     'multi',
-    ['DropDown',
+    [\atk4\ui\FormField\DropDown::class,
         'caption' => 'Multiple selection',
         'empty' => 'Choose has many options needed',
         'isMultiple' => true,

--- a/demos/input/field2.php
+++ b/demos/input/field2.php
@@ -112,7 +112,7 @@ $field = $form->addField('name', ['Line', 'hint' => 'this is sample hint that es
 $field->set('value in a form');
 
 $field = $form->addField('surname', new \atk4\ui\FormField\Line([
-    'hint' => ['View', 'template' => new \atk4\ui\Template(
+    'hint' => [\atk4\ui\View::class, 'template' => new \atk4\ui\Template(
         'Click <a href="http://example.com/" target="_blank">here</a>'
     )],
 ]));

--- a/demos/input/field2.php
+++ b/demos/input/field2.php
@@ -41,9 +41,9 @@ $g->addField('d_disb', [new \atk4\ui\FormField\DropDown(['values' => $values]), 
 
 $g = $f->addGroup('Radio');
 
-$g->addField('radio_norm', ['Radio'], ['enum' => ['one', 'two', 'three']])->set('two');
-$g->addField('radio_read', ['Radio', 'readonly' => true], ['enum' => ['one', 'two', 'three']])->set('two');
-$g->addField('radio_disb', ['Radio', 'disabled' => true], ['enum' => ['one', 'two', 'three']])->set('two');
+$g->addField('radio_norm', [\atk4\ui\FormField\Radio::class], ['enum' => ['one', 'two', 'three']])->set('two');
+$g->addField('radio_read', [\atk4\ui\FormField\Radio::class, 'readonly' => true], ['enum' => ['one', 'two', 'three']])->set('two');
+$g->addField('radio_disb', [\atk4\ui\FormField\Radio::class, 'disabled' => true], ['enum' => ['one', 'two', 'three']])->set('two');
 
 $g = $f->addGroup('File upload');
 
@@ -52,15 +52,15 @@ $onDelete = function () {
 $onUpload = function () {
 };
 
-$field = $g->addField('file_norm', ['Upload', ['accept' => ['.png', '.jpg']]])->set('normal', 'normal.jpg');
+$field = $g->addField('file_norm', [\atk4\ui\FormField\Upload::class, ['accept' => ['.png', '.jpg']]])->set('normal', 'normal.jpg');
 $field->onDelete($onDelete);
 $field->onUpload($onUpload);
 
-$field = $g->addField('file_read', ['Upload', ['accept' => ['.png', '.jpg'], 'readonly' => true]])->set('readonly', 'readonly.jpg');
+$field = $g->addField('file_read', [\atk4\ui\FormField\Upload::class, ['accept' => ['.png', '.jpg'], 'readonly' => true]])->set('readonly', 'readonly.jpg');
 $field->onDelete($onDelete);
 $field->onUpload($onUpload);
 
-$field = $g->addField('file_disb', ['Upload', ['accept' => ['.png', '.jpg'], 'disabled' => true]])->set('disabled', 'disabled.jpg');
+$field = $g->addField('file_disb', [\atk4\ui\FormField\Upload::class, ['accept' => ['.png', '.jpg'], 'disabled' => true]])->set('disabled', 'disabled.jpg');
 $field->onDelete($onDelete);
 $field->onUpload($onUpload);
 
@@ -75,14 +75,14 @@ $g->addField('Lookup_norm', [
 ])->set($m->loadAny()->id);
 
 $g->addField('Lookup_read', [
-    'Lookup',
+    \atk4\ui\FormField\Lookup::class,
     'model' => new CountryLock($db),
     'plus' => true,
     'readonly' => true,
 ])->set($m->loadAny()->id);
 
 $g->addField('Lookup_disb', [
-    'Lookup',
+    \atk4\ui\FormField\Lookup::class,
     'model' => new CountryLock($db),
     'plus' => true,
     'disabled' => true,
@@ -90,9 +90,9 @@ $g->addField('Lookup_disb', [
 
 $g = $f->addGroup('Calendar');
 
-$g->addField('calendar_norm', ['Calendar', 'type' => 'date'])->set(date($app->ui_persistence->date_format));
-$g->addField('calendar_read', ['Calendar', 'type' => 'date', 'readonly' => true])->set(date($app->ui_persistence->date_format));
-$g->addField('calendar_disb', ['Calendar', 'type' => 'date', 'disabled' => true])->set(date($app->ui_persistence->date_format));
+$g->addField('calendar_norm', [\atk4\ui\FormField\Calendar::class, 'type' => 'date'])->set(date($app->ui_persistence->date_format));
+$g->addField('calendar_read', [\atk4\ui\FormField\Calendar::class, 'type' => 'date', 'readonly' => true])->set(date($app->ui_persistence->date_format));
+$g->addField('calendar_disb', [\atk4\ui\FormField\Calendar::class, 'type' => 'date', 'disabled' => true])->set(date($app->ui_persistence->date_format));
 
 \atk4\ui\Header::addTo($app, ['Stand Alone Line']);
 // you can pass values to button
@@ -108,7 +108,7 @@ $form = \atk4\ui\Form::addTo($app);
 
 $field = $form->addField('Title', null, ['values' => ['Mr', 'Mrs', 'Miss'], 'ui' => ['hint' => 'select one']]);
 
-$field = $form->addField('name', ['Line', 'hint' => 'this is sample hint that escapes <html> characters']);
+$field = $form->addField('name', [\atk4\ui\FormField\Line::class, 'hint' => 'this is sample hint that escapes <html> characters']);
 $field->set('value in a form');
 
 $field = $form->addField('surname', new \atk4\ui\FormField\Line([

--- a/demos/input/form6.php
+++ b/demos/input/form6.php
@@ -13,16 +13,16 @@ $cc = \atk4\ui\Columns::addTo($app);
 $f = \atk4\ui\Form::addTo($cc->addColumn());
 
 $f->addField('one', null, ['enum' => ['female', 'male']])->set('male');
-$f->addField('two', ['Radio'], ['enum' => ['female', 'male']])->set('male');
+$f->addField('two', [\atk4\ui\FormField\Radio::class], ['enum' => ['female', 'male']])->set('male');
 
 $f->addField('three', null, ['values' => ['female', 'male']])->set(1);
-$f->addField('four', ['Radio'], ['values' => ['female', 'male']])->set(1);
+$f->addField('four', [\atk4\ui\FormField\Radio::class], ['values' => ['female', 'male']])->set(1);
 
 $f->addField('five', null, ['values' => [5 => 'female', 7 => 'male']])->set(7);
-$f->addField('six', ['Radio'], ['values' => [5 => 'female', 7 => 'male']])->set(7);
+$f->addField('six', [\atk4\ui\FormField\Radio::class], ['values' => [5 => 'female', 7 => 'male']])->set(7);
 
 $f->addField('seven', null, ['values' => ['F' => 'female', 'M' => 'male']])->set('M');
-$f->addField('eight', ['Radio'], ['values' => ['F' => 'female', 'M' => 'male']])->set('M');
+$f->addField('eight', [\atk4\ui\FormField\Radio::class], ['values' => ['F' => 'female', 'M' => 'male']])->set('M');
 
 $f->onSubmit(function (\atk4\ui\Form $form) {
     echo json_encode($form->model->get());

--- a/demos/input/lookup-dep.php
+++ b/demos/input/lookup-dep.php
@@ -10,7 +10,7 @@ $form = \atk4\ui\Form::addTo($app, ['segment']);
 \atk4\ui\Label::addTo($form, ['Input information here', 'top attached'], ['AboveFields']);
 
 $form->addField('starts_with', [
-    'DropDown',
+    \atk4\ui\FormField\DropDown::class,
     'values' => [
         'a' => 'Letter A',
         'b' => 'Letter B',
@@ -22,13 +22,13 @@ $form->addField('starts_with', [
 ]);
 
 $form->addField('contains', [
-    'Line',
+    \atk4\ui\FormField\Line::class,
     'hint' => 'Select string that lookup selection of Country will depend on.',
     'placeholder' => 'Search for country containing ...',
 ]);
 
 $lookup = $form->addField('country', [
-    'Lookup',
+    \atk4\ui\FormField\Lookup::class,
     'model' => new Country($db),
     'dependency' => function ($model, $data) {
         $conditions = [];
@@ -56,7 +56,7 @@ $form = \atk4\ui\Form::addTo($app, ['segment']);
 \atk4\ui\Label::addTo($form, ['Input information here', 'top attached'], ['AboveFields']);
 
 $form->addField('ends_with', [
-    'DropDown',
+    \atk4\ui\FormField\DropDown::class,
     'values' => [
         'a' => 'Letter A',
         'e' => 'Letter E',
@@ -67,7 +67,7 @@ $form->addField('ends_with', [
 ]);
 
 $lookup = $form->addField('country', [
-    'Lookup',
+    \atk4\ui\FormField\Lookup::class,
     'model' => new Country($db),
     'dependency' => function ($model, $data) {
         isset($data['ends_with']) ? $model->addCondition('name', 'like', '%' . $data['ends_with']) : null;

--- a/demos/input/lookup.php
+++ b/demos/input/lookup.php
@@ -28,7 +28,7 @@ $m->hasOne('country2', [new Country(), 'ui' => ['form' => [
 $form->setModel($m);
 
 $form->addField('country3', [
-    'Lookup',
+    \atk4\ui\FormField\Lookup::class,
     'model' => new Country($db),
     'placeholder' => 'Search for country by name or iso value',
     'search' => ['name', 'iso', 'iso3'],

--- a/demos/input/multiline.php
+++ b/demos/input/multiline.php
@@ -44,7 +44,7 @@ $ml = $f->addField('ml', ['MultiLine', 'options' => ['color' => 'blue'], 'rowLim
 $ml->setModel($inventory);
 
 // Add total field.
-$sub_layout = $f->layout->addSublayout('Columns');
+$sub_layout = $f->layout->addSublayout(\atk4\ui\FormLayout\Section\Columns::class);
 $sub_layout->addColumn(12);
 $c = $sub_layout->addColumn(4);
 $f_total = $c->addField('total', ['readonly' => true])->set($total);

--- a/demos/input/multiline.php
+++ b/demos/input/multiline.php
@@ -40,7 +40,7 @@ for ($i = 1; $i < 3; ++$i) {
 $f = \atk4\ui\Form::addTo($app);
 $f->addField('test');
 // Add multiline field and set model.
-$ml = $f->addField('ml', ['MultiLine', 'options' => ['color' => 'blue'], 'rowLimit' => 10, 'addOnTab' => true]);
+$ml = $f->addField('ml', [\atk4\ui\FormField\MultiLine::class, 'options' => ['color' => 'blue'], 'rowLimit' => 10, 'addOnTab' => true]);
 $ml->setModel($inventory);
 
 // Add total field.

--- a/demos/input/upload.php
+++ b/demos/input/upload.php
@@ -5,12 +5,12 @@ namespace atk4\ui\demo;
 require_once __DIR__ . '/../atk-init.php';
 
 $form = \atk4\ui\Form::addTo($app);
-$img = $form->addField('img', ['UploadImg', ['defaultSrc' => '../images/default.png', 'placeholder' => 'Click to add an image.']]);
+$img = $form->addField('img', [\atk4\ui\FormField\UploadImg::class, ['defaultSrc' => '../images/default.png', 'placeholder' => 'Click to add an image.']]);
 $img->cb->appSticky = true;
 //$img->set('a_new_token', 'an-img-file-name');
 //$img->setThumbnailSrc('./images/logo.png');
 
-$field = $form->addField('file', ['Upload', ['accept' => ['.png', '.jpg']]]);
+$field = $form->addField('file', [\atk4\ui\FormField\Upload::class, ['accept' => ['.png', '.jpg']]]);
 
 //$field->set('a_generated_token', 'a-file-name');
 //$field->set('a_generated_token');

--- a/demos/interactive/card-deck.php
+++ b/demos/interactive/card-deck.php
@@ -37,7 +37,7 @@ $info_action = $countries->addAction('request_info', [
 
 $info_action->args = [
     'email' => ['type' => 'email', 'required' => true, 'caption' => 'Please let us know your email address:'],
-    'country' => ['required' => true, 'ui' => ['form' => ['Lookup', 'model' => new Country($db), 'placeholder' => 'Please select a country.']]],
+    'country' => ['required' => true, 'ui' => ['form' => [\atk4\ui\FormField\Lookup::class, 'model' => new Country($db), 'placeholder' => 'Please select a country.']]],
 ];
 
 $deck = \atk4\ui\CardDeck::addTo($app, ['noRecordScopeActions' => ['request_info'], 'singleScopeActions' => ['book']]);

--- a/demos/interactive/loader.php
+++ b/demos/interactive/loader.php
@@ -50,7 +50,7 @@ ViewTester::addTo($app);
 \atk4\ui\Loader::addTo($app, [
     'ui' => '',   // this will prevent "loading spinner" from showing
     'shim' => [   // shim is displayed while content is leaded
-        'Message',
+        \atk4\ui\Message::class,
         'Generating LoremIpsum, please wait...',
         'red',
     ],

--- a/demos/interactive/loader2.php
+++ b/demos/interactive/loader2.php
@@ -13,7 +13,7 @@ $c = \atk4\ui\Columns::addTo($app);
 $grid = \atk4\ui\Grid::addTo($c->addColumn(), ['ipp' => 10, 'menu' => false]);
 $grid->setModel(new Country($db), ['name']);
 
-$country_loader = \atk4\ui\Loader::addTo($c->addColumn(), ['loadEvent' => false, 'shim' => ['Text', 'Select country on your left']]);
+$country_loader = \atk4\ui\Loader::addTo($c->addColumn(), ['loadEvent' => false, 'shim' => [\atk4\ui\Text::class, 'Select country on your left']]);
 
 $grid->table->onRowClick($country_loader->jsLoad(['id' => $grid->table->jsRow()->data('id')]));
 

--- a/demos/interactive/popup.php
+++ b/demos/interactive/popup.php
@@ -238,7 +238,7 @@ $signup->set(function ($pop) {
     } else {
         $f = \atk4\ui\Form::addTo($pop);
         $f->addField('email', null, ['required' => true]);
-        $f->addField('password', ['Password'], ['required' => true]);
+        $f->addField('password', [\atk4\ui\FormField\Password::class], ['required' => true]);
         $f->buttonSave->set('Login');
 
         // popup handles callbacks properly, so dynamic element such as form works

--- a/demos/interactive/wizard.php
+++ b/demos/interactive/wizard.php
@@ -53,9 +53,9 @@ $t->addStep(['Select Model', 'description' => '"Country" or "Stat"', 'icon' => '
     $t->setSource(['Country', 'Stat']);
 
     // should work after url() fix
-    $t->addDecorator('name', ['Link', [], ['name']]);
+    $t->addDecorator('name', [\atk4\ui\TableColumn\Link::class, [], ['name']]);
 
-    //$t->addDecorator('name', ['Link', [$w->stepCallback->name=>$w->currentStep], ['name']]);
+    //$t->addDecorator('name', [\atk4\ui\TableColumn\Link::class, [$w->stepCallback->name=>$w->currentStep], ['name']]);
 
     $w->buttonNext->addClass('disabled');
 });

--- a/demos/layout/layout-panel.php
+++ b/demos/layout/layout-panel.php
@@ -71,7 +71,7 @@ $txt->addParagraph('Try to change dropdown value and close without saving!');
 $panel_2->onOpen(function ($p) {
     $f = \atk4\ui\Form::addTo($p);
     $f->addHeader('Settings');
-    $f->addField('name', ['DropDown', 'values' => ['1' => 'Option 1', '2' => 'Option 2']])
+    $f->addField('name', [\atk4\ui\FormField\DropDown::class, 'values' => ['1' => 'Option 1', '2' => 'Option 2']])
         ->set('1')
         ->onChange($p->owner->jsDisplayWarning(true));
 

--- a/demos/layout/layouts.php
+++ b/demos/layout/layouts.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/../atk-init.php';
 $buttons = [
     ['page' => ['layouts_nolayout'],               'title' => 'HTML without layout'],
     ['page' => ['layouts_manual'],                 'title' => 'Manual layout'],
-    ['page' => ['/demos/basic/header', 'layout' => 'Centered'], 'title' => 'Centered layout'],
+    ['page' => ['/demos/basic/header', 'layout' => \atk4\ui\Layout\Centered::class], 'title' => 'Centered layout'],
     ['page' => ['layouts_admin'],                  'title' => 'Admin Layout'],
     ['page' => ['layouts_error'],                  'title' => 'Exception Error'],
 ];

--- a/demos/layout/layouts_admin.php
+++ b/demos/layout/layouts_admin.php
@@ -9,11 +9,11 @@ include_once '../vendor/autoload.php';
 try {
     $app = new \atk4\ui\App('Agile Toolkit Demo App');
 
-    $app->initLayout('Admin');
+    $app->initLayout(\atk4\ui\Layout\Admin::class);
 
     $m_comp = $app->layout->menu->addMenu(['Layouts', 'icon' => 'puzzle']);
-    $m_comp->addItem('Centered');
-    $m_comp->addItem('Admin');
+    $m_comp->addItem(\atk4\ui\Layout\Centered::class);
+    $m_comp->addItem(\atk4\ui\Layout\Admin::class);
 
     $m_right = $app->layout->menuRight;
     $m_right->addItem(['Warning', 'red', 'icon' => 'red warning']);

--- a/demos/obsolete/crud2.php
+++ b/demos/obsolete/crud2.php
@@ -11,4 +11,4 @@ $m->getAction('delete')->system = true;
 
 $g = \atk4\ui\CRUD::addTo($app, ['paginator' => false]);
 $g->setModel($m);
-$g->addDecorator('project_code', 'Link');
+$g->addDecorator('project_code', \atk4\ui\TableColumn\Link::class);

--- a/demos/others/recursive.php
+++ b/demos/others/recursive.php
@@ -1,9 +1,10 @@
 <?php
 
+namespace atk4\ui\demo;
+
 require_once __DIR__ . '/../atk-init.php';
 
-class recursive extends \atk4\ui\View
-{
+$mySwitcherClass = get_class(new class() extends \atk4\ui\View {
     public function init(): void
     {
         parent::init();
@@ -32,7 +33,8 @@ class recursive extends \atk4\ui\View
                 break;
         }
     }
-}
+});
 
 $view = \atk4\ui\View::addTo($app, ['ui' => 'segment']);
-$view->add(new recursive());
+
+$mySwitcherClass::addTo($view);

--- a/demos/others/sticky2.php
+++ b/demos/others/sticky2.php
@@ -34,7 +34,7 @@ if (isset($_GET['name'])) {
 
 $t = \atk4\ui\Table::addTo($app);
 $t->setSource(['Red', 'Green', 'Blue']);
-$t->addDecorator('name', ['Link', [], ['name']]);
+$t->addDecorator('name', [\atk4\ui\TableColumn\Link::class, [], ['name']]);
 
 $frame = \atk4\ui\View::addTo($app, ['ui' => 'green segment']);
 \atk4\ui\Button::addTo($frame, ['does not inherit sticky get'])->on('click', function () {

--- a/demos/tutorial/actions.php
+++ b/demos/tutorial/actions.php
@@ -94,7 +94,7 @@ EOF
 $country = new CountryLock($app->db);
 $country->loadAny();
 
-$app->add(['Button', 'Edit some country'])
+\atk4\ui\Button::addTo($app, 'Edit some country'])
     ->on('click', $country->getAction('edit'));
 CODE
     );
@@ -165,7 +165,7 @@ $app->add(new \atk4\ui\FormField\Line([
 
 $app->add(['ui'=>'divider']);
 
-$app->add(['Button', 'Ask Age'])
+\atk4\ui\Button::addTo($app, 'Ask Age'])
     ->on('click', $model->getAction('ask_age'));
 CODE
     );

--- a/demos/tutorial/actions.php
+++ b/demos/tutorial/actions.php
@@ -9,8 +9,7 @@ require_once __DIR__ . '/../_includes/PromotionText.php';
 // require for embeded coded
 $app->db = $db;
 
-/** @var \atk4\ui\View $wizard */
-$wizard = $app->add('Wizard');
+$wizard = \atk4\ui\Wizard::addTo($app);
 $app->stickyGet($wizard->name);
 
 $wizard->addStep('Define User Action', function ($page) {
@@ -43,7 +42,7 @@ $country->addAction('send_message');
 CODE
     );
 
-    $t = $page->add('Text');
+    $t = \atk4\ui\Text::addTo($page);
     $t->addParagraph(
         <<< 'EOF'
 Once defied - actions will be visualised in the Form, Grid, CRUD and CardDeck. Additionally add-ons will recognise
@@ -79,8 +78,7 @@ CODE
 });
 
 $wizard->addStep('UI Integration', function ($page) {
-    /** @var \atk4\ui\Text $t */
-    $t = $page->add('Text');
+    $t = \atk4\ui\Text::addTo($page);
     $t->addParagraph(
         <<< 'EOF'
 Agile UI introduces a new set of views called "Action Executors". Their job is to recognise all that meta-information
@@ -99,7 +97,7 @@ $country->loadAny();
 CODE
     );
 
-    $t = $page->add('Text');
+    $t = \atk4\ui\Text::addTo($page);
     $t->addParagraph(
         <<< 'EOF'
 It is not only the button, but any view can have "Action" passed as a second step of the on() call. Here the action
@@ -120,7 +118,7 @@ CODE
 });
 
 $wizard->addStep('Arguments', function ($page) {
-    $t = $page->add('Text');
+    $t = \atk4\ui\Text::addTo($page);
     $t->addParagraph(
         <<< 'EOF'
 Next demo defines an action that requires arguments. You can specify action when the action is invoked, but if not
@@ -193,7 +191,7 @@ CODE
 */
 
 $wizard->addStep('CRUD integration', function ($page) {
-    $t = $page->add('Text');
+    $t = \atk4\ui\Text::addTo($page);
     $t->addParagraph(
         <<< 'EOF'
 Compared to 1.x versions CRUD implementation has became much more lightweight, however you retain all the same

--- a/docs/app.rst
+++ b/docs/app.rst
@@ -15,7 +15,7 @@ will be automatically created if you execute `$component->init()` or `$component
 In most use-scenarios, however, you would create instance of an App class yourself before other components::
 
     $app = new \atk4\ui\App('My App');
-    $app->initLayout('Centered');
+    $app->initLayout(\atk4\ui\Layout\Centered::class);
     LoremIpsum::addTo($app);
 
 As you add one component into another, they will automatically inherit reference to App class. App
@@ -80,7 +80,7 @@ active. (See :ref:`system_pattern`)::
 
             // App class may be used for pages that do not require authentication
             if (!$auth) {
-                $this->initLayout('Centered');
+                $this->initLayout(\atk4\ui\Layout\Centered::class);
                 return;
             }
 
@@ -91,7 +91,7 @@ active. (See :ref:`system_pattern`)::
 
             // Make sure user is valid
             if(!$this->user->loaded()) {
-                $this->initLayout('Centered');
+                $this->initLayout(\atk4\ui\Layout\Centered::class);
                 Message::addTo($this, ['Login Required', 'error']);
                 Button::addTo($this, ['Login', 'primary'])->link('index.php');
                 exit;
@@ -100,7 +100,7 @@ active. (See :ref:`system_pattern`)::
             // Load company data (System) for present user
             $this->company = $this->user->ref('company_id');
 
-            $this->initLayout('Admin');
+            $this->initLayout(\atk4\ui\Layout\Admin::class);
 
             // Add more initialization here, such as a populating menu.
         }
@@ -158,7 +158,7 @@ Exception handling
 By default, App will also catch unhandled exceptions and will present them nicely to the user. If you have a
 better plan for exception, place your code inside a try-catch block.
 
-When Exception is caught, it's displayed using a 'Centered' layout and execution of original application is
+When Exception is caught, it's displayed using a Layout\Centered layout and execution of original application is
 terminated.
 
 Integration with other Frameworks
@@ -387,7 +387,7 @@ Adding the Layout
 
 Layout can be initialized through the app like this::
 
-    $app->initLayout('Centered');
+    $app->initLayout(\atk4\ui\Layout\Centered::class);
 
 This will initialize two new views inside the app::
 
@@ -397,7 +397,7 @@ This will initialize two new views inside the app::
 The first view is a HTML boilerplate - containing HEAD / BODY tags but not the body
 contents. It is a standard html5 doctype template.
 
-The layout will be selected based on your choice - 'Centered', 'Admin' etc. This will
+The layout will be selected based on your choice - Layout\Centered, Layout\Admin etc. This will
 not only change the overall page outline, but will also introduce some additional views.
 
 Each layout, depending on it's content, may come with several views that you can populate.
@@ -414,7 +414,7 @@ with top, left and right menu objects.
 
 Populating the left menu object is simply a matter of adding the right menu items to the layout menu::
 
-    $app->initLayout('Admin');
+    $app->initLayout(\atk4\ui\Layout\Admin::class);
     $layout = $app->layout;
 
     // Add item into menu

--- a/docs/autocomplete.rst
+++ b/docs/autocomplete.rst
@@ -31,14 +31,14 @@ form where you can enter new record details.
 The form save will re-use the model of your auto-complete, so be sure to set() defaults and
 addCondition()s::
 
-    $form->addField('test', ['AutoComplete', 'plus'=>true])->setModel(new Country($db));
+    $form->addField('test', [\atk4\ui\FormField\AutoComplete::class, 'plus'=>true])->setModel(new Country($db));
 
 Specifying in Model
 -------------------
 
 You can also specify that you prefer to use AutoComplete inside your model definition::
 
-    $model->hasOne('country_id', [new Country($db), 'ui'=>['form'=>['AutoComplete']]]);
+    $model->hasOne('country_id', [new Country($db), 'ui'=>['form'=>[\atk4\ui\FormField\AutoComplete::class]]]);
 
 Advanced Usage
 --------------
@@ -46,7 +46,7 @@ Advanced Usage
 You can do much more with AutoComplete field by passing dropdown settings::
 
     $form->addField('test', [
-        'AutoComplete', 
+        \atk4\ui\FormField\AutoComplete::class, 
         'settings'=>[
             'allowReselection' => true,
             'selectOnKeydown' => false,
@@ -69,7 +69,7 @@ use of Filters::
     $form = \atk4\ui\Form::addTo($app, ['segment']);
     \atk4\ui\Label::addTo($form, ['Add city', 'top attached'], ['AboveFields']);
 
-    $l = $form->addField('city',['Lookup']);
+    $l = $form->addField('city',[\atk4\ui\FormField\Lookup::class]);
 
     // will restraint possible city value in droddown base on country and/or language.
     $l->addFilter('country', 'Country');

--- a/docs/breadcrumb.rst
+++ b/docs/breadcrumb.rst
@@ -72,7 +72,7 @@ For example the next code will use some logic::
         // display list of users
         $table = Table::addTo($app);
         $table->setModel($m);
-        $table->addDecorator(['name', ['Link', [], ['user_id'=>'id']);
+        $table->addDecorator(['name', [\atk4\ui\TableColumn\Link::class, [], ['user_id'=>'id']);
     }
 
     $crumb->popTitle();

--- a/docs/core.rst
+++ b/docs/core.rst
@@ -16,7 +16,7 @@ create this class explicitly, components generally will do it for you. The commo
 is::
 
     $app = new \atk4\ui\App('My App');
-    $app->initLayout('Centered');
+    $app->initLayout(\atk4\ui\Layout\Centered::class);
     LoremIpsum::addTo($app);
 
 .. toctree::

--- a/docs/field.rst
+++ b/docs/field.rst
@@ -181,7 +181,7 @@ The rules are rather straightforward but may change in future versions of Agile 
 
 You always have an option to explicitly specify which field you would like to use::
 
-    $model->addField('long_text', ['ui'=>['Form'=>'TextArea']]);
+    $model->addField('long_text', ['ui'=>['rorm'=>\atk4\ui\FormField\TextArea::class]]);
 
 It is recommended however, that you use type when possible, because types will be universally supported
 by all components::
@@ -323,7 +323,7 @@ of records to display. DropDown renders all records when the paged is rendered, 
 :php:class:`Lookup` on the other hand is the better choice if there is lots of records (like more than 50).
 
 To render a model field as DropDown, use the ui property of the field::
-    $model->addField('someField', ['ui' => ['form' =>['DropDown']]]);
+    $model->addField('someField', ['ui' => ['form' =>[\atk4\ui\FormField\DropDown::class]]]);
 
 ..  Customizing how a Model's records are displayed in DropDown
 As default, DropDown will use the `$model->id_field` as value, and `$model->title_field` as title for each menu item.
@@ -436,7 +436,7 @@ See this example from Model class init method::
         'serialize' => 'json',
         'ui' => [
             'form' => [
-                'DropDown',
+                \atk4\ui\FormField\DropDown::class,
                 'isMultiple' => true,
                 'model' => $expr_model,
             ],

--- a/docs/filestructure.rst
+++ b/docs/filestructure.rst
@@ -172,14 +172,14 @@ If you want to write an app with a backend, create a file called "admin.php"::
   <?php
   $rootdir = "../";
   require_once __DIR__ . "init.php";
-  $app->initLayout('Admin');
+  $app->initLayout(\atk4\ui\Layout\Admin::class);
 
 If you want to write an app with a frontend, create a file called "index.php"::
 
   <?php
   $rootdir = "../";
   require_once __DIR__ . "init.php";
-  $app->initLayout('Centered');
+  $app->initLayout(\atk4\ui\Layout\Centered::class);
 
 
 Create your own classes

--- a/docs/fileupload.rst
+++ b/docs/fileupload.rst
@@ -51,7 +51,7 @@ Callbacks
 
 When adding an Upload or UploadImg field to a form, onUpload and onDelete callback must be defined::
 
-    $img = $form->addField('img', ['UploadImg', ['defaultSrc' => './images/default.png', 'placeholder' => 'Click to add an image.']]);
+    $img = $form->addField('img', [\atk4\ui\FormField\UploadImg::class, ['defaultSrc' => './images/default.png', 'placeholder' => 'Click to add an image.']]);
 
     $img->onUpload(function ($files) {
         //callback action here...

--- a/docs/form.rst
+++ b/docs/form.rst
@@ -162,7 +162,7 @@ Create a new field on a form::
 
     $form = Form::addTo($app);
     $form->addField('email');
-    $form->addField('gender', ['DropDown', 'values'=>['Female', 'Male']]);
+    $form->addField('gender', [\atk4\ui\FormField\DropDown::class, 'values'=>['Female', 'Male']]);
     $form->addField('terms', null, ['type'=>'boolean', 'caption'=>'Agree to Terms & Conditions']);
 
 Create a new field on a form using Model does not require you to describe each field.
@@ -185,7 +185,7 @@ Similar to :php:meth:`Form::addField()`, but allows to add multiple fields in on
     $form = Form::addTo($app);
     $form->addFields([
         'email',
-        ['gender', ['DropDown', 'values'=>['Female', 'Male']]],
+        ['gender', [\atk4\ui\FormField\DropDown::class, 'values'=>['Female', 'Male']]],
         ['terms', null, ['type'=>'boolean', 'caption'=>'Agree to Terms & Conditions']],
     ]);
 
@@ -228,8 +228,8 @@ For some examples see: https://ui.agiletoolkit.org/demos/form3.php
 
 Field Decorator can be passed to ``addField`` using 'string', :php:ref:`seed` or 'object'::
 
-    $form->addField('accept_terms', 'CheckBox');
-    $form->addField('gender', ['DropDown', 'values'=>['Female', 'Male']]);
+    $form->addField('accept_terms', \atk4\ui\FormField\CheckBox::class);
+    $form->addField('gender', [\atk4\ui\FormField\DropDown::class, 'values'=>['Female', 'Male']]);
 
     $calendar = new \atk4\ui\FormField\Calendar();
     $calendar->type = 'tyme';
@@ -251,7 +251,7 @@ Data field is the 3rd argument to ``Form::addField()``.
 
 There are 3 ways to define Data Field using 'string', 'array' or 'object'::
 
-    $form->addField('accept_terms', 'CheckBox', 'Accept Terms & Conditions');
+    $form->addField('accept_terms', \atk4\ui\FormField\CheckBox::class, 'Accept Terms & Conditions');
     $form->addField('gender', null, ['enum'=>['Female', 'Male']]);
 
     class MyBoolean extends \atk4\data\Field {
@@ -319,7 +319,7 @@ example displays a registration form for a User::
 Type vs Decorator Class
 -----------------------
 
-Sometimes you may wonder - should you pass decorator class ('CheckBox') or
+Sometimes you may wonder - should you pass decorator class (FormField\CheckBox) or
 a data field type (['type' => 'boolean']);
 
 It is always recommended to use data field type, because it will take care of type-casting
@@ -327,7 +327,7 @@ for you. Here is an example with date::
 
     $form = Form::addTo($app);
     $form->addField('date1', null, ['type'=>'date']);
-    $form->addField('date2', ['Calendar', 'type'=>'date']);
+    $form->addField('date2', [\atk4\ui\FormField\Calendar::class, 'type'=>'date']);
 
     $form->onSubmit(function($form) {
         echo 'date1 = '.print_r($form->model->get('date1'), true).' and date2 = '.print_r($form->model->get('date2'), true);
@@ -372,7 +372,7 @@ The seed for the UI will be combined with the default overriding :php:attr:`Form
 to allow month/year entry by the Calendar extension, which will then be saved and
 stored as a regular date. Obviously you can also specify decorator class::
 
-    $this->addField('birth_year', ['ui'=>['Calendar', 'type'=>'month']);
+    $this->addField('birth_year', ['ui'=>[\atk4\ui\FormField\Calendar::class, 'type'=>'month']);
 
 Without the data 'type' property, now the calendar selection will be stored as text.
 
@@ -786,11 +786,11 @@ Here is a more advanced example::
 
     $f_sub = Form::addTo($app);
     $f_sub->addField('name');
-    $f_sub->addField('subscribe', ['CheckBox', 'Subscribe to weekly newsletter', 'toggle']);
+    $f_sub->addField('subscribe', [\atk4\ui\FormField\CheckBox::class, 'Subscribe to weekly newsletter', 'toggle']);
     $f_sub->addField('email');
-    $f_sub->addField('gender', ['Radio'], ['enum'=>['Female', 'Male']])->set('Female');
-    $f_sub->addField('m_gift', ['DropDown', 'caption'=>'Gift for Men', 'values' => ['Beer Glass', 'Swiss Knife']]);
-    $f_sub->addField('f_gift', ['DropDown', 'caption'=>'Gift for Women', 'values' => ['Wine Glass', 'Lipstick']]);
+    $f_sub->addField('gender', [\atk4\ui\FormField\Radio::class], ['enum'=>['Female', 'Male']])->set('Female');
+    $f_sub->addField('m_gift', [\atk4\ui\FormField\DropDown::class, 'caption'=>'Gift for Men', 'values' => ['Beer Glass', 'Swiss Knife']]);
+    $f_sub->addField('f_gift', [\atk4\ui\FormField\DropDown::class, 'caption'=>'Gift for Women', 'values' => ['Wine Glass', 'Lipstick']]);
 
     // Show email and gender when subscribe is checked.
 
@@ -808,9 +808,9 @@ You may also define multiple conditions for the field to be visible if you wrap 
 
 
     $f_sub = Form::addTo($app);
-    $f_dog->addField('race', ['Line']);
+    $f_dog->addField('race', [\atk4\ui\FormField\Line::class]);
     $f_dog->addField('age');
-    $f_dog->addField('hair_cut', ['DropDown', 'values' => ['Short', 'Long']]);
+    $f_dog->addField('hair_cut', [\atk4\ui\FormField\DropDown::class, 'values' => ['Short', 'Long']]);
 
     // Show 'hair_cut' when race contains the word 'poodle' AND age is between 1 and 5
     // OR
@@ -832,13 +832,13 @@ Instead of defining rules for fields individually you can hide/show entire group
     $g_basic->addField('middle_name', ['width' => 'three']);
     $g_basic->addField('last_name', ['width' => 'five']);
 
-    $f_group->addField('dev', ['CheckBox', 'caption' => 'I am a developper']);
+    $f_group->addField('dev', [\atk4\ui\FormField\CheckBox::class, 'caption' => 'I am a developper']);
 
     $g_code = $f_group->addGroup(['Check all language that apply']);
-    $g_code->addField('php', ['CheckBox']);
-    $g_code->addField('js', ['CheckBox']);
-    $g_code->addField('html', ['CheckBox']);
-    $g_code->addField('css', ['CheckBox']);
+    $g_code->addField('php', [\atk4\ui\FormField\CheckBox::class]);
+    $g_code->addField('js', [\atk4\ui\FormField\CheckBox::class]);
+    $g_code->addField('html', [\atk4\ui\FormField\CheckBox::class]);
+    $g_code->addField('css', [\atk4\ui\FormField\CheckBox::class]);
 
     $g_other = $f_group->addGroup(['Others']);
     $g_other->addField('language', ['width' => 'eight']);

--- a/docs/form.rst
+++ b/docs/form.rst
@@ -702,12 +702,12 @@ The following example will show how to organize fields using regular sub layout 
     $f = Form::addTo($app);
     $f->setModel($m, false);
 
-    $sub_layout = $f->layout->addSubLayout('Generic');
+    $sub_layout = $f->layout->addSubLayout(\atk4\ui\FormLayout\Section\Generic::class);
 
     Header::addTo($sub_layout, ['Accordion Section in Form']);
     $sub_layout->setModel($m, ['name']);
 
-    $accordion_layout = $f->layout->addSubLayout('Accordion');
+    $accordion_layout = $f->layout->addSubLayout(\atk4\ui\FormLayout\Section\Accordion::class);
 
     $a1 = $accordion_layout->addSection('Section 1');
     $a1->setModel($m, ['iso', 'iso3']);

--- a/docs/form.rst
+++ b/docs/form.rst
@@ -299,7 +299,7 @@ example displays a registration form for a User::
     $form->setModel(new User($db));
 
     // add password verification field
-    $form->addField('password_verify', 'Password', 'Type password again');
+    $form->addField('password_verify', \atk4\ui\FormField\Password::class, 'Type password again');
     $form->addField('accept_terms', null, ['type'=>'boolean']);
 
     // submit event

--- a/docs/multiline.rst
+++ b/docs/multiline.rst
@@ -110,7 +110,7 @@ If you want to edit them along with the user, Multiline is set up in a few lines
     //Add a form to UI to edit User record
     $user_form = \atk4\ui\Form::addTo($app);
     $user_form->setModel($user);
-    $ml = $user_form->addField('email_addresses', ['MultiLine']);
+    $ml = $user_form->addField('email_addresses', [\atk4\ui\FormField\MultiLine::class]);
     $ml->setModel($user->ref('Email'));
 
     //set up saving of Email on Form submit
@@ -202,7 +202,7 @@ Footer
 ------
 You can add a footer to Multiline FormField by adding a sublayout to it. In this example, we add a footer containing a read-only input which could get the value from ``onLineChange`` callback (see above)::
    
-    $ml = $form->addField('ml', ['MultiLine', 'options' => ['color' => 'blue']]);
+    $ml = $form->addField('ml', [\atk4\ui\FormField\MultiLine::class, 'options' => ['color' => 'blue']]);
     $ml->setModel($inventory);
     // Add sublayout with total field.
     $sub_layout = $f->layout->addSublayout(\atk4\ui\FormLayout\Section\Columns::class);

--- a/docs/multiline.rst
+++ b/docs/multiline.rst
@@ -205,7 +205,7 @@ You can add a footer to Multiline FormField by adding a sublayout to it. In this
     $ml = $form->addField('ml', ['MultiLine', 'options' => ['color' => 'blue']]);
     $ml->setModel($inventory);
     // Add sublayout with total field.
-    $sub_layout = $f->layout->addSublayout('Columns');
+    $sub_layout = $f->layout->addSublayout(\atk4\ui\FormLayout\Section\Columns::class);
     $sub_layout->addColumn(12);
     $c = $sub_layout->addColumn(4);
     $f_total = $c->addField('total', ['readonly' => true])->set($total);

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -117,7 +117,7 @@ clarifications::
 
     // Create Application object and initialize Admin Layout
     $app = new \atk4\ui\App('Offer tracking system');
-    $app->initLayout('Admin');
+    $app->initLayout(\atk4\ui\Layout\Admin::class);
 
     // Connect to database and place a fully-interactive CRUD
     $db = new \atk4\data\Persistence_SQL($dsn);

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -38,7 +38,7 @@ Open a new file `index.php` and enter the following code::
     require_once __DIR__ . '/vendor/autoload.php'; // 2
 
     $app = new \atk4\ui\App('My First App');       // 3
-    $app->initLayout('Centered');                  // 4
+    $app->initLayout(\atk4\ui\Layout\Centered::class);                  // 4
 
     \atk4\ui\HelloWorld::addTo($app);                       // 5
 
@@ -51,7 +51,7 @@ Open a new file `index.php` and enter the following code::
 
 .. [#f3] The `App` class represents your web application. This line may change if you integrate Agile UI with another framework.
 
-.. [#f4] Specifies default page layout for your application. Try changing between 'Centered' and 'Admin'
+.. [#f4] Specifies default page layout for your application. Try changing between Layout\Centered and Layout\Centered.
 
 .. [#f5] Creates new component 'HelloWorld' and adds it into Application Layout.
 
@@ -105,7 +105,7 @@ create the application::
     require_once __DIR__ . '/vendor/autoload.php';
 
     $app = new \atk4\ui\App('ToDo List');
-    $app->initLayout('Centered');
+    $app->initLayout(\atk4\ui\Layout\Centered::class);
 
 All components of Agile Data are database-agnostic and will not concern themselves with the way how you store data.
 I will start the session and connect `persistence <https://agile-data.readthedocs.io/en/develop/persistence.html>`_

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -209,7 +209,7 @@ Next we need to add Components that are capable of manipulating the data::
 
 .. rubric:: Clarifications
 
-.. [#] We wish to position Form and Table side-by-side, so we use 'Columns' component and
+.. [#] We wish to position Form and Table side-by-side, so we use `\atk4\ui\Columns` component and
     inject a Fomantic UI CSS class "divided" that will appear as a vertical separation line.
 
 .. [#] $col_reload is a special object which we call :ref:`js_action`. It represents a Browser-event

--- a/docs/render.rst
+++ b/docs/render.rst
@@ -53,7 +53,7 @@ Late initialization
 When you create an application and select a Layout, the layout is automatically initialized::
 
     $app = new \atk4\ui\App();
-    $app->initLayout('Centered');
+    $app->initLayout(\atk4\ui\Layout\Centered::class);
 
     echo $app->layout->name; // present, because layout is initialized!
 

--- a/docs/seed.rst
+++ b/docs/seed.rst
@@ -57,7 +57,7 @@ For more information about seeds, merging seeds, factories and namespaces, see h
 
 The most important points of a seed such as this one::
 
-    $seed = ['Button', 'hello', 'big red', 'icon'=>['book', 'red']];
+    $seed = [Button::class, 'hello', 'big red', 'icon'=>['book', 'red']];
 
 are:
 

--- a/docs/seed.rst
+++ b/docs/seed.rst
@@ -85,11 +85,11 @@ Additional cases
 An individual object may add more ways to deal with seed. For example, when adding columns
 to your Table you can specify seed for the decorator: :php:class:`atk4\\ui\\TableColumn\\Generic`::
 
-    $table->addColumn('salary', 'Money');
+    $table->addColumn('salary', \atk4\ui\TableColumn\Money::class);
 
     // or
 
-    $table->addColumn('salary', ['Money']);
+    $table->addColumn('salary', [\atk4\ui\TableColumn\Money::class]);
 
     // or
 

--- a/docs/table.rst
+++ b/docs/table.rst
@@ -376,7 +376,7 @@ There are a few things to note:
 
 2. formatting is always applied in same order as defined - in example above Money first, Link after.
 
-3. output of the 'Money' decorator is used into Link decorator as if it would be value of cell, however
+3. output of the \atk4\ui\TableColumn\Money decorator is used into Link decorator as if it would be value of cell, however
    decorators have access to original value also. Decorator implementation is usually aware of combinations.
 
 :php:meth:`TableColumn\\Money::getDataCellTemplate` is called, which returns ONLY the HTML value,
@@ -509,12 +509,12 @@ There are several ways to make your code more readable::
 
 Or if you wish to use factory, the syntax is::
 
-    $table->addColumn('name', 'Generic')
+    $table->addColumn('name', \atk4\ui\TableColumn\Generic::class)
         ->addClass('right aligned', 'all');
 
 For setting an attribute you can use setAttr() method::
 
-    $table->addColumn('name', 'Generic')
+    $table->addColumn('name', \atk4\ui\TableColumn\Generic::class)
         ->setAttr('colspan', 2, 'all');
 
 Setting a new value to the attribute will override previous value.

--- a/docs/table.rst
+++ b/docs/table.rst
@@ -55,7 +55,7 @@ You can also use Table with Array data source like this::
     $table->setSource($my_array);
 
     $table->addColumn('name');
-    $table->addColumn('surname', ['Link', 'url'=>'details.php?surname={$surname}']);
+    $table->addColumn('surname', [\atk4\ui\TableColumn\Link::class, 'url'=>'details.php?surname={$surname}']);
     $table->addColumn('birthdate', null, ['type'=>'date']);
 
 .. warning:: I encourage you to seek appropriate Agile Data persistence instead of

--- a/docs/tablecolumn.rst
+++ b/docs/tablecolumn.rst
@@ -235,17 +235,17 @@ Multiformat
 -----------
 
 Sometimes your formatting may change depending on value. For example you may want to place link
-only on certain rows. For this you can use a 'Multiformat' decorator::
+only on certain rows. For this you can use a \atk4\ui\TableColumn\Multiformat decorator::
 
-    $table->addColumn('amount', ['Multiformat', function($m) {
+    $table->addColumn('amount', [\atk4\ui\TableColumn\Multiformat::class, function($m) {
 
         if ($m->get('is_invoiced') > 0) {
-            return ['Money', [\atk4\ui\TableColumn\Link::class, 'invoice', ['invoice_id'=>'id']]];
+            return [\atk4\ui\TableColumn\Money::class, [\atk4\ui\TableColumn\Link::class, 'invoice', ['invoice_id'=>'id']]];
         } elseif (abs($m->get('is_refunded')) < 50) {
-            return [['Template', 'Amount was <b>refunded</b>']];
+            return [[\atk4\ui\TableColumn\Template::class, 'Amount was <b>refunded</b>']];
         }
 
-        return 'Money';
+        return \atk4\ui\TableColumn\Money::class;
     }]);
 
 You supply a callback to the Multiformat decorator, which will then be used to determine
@@ -254,7 +254,7 @@ fields of your models and will conditionally add Link on top of Money formatting
 
 Your callback can return things in varous ways:
 
- - return array of seeds: [[\atk4\ui\TableColumn\Link::class], atk4\ui\TableColumn\Money::class];
+ - return array of seeds: [[\atk4\ui\TableColumn\Link::class], \atk4\ui\TableColumn\Money::class];
  - if string or object is returned it is wrapped inside array automatically
 
 Multiple decorators will be created and merged.

--- a/docs/tablecolumn.rst
+++ b/docs/tablecolumn.rst
@@ -98,16 +98,16 @@ Link
 Put `<a href..` link over the value of the cell. The page property can be specified to constructor. There
 are two usage patterns. With the first you can specify full URL as a string::
 
-    $table->addColumn('name', ['Link', 'https://google.com/?q={$name}']);
+    $table->addColumn('name', [\atk4\ui\TableColumn\Link::class, 'https://google.com/?q={$name}']);
 
 The URL may also be specified as an array. It will be passed to App::url() which will encode arguments::
 
-    $table->addColumn('name', ['Link', ['details', 'id'=>123, 'q'=>$anything]]);
+    $table->addColumn('name', [\atk4\ui\TableColumn\Link::class, ['details', 'id'=>123, 'q'=>$anything]]);
 
 In this case even if `$anything = '{$name}'` the substitution will not take place for safety reasons. To
 pass on some values from your model, use second argument to constructor::
 
-    $table->addColumn('name', ['Link', ['details', 'id'=>123], ['q'=>'name']]);
+    $table->addColumn('name', [\atk4\ui\TableColumn\Link::class, ['details', 'id'=>123], ['q'=>'name']]);
 
 
 Money
@@ -240,7 +240,7 @@ only on certain rows. For this you can use a 'Multiformat' decorator::
     $table->addColumn('amount', ['Multiformat', function($m) {
 
         if ($m->get('is_invoiced') > 0) {
-            return ['Money', ['Link', 'invoice', ['invoice_id'=>'id']]];
+            return ['Money', [\atk4\ui\TableColumn\Link::class, 'invoice', ['invoice_id'=>'id']]];
         } elseif (abs($m->get('is_refunded')) < 50) {
             return [['Template', 'Amount was <b>refunded</b>']];
         }
@@ -254,7 +254,7 @@ fields of your models and will conditionally add Link on top of Money formatting
 
 Your callback can return things in varous ways:
 
- - return array of seeds: [['Link'], 'Money'];
+ - return array of seeds: [[\atk4\ui\TableColumn\Link::class], atk4\ui\TableColumn\Money::class];
  - if string or object is returned it is wrapped inside array automatically
 
 Multiple decorators will be created and merged.

--- a/docs/view.rst
+++ b/docs/view.rst
@@ -103,7 +103,7 @@ App class first and then continue with Layout initialization::
 Finally, if you prefer a more consise code, you can also use the following format::
 
     $app = new \atk4\ui\App('My App');
-    $top = $app->initLayout('View', ['ui'=>'segments']);
+    $top = $app->initLayout(\atk4\ui\View::class, ['ui'=>'segments']);
 
     $middle = View::addTo($top, ['ui'=>'segment', 'red']);
 

--- a/src/ActionExecutor/ArgumentForm.php
+++ b/src/ActionExecutor/ArgumentForm.php
@@ -45,7 +45,7 @@ class ArgumentForm extends Basic
 
             if (isset($val['model'])) {
                 $val['model'] = $this->factory($val['model']);
-                $this->form->addField($key, ['Lookup'])->setModel($val['model']);
+                $this->form->addField($key, [\atk4\ui\FormField\Lookup::class])->setModel($val['model']);
             } else {
                 $this->form->addField($key, null, $val);
             }

--- a/src/ActionExecutor/UserAction.php
+++ b/src/ActionExecutor/UserAction.php
@@ -161,7 +161,7 @@ class UserAction extends Modal implements Interface_, jsInterface_
         if ($this->steps = $this->getSteps($action)) {
             $this->title = $this->title ?? trim($action->caption . ' ' . $this->action->owner->getModelCaption());
 
-            $this->btns->add($this->execActionBtn = $this->factory($this->action->ui['execButton'] ?? ['Button', $this->action->caption, 'blue'], [], 'atk4\ui'));
+            $this->btns->add($this->execActionBtn = $this->factory($this->action->ui['execButton'] ?? [Button::class, $this->action->caption, 'blue'], []));
 
             // get current step.
             $this->step = $this->stickyGet('step') ?? $this->steps[0];

--- a/src/ActionExecutor/UserAction.php
+++ b/src/ActionExecutor/UserAction.php
@@ -294,7 +294,7 @@ class UserAction extends Modal implements Interface_, jsInterface_
 
             if (isset($val['model'])) {
                 $val['model'] = $this->factory($val['model']);
-                $f->addField($key, ['Lookup'])->setModel($val['model']);
+                $f->addField($key, [\atk4\ui\FormField\Lookup::class])->setModel($val['model']);
             } else {
                 $f->addField($key, null, $val);
             }

--- a/src/App.php
+++ b/src/App.php
@@ -434,7 +434,7 @@ class App
      */
     public function initLayout($seed)
     {
-        $layout = $this->factory($seed, null, 'atk4\ui\Layout');
+        $layout = $this->factory($seed);
         $layout->app = $this;
 
         if (!$this->html) {
@@ -1016,7 +1016,7 @@ class App
      * to put it inside boilerplate HTML and output, e.g:.
      *
      *   $l = new \atk4\ui\App();
-     *   $l->initLayout('Centered');
+     *   $l->initLayout(\atk4\ui\Layout\Centered::class);
      *   $l->layout->template->setHTML('Content', $e->getHTML());
      *   $l->run();
      *   exit;

--- a/src/CRUD.php
+++ b/src/CRUD.php
@@ -23,7 +23,7 @@ class CRUD extends Grid
     public $addFields;
 
     /** @var array Default notifier to perform when adding or editing is successful * */
-    public $notifyDefault = ['jsToast'];
+    public $notifyDefault = [jsToast::class];
 
     /** @var string default js action executor class in UI for model action. */
     public $jsExecutor = jsUserAction::class;
@@ -253,7 +253,7 @@ class CRUD extends Grid
      */
     protected function getNotifier(string $msg = null)
     {
-        $notifier = $this->factory($this->notifyDefault, null, 'atk4\ui');
+        $notifier = $this->factory($this->notifyDefault);
         if ($msg) {
             $notifier->setMessage($msg);
         }

--- a/src/CardDeck.php
+++ b/src/CardDeck.php
@@ -411,7 +411,7 @@ class CardDeck extends View
             if (is_string($button)) {
                 $button = [$button, 'ui' => 'button ' . $this->menuBtnStyle];
             }
-            $button = $this->factory('Button', $button, 'atk4\ui');
+            $button = $this->factory(Button::class, $button, 'atk4\ui');
         }
 
         if ($button->icon && !is_object($button->icon)) {

--- a/src/CardDeck.php
+++ b/src/CardDeck.php
@@ -274,7 +274,7 @@ class CardDeck extends View
      */
     protected function getNotifier($msg = null, $action = null)
     {
-        $notifier = $this->factory($this->notifyDefault, null, 'atk4\ui');
+        $notifier = $this->factory($this->notifyDefault);
         if ($msg) {
             $notifier->setMessage($msg);
         }
@@ -411,11 +411,11 @@ class CardDeck extends View
             if (is_string($button)) {
                 $button = [$button, 'ui' => 'button ' . $this->menuBtnStyle];
             }
-            $button = $this->factory(Button::class, $button, 'atk4\ui');
+            $button = $this->factory(Button::class, $button);
         }
 
         if ($button->icon && !is_object($button->icon)) {
-            $button->icon = $this->factory('Icon', [$button->icon], 'atk4\ui');
+            $button->icon = $this->factory(Icon::class, [$button->icon]);
         }
 
         if ($isDisabled) {

--- a/src/CardTable.php
+++ b/src/CardTable.php
@@ -38,7 +38,7 @@ class CardTable extends Table
 
         $this->_bypass = true;
         $mm = parent::setSource($data);
-        $this->addDecorator('value', ['Multiformat', function ($row, $field) use ($m) {
+        $this->addDecorator('value', [\atk4\ui\TableColumn\Multiformat::class, function ($row, $field) use ($m) {
             $field = $m->getField($row->data['id']);
             $ret = $this->decoratorFactory($field);
             if ($ret instanceof \atk4\ui\TableColumn\Money) {

--- a/src/Columns.php
+++ b/src/Columns.php
@@ -46,7 +46,7 @@ class Columns extends View
         $size = $defaults[0];
         unset($defaults[0]);
 
-        $column = $this->factory(['View'], $defaults, 'atk4\ui');
+        $column = $this->factory([\atk4\ui\View::class], $defaults, 'atk4\ui');
         $this->add($column);
 
         if ($size && isset($this->sizes[$size])) {

--- a/src/Columns.php
+++ b/src/Columns.php
@@ -46,7 +46,7 @@ class Columns extends View
         $size = $defaults[0];
         unset($defaults[0]);
 
-        $column = $this->factory([\atk4\ui\View::class], $defaults, 'atk4\ui');
+        $column = $this->factory([\atk4\ui\View::class], $defaults);
         $this->add($column);
 
         if ($size && isset($this->sizes[$size])) {

--- a/src/Form.php
+++ b/src/Form.php
@@ -496,14 +496,14 @@ class Form extends View
      * @var array Describes how factory converts type to decorator seed
      */
     protected $typeToDecorator = [
-        'boolean' => 'CheckBox',
-        'text' => 'TextArea',
-        'string' => 'Line',
-        'password' => 'Password',
-        'datetime' => 'Calendar',
-        'date' => ['Calendar', 'type' => 'date'],
-        'time' => ['Calendar', 'type' => 'time', 'ampm' => false],
-        'money' => 'Money',
+        'boolean' => FormField\CheckBox::class,
+        'text' => FormField\TextArea::class,
+        'string' => FormField\Line::class,
+        'password' => FormField\Password::class,
+        'datetime' => FormField\Calendar::class,
+        'date' => [FormField\Calendar::class, 'type' => 'date'],
+        'time' => [FormField\Calendar::class, 'type' => 'time', 'ampm' => false],
+        'money' => FormField\Money::class,
     ];
 
     /**

--- a/src/Form.php
+++ b/src/Form.php
@@ -450,19 +450,19 @@ class Form extends View
             throw new Exception(['Argument 1 for decoratorFactory must be \atk4\data\Field or null', 'f' => $f]);
         }
 
-        $fallback_seed = ['Line'];
+        $fallback_seed = [\atk4\ui\FormField\Line::class];
 
         if ($f->type === 'array' && $f->reference) {
             $limit = ($f->reference instanceof ContainsMany) ? 0 : 1;
             $model = $f->reference->refModel();
-            $fallback_seed = ['MultiLine', 'model' => $model, 'rowLimit' => $limit, 'caption' => $model->getModelCaption()];
+            $fallback_seed = [\atk4\ui\FormField\MultiLine::class, 'model' => $model, 'rowLimit' => $limit, 'caption' => $model->getModelCaption()];
         } elseif ($f->type !== 'boolean') {
             if ($f->enum) {
-                $fallback_seed = ['DropDown', 'values' => array_combine($f->enum, $f->enum)];
+                $fallback_seed = [\atk4\ui\FormField\DropDown::class, 'values' => array_combine($f->enum, $f->enum)];
             } elseif ($f->values) {
-                $fallback_seed = ['DropDown', 'values' => $f->values];
+                $fallback_seed = [\atk4\ui\FormField\DropDown::class, 'values' => $f->values];
             } elseif (isset($f->reference)) {
-                $fallback_seed = ['Lookup', 'model' => $f->reference->refModel()];
+                $fallback_seed = [\atk4\ui\FormField\Lookup::class, 'model' => $f->reference->refModel()];
             }
         }
 
@@ -487,7 +487,7 @@ class Form extends View
             'short_name' => $f->short_name,
         ];
 
-        return $this->factory($seed, $defaults, 'atk4\ui\FormField');
+        return $this->factory($seed, $defaults);
     }
 
     /**

--- a/src/Form.php
+++ b/src/Form.php
@@ -68,7 +68,7 @@ class Form extends View
      *
      * @var Button|array|false Button object, seed or false to not show button at all
      */
-    public $buttonSave = ['Button', 'Save', 'primary'];
+    public $buttonSave = [Button::class, 'Save', 'primary'];
 
     /**
      * When form is submitted successfully, this template is used by method

--- a/src/Form.php
+++ b/src/Form.php
@@ -171,11 +171,11 @@ class Form extends View
     protected function initLayout()
     {
         if ($this->layout === null) {
-            $this->layout = 'Generic';
+            $this->layout = \atk4\ui\FormLayout\Generic::class;
         }
 
         if (is_string($this->layout) || is_array($this->layout)) {
-            $this->layout = $this->factory($this->layout, ['form' => $this], 'atk4\ui\FormLayout');
+            $this->layout = $this->factory($this->layout, ['form' => $this]);
             $this->layout = $this->add($this->layout);
         } elseif (is_object($this->layout)) {
             $this->layout->form = $this;

--- a/src/FormField/DropDownCascade.php
+++ b/src/FormField/DropDownCascade.php
@@ -41,7 +41,7 @@ class DropDownCascade extends DropDown
         $this->cascadeInput = is_string($this->cascadeFrom) ? $this->form->getField($this->cascadeFrom) : $this->cascadeFrom;
 
         if (!$this->cascadeInput instanceof Generic) {
-            throw new Exception('cascadeFrom property should be an instance of atk4/ui/FormField/Generic');
+            throw new Exception('cascadeFrom property should be an instance of ' . Generic::class);
         }
 
         $this->cascadeInputValue = $_POST[$this->cascadeInput->name] ?? $this->cascadeInput->field->get('value');

--- a/src/FormField/Generic.php
+++ b/src/FormField/Generic.php
@@ -47,7 +47,7 @@ class Generic extends View
 
     /**
      * Placed as a pointing label below the field. This only works when FormField appears in a form. You can also
-     * set this to object, such as 'Text' otherwise HTML characters are escaped.
+     * set this to object, such as \atk4\ui\Text otherwise HTML characters are escaped.
      *
      * @var string|\atk4\ui\View|array
      */

--- a/src/FormField/Lookup.php
+++ b/src/FormField/Lookup.php
@@ -102,7 +102,7 @@ class Lookup extends Input
      *
      * For example, using this setting will automatically submit
      * form when field value is changes.
-     * $form->addField('field', ['Lookup', 'settings'=>['allowReselection' => true,
+     * $form->addField('field', [\atk4\ui\FormField\Lookup::class, 'settings'=>['allowReselection' => true,
      *                           'selectOnKeydown' => false,
      *                           'onChange'        => new atk4\ui\jsExpression('function(value,t,c){
      *                                                          if ($(this).data("value") !== value) {

--- a/src/FormField/Lookup.php
+++ b/src/FormField/Lookup.php
@@ -243,7 +243,7 @@ class Lookup extends Input
 
         $buttonSeed = is_string($buttonSeed) ? ['content' => $buttonSeed] : $buttonSeed;
 
-        $defaultSeed = ['Button', 'disabled' => ($this->disabled || $this->readonly)];
+        $defaultSeed = [\atk4\ui\Button::class, 'disabled' => ($this->disabled || $this->readonly)];
 
         $this->action = $this->factory(array_merge($defaultSeed, (array) $buttonSeed), null, 'atk4\ui');
 

--- a/src/FormField/Lookup.php
+++ b/src/FormField/Lookup.php
@@ -245,7 +245,7 @@ class Lookup extends Input
 
         $defaultSeed = [\atk4\ui\Button::class, 'disabled' => ($this->disabled || $this->readonly)];
 
-        $this->action = $this->factory(array_merge($defaultSeed, (array) $buttonSeed), null, 'atk4\ui');
+        $this->action = $this->factory(array_merge($defaultSeed, (array) $buttonSeed));
 
         if ($this->form) {
             $vp = \atk4\ui\VirtualPage::addTo($this->form);

--- a/src/FormField/MultiLine.php
+++ b/src/FormField/MultiLine.php
@@ -55,7 +55,7 @@
  * If your model contains a lot of records, you should handle their limit somehow.
  *
  * $f = \atk4\ui\Form::addTo($app);
- * $ml = $f->addField('ml', ['MultiLine']);
+ * $ml = $f->addField('ml', [\atk4\ui\FormField\MultiLine::class]);
  * $ml->setModel($user, ['name','is_vip']);
  *
  * $f->onSubmit(function($f) use ($ml) {

--- a/src/FormLayout/Custom.php
+++ b/src/FormLayout/Custom.php
@@ -28,6 +28,6 @@ class Custom extends _Abstract
      */
     public function addButton($seed)
     {
-        return $this->add($this->mergeSeeds(['Button'], $seed), 'Buttons');
+        return $this->add($this->mergeSeeds([\atk4\ui\Button::class], $seed), 'Buttons');
     }
 }

--- a/src/FormLayout/Generic.php
+++ b/src/FormLayout/Generic.php
@@ -119,9 +119,9 @@ class Generic extends _Abstract
      *
      * @return static
      */
-    public function addSubLayout($seed = 'Generic', $addDivider = true)
+    public function addSubLayout($seed = self::class, $addDivider = true)
     {
-        $v = $this->add($this->factory($seed, ['form' => $this->form], 'atk4\ui\FormLayout\Section'));
+        $v = $this->add($this->factory($seed, ['form' => $this->form]));
         if ($v instanceof \atk4\ui\FormLayout\Section\Generic) {
             $v = $v->addSection();
         }

--- a/src/FormLayout/Generic.php
+++ b/src/FormLayout/Generic.php
@@ -68,7 +68,7 @@ class Generic extends _Abstract
      */
     public function addButton($seed)
     {
-        return $this->add($this->mergeSeeds(['Button'], $seed), 'Buttons');
+        return $this->add($this->mergeSeeds([\atk4\ui\Button::class], $seed), 'Buttons');
     }
 
     /**

--- a/src/FormLayout/_Abstract.php
+++ b/src/FormLayout/_Abstract.php
@@ -70,7 +70,7 @@ abstract class _Abstract extends \atk4\ui\View
                 $decorator = $this->form->decoratorFactory($field);
             } elseif (is_object($decorator)) {
                 if (!$decorator instanceof \atk4\ui\FormField\Generic) {
-                    throw new Exception(['Field decorator must descend from \atk4\ui\FormField\Generic', 'decorator' => $decorator]);
+                    throw new Exception(['Field decorator must descend from ' . \atk4\ui\FormField\Generic::class, 'decorator' => $decorator]);
                 }
                 $decorator->field = $field;
                 $decorator->form = $this->form;

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -665,7 +665,7 @@ class Grid extends View
      */
     public function addSelection()
     {
-        $this->selection = $this->table->addColumn(null, 'CheckBox');
+        $this->selection = $this->table->addColumn(null, TableColumn\CheckBox::class);
 
         // Move last column to the beginning in table column array.
         array_unshift($this->table->columns, array_pop($this->table->columns));
@@ -681,7 +681,7 @@ class Grid extends View
      */
     public function addDragHandler()
     {
-        $handler = $this->table->addColumn(null, 'DragHandler');
+        $handler = $this->table->addColumn(null, TableColumn\DragHandler::class);
 
         // Move last column to the beginning in table column array.
         array_unshift($this->table->columns, array_pop($this->table->columns));

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -108,20 +108,18 @@ class Grid extends View
     public $defaultTemplate = 'grid.html';
 
     /**
-     * TableColumn\ActionButtons seed.
      * Defines which Table Decorator to use for ActionButtons.
      *
      * @var string
      */
-    protected $actionButtonsDecorator = 'ActionButtons';
+    protected $actionButtonsDecorator = TableColumn\ActionButtons::class;
 
     /**
-     * TableColumn\ActionMenu seed.
      * Defines which Table Decorator to use for ActionMenu.
      *
      * @var array
      */
-    protected $actionMenuDecorator = ['ActionMenu', 'label' => 'Actions...'];
+    protected $actionMenuDecorator = [TableColumn\ActionMenu::class, 'label' => 'Actions...'];
 
     public function init(): void
     {
@@ -135,14 +133,14 @@ class Grid extends View
 
         // if menu not disabled ot not already assigned as existing object
         if ($this->menu !== false && !is_object($this->menu)) {
-            $this->menu = $this->add($this->factory(['Menu', 'activate_on_click' => false], $this->menu, 'atk4\ui'), 'Menu');
+            $this->menu = $this->add($this->factory([Menu::class, 'activate_on_click' => false], $this->menu), 'Menu');
         }
 
-        $this->table = $this->container->add($this->factory(['Table', 'very compact very basic striped single line', 'reload' => $this->container], $this->table, 'atk4\ui'), 'Table');
+        $this->table = $this->container->add($this->factory([Table::class, 'very compact very basic striped single line', 'reload' => $this->container], $this->table), 'Table');
 
         if ($this->paginator !== false) {
             $seg = View::addTo($this->container, [], ['Paginator'])->addStyle('text-align', 'center');
-            $this->paginator = $seg->add($this->factory(['Paginator', 'reload' => $this->container], $this->paginator, 'atk4\ui'));
+            $this->paginator = $seg->add($this->factory([Paginator::class, 'reload' => $this->container], $this->paginator));
             $this->app ? $this->app->stickyGet($this->paginator->name) : $this->stickyGet($this->paginator->name);
         }
 

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -43,7 +43,7 @@ class Loader extends View
         parent::init();
 
         if (!$this->shim) {
-            $this->shim = ['View', 'class' => ['padded segment'], 'style' => ['min-height' => '7em']];
+            $this->shim = [View::class, 'class' => ['padded segment'], 'style' => ['min-height' => '7em']];
         }
 
         $this->cb = Callback::addTo($this, ['appSticky' => $this->appStickyCb]);

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -168,7 +168,7 @@ class Menu extends View
      */
     public function addDivider()
     {
-        return parent::add(['View', 'class' => ['divider']]);
+        return parent::add([View::class, 'class' => ['divider']]);
     }
 
     /*

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -44,7 +44,7 @@ class Menu extends View
         if (!is_object($item)) {
             $item = (array) $item;
 
-            array_unshift($item, 'Item');
+            array_unshift($item, Item::class);
         }
 
         $item = $this->add($item)->setElement('a');

--- a/src/Popup.php
+++ b/src/Popup.php
@@ -65,8 +65,6 @@ class Popup extends View
      * The dynamic View to load inside the popup
      * when dynamic content is use.
      *
-     * Default to 'View'.
-     *
      * @var View|string
      */
     public $dynamicContent = View::class;

--- a/src/Table.php
+++ b/src/Table.php
@@ -19,7 +19,7 @@ class Table extends Lister
     public $reload;
 
     /**
-     * Column objects can service multiple columns. You can use it for your advancage by re-using the object
+     * Column objects can service multiple columns. You can use it for your advantage by re-using the object
      * when you pass it to addColumn(). If you omit the argument, then a column of a type 'Generic' will be
      * used.
      *
@@ -220,7 +220,7 @@ class Table extends Lister
 
         if ($field === null) {
             // column is not associated with any model field
-            $columnDecorator = $this->_add($this->factory($columnDecorator, ['table' => $this], 'atk4\ui\TableColumn'));
+            $columnDecorator = $this->_add($this->factory($columnDecorator, ['table' => $this]));
         } elseif (is_array($columnDecorator) || is_string($columnDecorator)) {
             $columnDecorator = $this->decoratorFactory($field, array_merge(['columnData' => $name], is_string($columnDecorator) ? [$columnDecorator] : $columnDecorator));
         } elseif (!$columnDecorator) {
@@ -302,7 +302,7 @@ class Table extends Lister
         if (!$this->columns[$name]) {
             throw new Exception(['No such column, cannot decorate', 'name' => $name]);
         }
-        $decorator = $this->_add($this->factory($seed, ['table' => $this], 'atk4\ui\TableColumn'));
+        $decorator = $this->_add($this->factory($seed, ['table' => $this]));
 
         if (!is_array($this->columns[$name])) {
             $this->columns[$name] = [$this->columns[$name]];
@@ -352,17 +352,17 @@ class Table extends Lister
             $seed,
             $field->ui['table'] ?? null,
             $this->typeToDecorator[$field->type] ?? null,
-            [$this->default_column ? $this->default_column : 'Generic']
+            [$this->default_column ? $this->default_column : TableColumn\Generic::class]
         );
 
-        return $this->_add($this->factory($seed, ['table' => $this], 'atk4\ui\TableColumn'));
+        return $this->_add($this->factory($seed, ['table' => $this]));
     }
 
     protected $typeToDecorator = [
-        'password' => 'Password',
-        'money' => 'Money',
-        'text' => 'Text',
-        'boolean' => ['Status', ['positive' => [true], 'negative' => [false]]],
+        'password' => TableColumn\Password::class,
+        'money' => TableColumn\Money::class,
+        'text' => TableColumn\Text::class,
+        'boolean' => [TableColumn\Status::class, ['positive' => [true], 'negative' => [false]]],
     ];
 
     /**

--- a/src/Table.php
+++ b/src/Table.php
@@ -20,8 +20,8 @@ class Table extends Lister
 
     /**
      * Column objects can service multiple columns. You can use it for your advantage by re-using the object
-     * when you pass it to addColumn(). If you omit the argument, then a column of a type 'Generic' will be
-     * used.
+     * when you pass it to addColumn(). If you omit the argument, then a column of a type TableColumn\Generic
+     * will be used.
      *
      * @var TableColumn\Generic
      */
@@ -227,7 +227,7 @@ class Table extends Lister
             $columnDecorator = $this->decoratorFactory($field, ['columnData' => $name]);
         } elseif (is_object($columnDecorator)) {
             if (!$columnDecorator instanceof \atk4\ui\TableColumn\Generic) {
-                throw new Exception(['Column decorator must descend from \atk4\ui\TableColumn\Generic', 'columnDecorator' => $columnDecorator]);
+                throw new Exception(['Column decorator must descend from ' . \atk4\ui\TableColumn\Generic::class, 'columnDecorator' => $columnDecorator]);
             }
             $columnDecorator->table = $this;
             if (!$columnDecorator->columnData) {

--- a/src/TableColumn/ActionButtons.php
+++ b/src/TableColumn/ActionButtons.php
@@ -77,7 +77,7 @@ class ActionButtons extends Generic
         }
 
         if (!is_object($button)) {
-            $button = $this->factory('Button', [$button, 'id' => false], 'atk4\ui');
+            $button = $this->factory(\atk4\ui\Button::class, [$button, 'id' => false], 'atk4\ui');
         }
 
         if ($button->icon && !is_object($button->icon)) {

--- a/src/TableColumn/ActionButtons.php
+++ b/src/TableColumn/ActionButtons.php
@@ -77,11 +77,11 @@ class ActionButtons extends Generic
         }
 
         if (!is_object($button)) {
-            $button = $this->factory(\atk4\ui\Button::class, [$button, 'id' => false], 'atk4\ui');
+            $button = $this->factory(\atk4\ui\Button::class, [$button, 'id' => false]);
         }
 
         if ($button->icon && !is_object($button->icon)) {
-            $button->icon = $this->factory('Icon', [$button->icon, 'id' => false], 'atk4\ui');
+            $button->icon = $this->factory(\atk4\ui\Icon::class, [$button->icon, 'id' => false]);
         }
 
         $button->app = $this->table->app;

--- a/src/TableColumn/ActionMenu.php
+++ b/src/TableColumn/ActionMenu.php
@@ -114,7 +114,7 @@ class ActionMenu extends Generic
         }
 
         if (!is_object($item)) {
-            $item = $this->factory('View', ['id' => false, 'ui' => 'item', 'content' => $item], 'atk4\ui');
+            $item = $this->factory(\atk4\ui\View::class, ['id' => false, 'ui' => 'item', 'content' => $item]);
         }
 
         $this->items[] = $item;

--- a/src/TableColumn/ColorRating.php
+++ b/src/TableColumn/ColorRating.php
@@ -10,7 +10,7 @@ use atk4\ui\Exception;
  * Class ColorRating
  * Can be defined like this :
  * [
- * 'ColorRating',
+ * ColorRating::class,
  *      [
  *      'min'     => 1,
  *      'max'     => 3,

--- a/src/TableColumn/FilterModel/TypeDate.php
+++ b/src/TableColumn/FilterModel/TypeDate.php
@@ -56,7 +56,7 @@ class TypeDate extends Generic
         $this->addField('exact_date', ['type' => 'date', 'ui' => ['caption' => '']]);
 
         // The integer field to generate a date when x day selector is used.
-        $this->addField('number_days', ['ui' => ['caption' => '', 'form' => ['Line', 'inputType' => 'number']]]);
+        $this->addField('number_days', ['ui' => ['caption' => '', 'form' => [\atk4\ui\FormField\Line::class, 'inputType' => 'number']]]);
     }
 
     /**

--- a/src/TableColumn/FilterModel/TypeDatetime.php
+++ b/src/TableColumn/FilterModel/TypeDatetime.php
@@ -56,7 +56,7 @@ class TypeDatetime extends Generic
         $this->addField('exact_date', ['type' => 'date', 'ui' => ['caption' => '']]);
 
         // The integer field to generate a date when x day selector is used.
-        $this->addField('number_days', ['ui' => ['caption' => '', 'form' => ['Line', 'inputType' => 'number']]]);
+        $this->addField('number_days', ['ui' => ['caption' => '', 'form' => [\atk4\ui\FormField\Line::class, 'inputType' => 'number']]]);
     }
 
     /**

--- a/src/TableColumn/FilterModel/TypeNumber.php
+++ b/src/TableColumn/FilterModel/TypeNumber.php
@@ -19,8 +19,8 @@ class TypeNumber extends Generic
         ];
         $this->op->default = '=';
 
-        $this->value->ui['form'] = ['Line', 'inputType' => 'number'];
-        $this->addField('range', ['ui' => ['caption' => '', 'form' => ['Line', 'inputType' => 'number']]]);
+        $this->value->ui['form'] = [\atk4\ui\FormField\Line::class, 'inputType' => 'number'];
+        $this->addField('range', ['ui' => ['caption' => '', 'form' => [\atk4\ui\FormField\Line::class, 'inputType' => 'number']]]);
     }
 
     public function setConditionForModel($m)

--- a/src/TableColumn/Generic.php
+++ b/src/TableColumn/Generic.php
@@ -89,16 +89,15 @@ class Generic
      * Add popup to header.
      * Use ColumnName for better popup positioning.
      *
-     * @param Popup  $popup
-     * @param string $icon  the css class for filter icon
+     * @param string $icon CSS class for filter icon
      *
      * @return mixed
      */
-    public function addPopup($popup = null, $icon = 'table-filter-off')
+    public function addPopup(Popup $popup = null, $icon = 'table-filter-off')
     {
         $id = $this->name . '_ac';
 
-        $popup = $this->table->owner->add($popup ?: 'Popup')->setHoverable();
+        $popup = $this->table->owner->add($popup ?: Popup::class)->setHoverable();
 
         $this->setHeaderPopup($icon, $id);
 

--- a/src/TableColumn/KeyValue.php
+++ b/src/TableColumn/KeyValue.php
@@ -34,7 +34,7 @@ use atk4\ui\Exception;
  *      3 => __('paid'),
  *  ],
  *  'ui'      => [
- *      'form' => ['DropDown'],
+ *      'form' => [\atk4\ui\FormField\DropDown::class],
  *      'table' => ['KeyValue'],
  *  ],
  * ]);

--- a/src/View.php
+++ b/src/View.php
@@ -413,13 +413,12 @@ class View implements jsExpressionable
             // later consider to accept strictly objects only
 
             // for BC:
-            // - allow relative class names from "atk4/ui" namespace
             // - use self/View class if no class name is defined in the seed
             if (is_string($object)) {
                 $object = [$object];
             }
             if (isset($object[0]) && is_string($object[0])) {
-                $object[0] = $this->normalizeClassName($object[0], 'atk4\ui');
+                $object[0] = $this->normalizeClassName($object[0]);
             } elseif (!isset($object[0])) {
                 $object[0] = self::class;
             }

--- a/src/Wizard.php
+++ b/src/Wizard.php
@@ -90,11 +90,11 @@ class Wizard extends View
     public function addStep($name, $callback)
     {
         $step = $this->factory([
-            'Step',
+            Step::class,
             'wizard' => $this,
             'template' => clone $this->stepTemplate,
             'sequence' => count($this->steps),
-        ], $name, 'atk4\ui');
+        ], $name);
 
         // add tabs menu item
         $this->steps[] = $this->add($step, 'Step');

--- a/tests/BuiltInWebServerAbstract.php
+++ b/tests/BuiltInWebServerAbstract.php
@@ -109,14 +109,9 @@ abstract class BuiltInWebServerAbstract extends AtkPhpunit\TestCase
         return new Client(['base_uri' => 'http://localhost:' . self::$port]);
     }
 
-    protected function getResponseFromRequestFormPOST($path, $data): ResponseInterface
+    protected function getResponseFromRequest(string $path, array $options = []): ResponseInterface
     {
-        return $this->getClient()->request('POST', $this->getPathWithAppVars($path), ['form_params' => $data]);
-    }
-
-    protected function getResponseFromRequestGET($path): ResponseInterface
-    {
-        return $this->getClient()->request('GET', $this->getPathWithAppVars($path));
+        return $this->getClient()->request(isset($options['form_params']) !== null ? 'POST' : 'GET', $this->getPathWithAppVars($path), $options);
     }
 
     private function getPathWithAppVars($path)

--- a/tests/CallbackTest.php
+++ b/tests/CallbackTest.php
@@ -34,7 +34,7 @@ class CallbackTest extends AtkPhpunit\TestCase
     protected function setUp(): void
     {
         $this->app = new AppMock(['always_run' => false]);
-        $this->app->initLayout('Centered');
+        $this->app->initLayout(\atk4\ui\Layout\Centered::class);
 
         // reset var, between tests
         $_GET = [];

--- a/tests/DemoCallExitTest.php
+++ b/tests/DemoCallExitTest.php
@@ -73,7 +73,7 @@ class DemoCallExitTest extends BuiltInWebServerAbstract
      */
     public function testDemoHTMLStatusAndResponse(string $uri)
     {
-        $response = $this->getResponseFromRequestGET($uri);
+        $response = $this->getResponseFromRequest($uri);
         $this->assertSame(200, $response->getStatusCode(), ' Status error on ' . $uri);
         $this->assertMatchesRegularExpression($this->regexHTML, $response->getBody()->getContents(), ' RegExp error on ' . $uri);
     }
@@ -89,7 +89,7 @@ class DemoCallExitTest extends BuiltInWebServerAbstract
      */
     public function testDemoGet(string $uri)
     {
-        $response = $this->getResponseFromRequestGET($uri);
+        $response = $this->getResponseFromRequest($uri);
         $this->assertSame(200, $response->getStatusCode(), ' Status error on ' . $uri);
         $this->assertSame('text/html', preg_replace('~;\s*charset=.+$~', '', $response->getHeaderLine('Content-Type')), ' Content type error on ' . $uri);
         $this->assertMatchesRegularExpression($this->regexHTML, $response->getBody()->getContents(), ' RegExp error on ' . $uri);
@@ -107,18 +107,18 @@ class DemoCallExitTest extends BuiltInWebServerAbstract
 
     public function testWizard()
     {
-        $response = $this->getResponseFromRequestFormPOST(
+        $response = $this->getResponseFromRequest(
             'interactive/wizard.php?atk_admin_wizard=1&atk_admin_wizard_form_submit=ajax&__atk_callback=1',
-            [
+            ['form_params' => [
                 'dsn' => 'mysql://root:root@db-host.example.com/atk4',
                 'atk_admin_wizard_form_submit' => 'submit',
-            ]
+            ]]
         );
 
         $this->assertSame(200, $response->getStatusCode());
         $this->assertMatchesRegularExpression($this->regexJSON, $response->getBody()->getContents());
 
-        $response = $this->getResponseFromRequestGET('interactive/wizard.php?atk_admin_wizard=2&name=Country');
+        $response = $this->getResponseFromRequest('interactive/wizard.php?atk_admin_wizard=2&name=Country');
         $this->assertSame(200, $response->getStatusCode());
         $this->assertMatchesRegularExpression($this->regexHTML, $response->getBody()->getContents());
     }
@@ -130,7 +130,7 @@ class DemoCallExitTest extends BuiltInWebServerAbstract
      */
     public function testDemoAssertJSONResponse(string $uri)
     {
-        $response = $this->getResponseFromRequestGET($uri);
+        $response = $this->getResponseFromRequest($uri);
         $this->assertSame(200, $response->getStatusCode(), ' Status error on ' . $uri);
         if (!($this instanceof DemoCallExitExceptionTest)) { // content type is not set when App->call_exit equals to true
             $this->assertSame('application/json', preg_replace('~;\s*charset=.+$~', '', $response->getHeaderLine('Content-Type')), ' Content type error on ' . $uri);
@@ -160,7 +160,7 @@ class DemoCallExitTest extends BuiltInWebServerAbstract
      */
     public function testDemoAssertSSEResponse(string $uri)
     {
-        $response = $this->getResponseFromRequestGET($uri);
+        $response = $this->getResponseFromRequest($uri);
         $this->assertSame(200, $response->getStatusCode(), ' Status error on ' . $uri);
 
         $output_rows = preg_split('~\r?\n|\r~', $response->getBody()->getContents());
@@ -202,9 +202,9 @@ class DemoCallExitTest extends BuiltInWebServerAbstract
     /**
      * @dataProvider JSONResponsePOSTDataProvider
      */
-    public function testDemoAssertJSONResponsePOST(string $uri, array $post_data)
+    public function testDemoAssertJSONResponsePOST(string $uri, array $postData)
     {
-        $response = $this->getResponseFromRequestFormPOST($uri, $post_data);
+        $response = $this->getResponseFromRequest($uri, ['form_params' => $postData]);
         $this->assertSame(200, $response->getStatusCode(), ' Status error on ' . $uri);
         $this->assertMatchesRegularExpression($this->regexJSON, $response->getBody()->getContents(), ' RegExp error on ' . $uri);
     }

--- a/tests/DemoCallExitTest.php
+++ b/tests/DemoCallExitTest.php
@@ -81,7 +81,7 @@ class DemoCallExitTest extends BuiltInWebServerAbstract
     public function testResponseError()
     {
         $this->expectExceptionCode(500);
-        $this->getResponseFromRequestGET('layout/layouts_error.php');
+        $this->getResponseFromRequest('layout/layouts_error.php');
     }
 
     /**

--- a/tests/GridTest.php
+++ b/tests/GridTest.php
@@ -58,7 +58,7 @@ class GridTest extends AtkPhpunit\TestCase
         $t = new Table();
         $t->init();
         $t->setModel($this->m, ['email']);
-        $t->addColumn(null, 'Delete');
+        $t->addColumn(null, \atk4\ui\TableColumn\Delete::class);
 
         $this->assertSame('<td>{$email}</td><td><a href="#" title="Delete {$email}?" class="delete"><i class="ui red trash icon"></i>Delete</a></td>', $t->getDataRowHTML());
         $this->assertSame(

--- a/tests/TableColumnColorRatingTest.php
+++ b/tests/TableColumnColorRatingTest.php
@@ -4,6 +4,7 @@ namespace atk4\ui\tests;
 
 use atk4\core\AtkPhpunit;
 use atk4\ui\Table;
+use atk4\ui\TableColumn\ColorRating;
 
 class TableColumnColorRatingTest extends AtkPhpunit\TestCase
 {
@@ -40,7 +41,7 @@ class TableColumnColorRatingTest extends AtkPhpunit\TestCase
     public function testValueGreaterThanMax()
     {
         $this->table->addDecorator('rating', [
-            'ColorRating',
+            ColorRating::class,
             [
                 'min' => 0,
                 'max' => 2,
@@ -67,7 +68,7 @@ class TableColumnColorRatingTest extends AtkPhpunit\TestCase
     public function testValueGreaterThanMaxNoColor()
     {
         $this->table->addDecorator('rating', [
-            'ColorRating',
+            ColorRating::class,
             [
                 'min' => 0,
                 'max' => 2,
@@ -90,7 +91,7 @@ class TableColumnColorRatingTest extends AtkPhpunit\TestCase
     public function testValueLowerThanMin()
     {
         $this->table->addDecorator('rating', [
-            'ColorRating',
+            ColorRating::class,
             [
                 'min' => 4,
                 'max' => 10,
@@ -117,7 +118,7 @@ class TableColumnColorRatingTest extends AtkPhpunit\TestCase
     public function testValueLowerThanMinNoColor()
     {
         $this->table->addDecorator('rating', [
-            'ColorRating',
+            ColorRating::class,
             [
                 'min' => 4,
                 'max' => 10,
@@ -142,7 +143,7 @@ class TableColumnColorRatingTest extends AtkPhpunit\TestCase
         $this->expectException(\atk4\ui\Exception::class);
 
         $this->table->addDecorator('rating', [
-            'ColorRating',
+            ColorRating::class,
             [
                 'min' => 3,
                 'max' => 1,
@@ -161,7 +162,7 @@ class TableColumnColorRatingTest extends AtkPhpunit\TestCase
         $this->expectException(\atk4\ui\Exception::class);
 
         $this->table->addDecorator('rating', [
-            'ColorRating',
+            ColorRating::class,
             [
                 'min' => 3,
                 'max' => 3,
@@ -180,7 +181,7 @@ class TableColumnColorRatingTest extends AtkPhpunit\TestCase
         $this->expectException(\atk4\ui\Exception::class);
 
         $this->table->addDecorator('rating', [
-            'ColorRating',
+            ColorRating::class,
             [
                 'min' => 1,
                 'max' => 3,
@@ -199,7 +200,7 @@ class TableColumnColorRatingTest extends AtkPhpunit\TestCase
         $this->expectException(\atk4\ui\Exception::class);
 
         $this->table->addDecorator('rating', [
-            'ColorRating',
+            ColorRating::class,
             [
                 'min' => 1,
                 'max' => 3,

--- a/tests/TableColumnLinkTest.php
+++ b/tests/TableColumnLinkTest.php
@@ -127,7 +127,7 @@ class TableColumnLinkTest extends AtkPhpunit\TestCase
     public function testRender1a()
     {
         // Simplest way to integrate
-        $this->table->addColumn(null, ['Template', 'hello<b>world</b>']);
+        $this->table->addColumn(null, [\atk4\ui\TableColumn\Template::class, 'hello<b>world</b>']);
 
         $this->assertSame(
             '<td>{$name}</td><td>{$ref}</td><td>hello<b>world</b></td>',
@@ -157,7 +157,7 @@ class TableColumnLinkTest extends AtkPhpunit\TestCase
 
     public function testLink1a()
     {
-        $this->table->addDecorator('name', ['Link', 'url' => 'example.php?id={$id}']);
+        $this->table->addDecorator('name', [\atk4\ui\TableColumn\Link::class, 'url' => 'example.php?id={$id}']);
 
         $this->assertSame(
             '<td><a href="{$c_link}">{$name}</a></td><td>{$ref}</td>',
@@ -204,7 +204,7 @@ class TableColumnLinkTest extends AtkPhpunit\TestCase
 
     public function testLink5()
     {
-        $this->table->addDecorator('name', ['Link', ['example'], ['test' => 'id']]);
+        $this->table->addDecorator('name', [\atk4\ui\TableColumn\Link::class, ['example'], ['test' => 'id']]);
 
         $this->assertSame(
             '<tr data-id="1"><td><a href="example.php?test=1">bar</a></td><td>ref123</td></tr>',
@@ -214,7 +214,7 @@ class TableColumnLinkTest extends AtkPhpunit\TestCase
 
     public function testLink6()
     {
-        $this->table->addDecorator('name', ['Link', ['example'], ['test' => 'id'], 'force_download' => true]);
+        $this->table->addDecorator('name', [\atk4\ui\TableColumn\Link::class, ['example'], ['test' => 'id'], 'force_download' => true]);
 
         $this->assertSame(
             '<tr data-id="1"><td><a href="example.php?test=1" download="true" >bar</a></td><td>ref123</td></tr>',
@@ -224,7 +224,7 @@ class TableColumnLinkTest extends AtkPhpunit\TestCase
 
     public function testLink7()
     {
-        $this->table->addDecorator('name', ['Link', ['example'], ['test' => 'id'], 'target' => '_blank']);
+        $this->table->addDecorator('name', [\atk4\ui\TableColumn\Link::class, ['example'], ['test' => 'id'], 'target' => '_blank']);
 
         $this->assertSame(
             '<tr data-id="1"><td><a href="example.php?test=1" target="_blank" >bar</a></td><td>ref123</td></tr>',
@@ -234,7 +234,7 @@ class TableColumnLinkTest extends AtkPhpunit\TestCase
 
     public function testLink8()
     {
-        $this->table->addDecorator('name', ['Link', ['example'], ['test' => 'id'], 'icon' => 'info']);
+        $this->table->addDecorator('name', [\atk4\ui\TableColumn\Link::class, ['example'], ['test' => 'id'], 'icon' => 'info']);
 
         $this->assertSame(
             '<tr data-id="1"><td><a href="example.php?test=1"><i class="icon info"></i>bar</a></td><td>ref123</td></tr>',
@@ -244,7 +244,7 @@ class TableColumnLinkTest extends AtkPhpunit\TestCase
 
     public function testLink9()
     {
-        $this->table->addDecorator('name', ['Link', ['example'], ['test' => 'id'], 'use_label' => false]);
+        $this->table->addDecorator('name', [\atk4\ui\TableColumn\Link::class, ['example'], ['test' => 'id'], 'use_label' => false]);
 
         $this->assertSame(
             '<tr data-id="1"><td><a href="example.php?test=1"></a></td><td>ref123</td></tr>',
@@ -265,7 +265,7 @@ class TableColumnLinkTest extends AtkPhpunit\TestCase
         $this->table->init();
         $this->table->setModel($m, ['name', 'ref']);
 
-        $this->table->addDecorator('name', ['NoValue', ['no_value' => ' --- ']]);
+        $this->table->addDecorator('name', [\atk4\ui\TableColumn\NoValue::class, ['no_value' => ' --- ']]);
 
         $this->assertSame(
             '<tr data-id="1"><td> --- </td><td>ref123</td></tr>',
@@ -275,7 +275,7 @@ class TableColumnLinkTest extends AtkPhpunit\TestCase
 
     public function testLink11()
     {
-        $this->table->addDecorator('name', ['Tooltip', ['tooltip_field' => 'ref']]);
+        $this->table->addDecorator('name', [\atk4\ui\TableColumn\Tooltip::class, ['tooltip_field' => 'ref']]);
 
         $this->assertSame(
             '<tr data-id="1"><td class=""> bar<span class="ui icon link " data-tooltip="ref123"><i class="ui icon info circle"></span></td><td>ref123</td></tr>',

--- a/tests/TableTest.php
+++ b/tests/TableTest.php
@@ -24,8 +24,8 @@ class TableTest extends AtkPhpunit\TestCase
         // multiple ways to add column which doesn't exist in model
         $t->addColumn('five', new \atk4\ui\TableColumn\Link('test.php?id=1'));
         $t->addColumn('six', [new \atk4\ui\TableColumn\Link('test.php?id=2')]);
-        $t->addColumn('seven', ['Link', ['id' => 3]]);
-        $t->addColumn('eight', 'Link');
+        $t->addColumn('seven', [\atk4\ui\TableColumn\Link::class, ['id' => 3]]);
+        $t->addColumn('eight', \atk4\ui\TableColumn\Link::class);
         $t->addColumn('nine');
 
         $t->render();


### PR DESCRIPTION
Relative names are absolutely no longer needed when classes are referred by `::class` expr.

This PR removes the deprecated behaviour. It breaks BC, but it prevent bad use of unrefactorable classes which is stronger.

To fix your projects check the results of regex (for bests result use case-sensitive matching mode and do in the order like here):

- `atk4\ui\FormLayout\Section` (used only with `->addSubLayout()`)
   ```
   ['"]([^'" ]+\\)?(Accordion|Columns|Generic|Tabs)['"]
   ```
- `atk4\ui\FormLayout`
   ```
   ['"]([^'" ]+\\)?(_Abstract|Columns|Custom|Generic)['"]
   ```
- `atk4\ui\Layout`
   ```
   ['"]([^'" ]+\\)?(Admin|Centered|Column|Generic|Maestro|Navigable|Product)['"]
   ```
- `atk4\ui\FormField`
   ```
   ['"]([^'" ]+\\)?(AutoComplete|DropDownCascade|Hidden|Lookup|Password|TreeItemSelector|Calendar|DropDown|Input|Money|Radio|UploadImg|CheckBox|Generic|Line|MultiLine|TextArea|Upload)['"]
   ```
- `atk4\ui`
   ```
   ['"]([^'" ]+\\)?(Accordion|HelloWorld|jsNotify|Locale|Table|AccordionSection|Console|Icon|jsPaginator|LoremIpsum|Tab|CRUD|Image|jsReload|Menu|Tabs|App|DropDownButton|Item|jsSearch|Message|TabsSubView|BreadCrumb|DropDown|ItemsPerPageSelector|jsSortable|Template|Button|jQuery|jsSSE|Modal|Text|CallbackLater|Exception|jsCallback|jsToast|Paginator|View|Callback|jsChain|jsVueService|VirtualPage|CardDeck|jsConditionalForm|jUniv|Wizard|Card|Form|jsExpressionable|Label|Popup|CardSection|GridLayout|jsExpression|ProgressBar|CardTable|Grid|jsFunction|Lister|Step|Columns|Header|jsModal|Loader|TableColumn)['"]
   ```