### PR TITLE
Fix cdn caching for develop

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -17,7 +17,7 @@ jobs:
           echo "::set-env name=version::$v"
 
           git branch
-          sed -i "s|'https://cdn.jsdelivr.net/gh/atk4/ui.*|'https://cdn.jsdelivr.net/gh/atk4/ui@$v/public',|" src/App.php
+          sed -i "s|'https://raw.githubusercontent.com/atk4/ui/.*/public',|'https://cdn.jsdelivr.net/gh/atk4/ui@$v/public',|" src/App.php
           sed -i "s|public \$version.*|public \$version = '$v';|" src/App.php
 
       - uses: teaminkling/autocommit@master

--- a/src/App.php
+++ b/src/App.php
@@ -32,7 +32,7 @@ class App
 
     /** @var array|false Location where to load JS/CSS files */
     public $cdn = [
-        'atk' => 'https://cdn.jsdelivr.net/gh/atk4/ui@develop/public',
+        'atk' => 'https://raw.githubusercontent.com/atk4/ui/develop/public',
         'jquery' => 'https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1',
         'serialize-object' => 'https://cdnjs.cloudflare.com/ajax/libs/jquery-serialize-object/2.5.0',
         'semantic-ui' => 'https://cdn.jsdelivr.net/npm/fomantic-ui@2.7.4/dist',

--- a/src/App.php
+++ b/src/App.php
@@ -35,7 +35,7 @@ class App
         'atk' => 'https://raw.githubusercontent.com/atk4/ui/develop/public',
         'jquery' => 'https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1',
         'serialize-object' => 'https://cdnjs.cloudflare.com/ajax/libs/jquery-serialize-object/2.5.0',
-        'semantic-ui' => 'https://cdn.jsdelivr.net/npm/fomantic-ui@2.7.4/dist',
+        'semantic-ui' => 'https://cdnjs.cloudflare.com/ajax/libs/fomantic-ui/2.7.4',
     ];
 
     /** @var string Version of Agile UI */


### PR DESCRIPTION
Current CDN caches the resource for about a day, this fixes it for the develop.

Also Unify CDNs in favor of Cloudflare.

This PR helps, confirmed by https://github.com/atk4/ui/pull/1151#issuecomment-623169453

> Works now, probably then was that caching/CDN delay problem.