### PR TITLE
Allow backslash escapes in template

### DIFF
--- a/src/Template.php
+++ b/src/Template.php
@@ -804,7 +804,7 @@ class Template implements \ArrayAccess
      */
     protected function parseTemplate($str)
     {
-        $tag = '/{([\/$]?[-_:\w]*[\?]?)}/';
+        $tag = '~(?<!\\\\)(?:\\\\\\\\)*+\K{([/$]?[\w\-:]*[\?]?)}~';
 
         $input = preg_split($tag, $str, -1, PREG_SPLIT_DELIM_CAPTURE);
 


### PR DESCRIPTION
Is it wanted? Templates usually does not contain backslashes, but we may want something like this https://stackoverflow.com/questions/12497130/how-to-escape-twig-delimiters-in-a-twig-template

Also needed for jsExpression which is parsed more like https://github.com/atk4/dsql/pull/201