### PR TITLE
Convert callables to closures and move hook names to constants

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -63,6 +63,8 @@ jobs:
           if [ "${{ matrix.type }}" != "Behat" ]; then composer remove --no-interaction --no-update 'behat/*' --dev ; fi
           if [ "${{ matrix.type }}" != "CodingStyle" ]; then composer remove --no-interaction --no-update friendsofphp/php-cs-fixer --dev ; fi
           composer install --no-suggest --ansi --prefer-dist --no-interaction --no-progress --optimize-autoloader
+          (cd vendor/atk4 && rm -R core && git clone https://github.com/atk4/core.git && cd core && git fetch origin pull/196/head && git checkout FETCH_HEAD)
+          (cd vendor/atk4 && rm -R data && git clone https://github.com/atk4/data.git && cd data && git fetch origin pull/597/head && git checkout FETCH_HEAD)
 
       - name: Install JS dependencies (only for Behat)
         if: matrix.type == 'Behat'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -63,8 +63,6 @@ jobs:
           if [ "${{ matrix.type }}" != "Behat" ]; then composer remove --no-interaction --no-update 'behat/*' --dev ; fi
           if [ "${{ matrix.type }}" != "CodingStyle" ]; then composer remove --no-interaction --no-update friendsofphp/php-cs-fixer --dev ; fi
           composer install --no-suggest --ansi --prefer-dist --no-interaction --no-progress --optimize-autoloader
-          (cd vendor/atk4 && rm -R core && git clone https://github.com/atk4/core.git && cd core && git fetch origin pull/196/head && git checkout FETCH_HEAD)
-          (cd vendor/atk4 && rm -R data && git clone https://github.com/atk4/data.git && cd data && git fetch origin pull/597/head && git checkout FETCH_HEAD)
 
       - name: Install JS dependencies (only for Behat)
         if: matrix.type == 'Behat'

--- a/demos/atk-init.php
+++ b/demos/atk-init.php
@@ -26,7 +26,7 @@ if ($app->catch_exceptions !== true) {
 }
 
 if (file_exists(__DIR__ . '/coverage.php')) {
-    $app->onHook('beforeExit', function () {
+    $app->onHook(atk4\ui\App::HOOK_BEFORE_EXIT, function () {
         coverage();
     });
 }

--- a/demos/collection/actions.php
+++ b/demos/collection/actions.php
@@ -42,7 +42,7 @@ $executor->setAction($action);
 $executor->ui = 'segment';
 $executor->description = 'Execute action using "Basic" executor and path="." argument';
 $executor->setArguments(['path' => '.']);
-$executor->onHook('afterExecute', function ($x, $ret) {
+$executor->onHook(\atk4\ui\ActionExecutor\Basic::HOOK_AFTER_EXECUTE, function ($x, $ret) {
     return new \atk4\ui\jsToast('Files imported: ' . $ret);
 });
 
@@ -50,7 +50,7 @@ $grid->add($executor = new \atk4\ui\ActionExecutor\ArgumentForm(), 'r1c2');
 $executor->setAction($action);
 $executor->description = 'ArgumentForm executor will ask user about arguments';
 $executor->ui = 'segment';
-$executor->onHook('afterExecute', function ($x, $ret) {
+$executor->onHook(\atk4\ui\ActionExecutor\Basic::HOOK_AFTER_EXECUTE, function ($x, $ret) {
     return new \atk4\ui\jsToast('Files imported: ' . $ret);
 });
 
@@ -60,7 +60,7 @@ $executor->ui = 'segment';
 $executor->previewType = 'console';
 $executor->description = 'Displays preview in console prior to executing';
 $executor->setArguments(['path' => '.']);
-$executor->onHook('afterExecute', function ($x, $ret) {
+$executor->onHook(\atk4\ui\ActionExecutor\Basic::HOOK_AFTER_EXECUTE, function ($x, $ret) {
     return new \atk4\ui\jsToast('Files imported: ' . $ret);
 });
 

--- a/demos/collection/crud.php
+++ b/demos/collection/crud.php
@@ -46,7 +46,7 @@ $crud = \atk4\ui\CRUD::addTo($cc, [
 // Condition on the model can be applied on a model
 $m = new CountryLock($db);
 $m->addCondition('numcode', '<', 200);
-$m->onHook('validate', function ($m2, $intent) {
+$m->onHook(atk4\data\Model::HOOK_VALIDATE, function ($m2, $intent) {
     $err = [];
     if ($m2->get('numcode') >= 200) {
         $err['numcode'] = 'Should be less than 200';

--- a/demos/collection/grid.php
+++ b/demos/collection/grid.php
@@ -10,7 +10,7 @@ $m->addAction('test', function ($m) {
 
 // Delete is already prevent by our lock Model, just simulating it.
 $ex = new \atk4\ui\ActionExecutor\jsUserAction();
-$ex->onHook('afterExecute', function () {
+$ex->onHook(\atk4\ui\ActionExecutor\Basic::HOOK_AFTER_EXECUTE, function () {
     return [
         (new \atk4\ui\jQuery())->closest('tr')->transition('fade left'),
         new \atk4\ui\jsToast('Simulating delete in demo mode.'),

--- a/demos/collection/jsactions.php
+++ b/demos/collection/jsactions.php
@@ -53,7 +53,7 @@ $f_action = $files->addAction(
 $btn = \atk4\ui\Button::addTo($app, ['Import File']);
 $executor = \atk4\ui\ActionExecutor\jsUserAction::addTo($app);
 $executor->setAction($f_action, ['path' => '.']);
-$executor->onHook('afterExecute', function ($t, $m) {
+$executor->onHook(\atk4\ui\ActionExecutor\Basic::HOOK_AFTER_EXECUTE, function ($t, $m) {
     return new \atk4\ui\jsToast('Files imported');
 });
 

--- a/demos/collection/jssortable.php
+++ b/demos/collection/jssortable.php
@@ -12,7 +12,7 @@ $view = \atk4\ui\View::addTo($app, ['template' => new \atk4\ui\Template(
 )]);
 
 $lister = \atk4\ui\Lister::addTo($view, [], ['List']);
-$lister->onHook('beforeRow', function (atk4\ui\Lister $lister) {
+$lister->onHook(\atk4\ui\Lister::HOOK_BEFORE_ROW, function (atk4\ui\Lister $lister) {
     $lister->current_row->set('iso', mb_strtolower($lister->current_row->get('iso')));
 });
 $lister->setModel(new Country($db))

--- a/demos/collection/lister-ipp.php
+++ b/demos/collection/lister-ipp.php
@@ -17,7 +17,7 @@ $view = \atk4\ui\View::addTo($app, ['template' => new \atk4\ui\Template('<div>
 </div>')]);
 
 $lister = \atk4\ui\Lister::addTo($view, [], ['List']);
-$lister->onHook('beforeRow', function (atk4\ui\Lister $lister) {
+$lister->onHook(\atk4\ui\Lister::HOOK_BEFORE_ROW, function (atk4\ui\Lister $lister) {
     $lister->current_row->set('iso', mb_strtolower($lister->current_row->get('iso')));
 });
 $lister->setModel(new Country($db))
@@ -37,7 +37,7 @@ $view = \atk4\ui\View::addTo($app, ['template' => new \atk4\ui\Template('<div>
 </div>')]);
 
 $lister = \atk4\ui\Lister::addTo($view, [], ['List']);
-$lister->onHook('beforeRow', function (atk4\ui\Lister $lister) {
+$lister->onHook(\atk4\ui\Lister::HOOK_BEFORE_ROW, function (atk4\ui\Lister $lister) {
     $lister->current_row->set('iso', mb_strtolower($lister->current_row->get('iso')));
 });
 $lister->setModel(new Country($db))
@@ -54,7 +54,7 @@ $v = \atk4\ui\View::addTo($container, ['template' => new \atk4\ui\Template('<div
 </ul>{$Content}</div>')]);
 
 $l = \atk4\ui\Lister::addTo($v, [], ['List']);
-$l->onHook('beforeRow', function (atk4\ui\Lister $lister) {
+$l->onHook(\atk4\ui\Lister::HOOK_BEFORE_ROW, function (atk4\ui\Lister $lister) {
     $lister->current_row->set('iso', mb_strtolower($lister->current_row->get('iso')));
 });
 

--- a/demos/collection/table.php
+++ b/demos/collection/table.php
@@ -27,7 +27,7 @@ $table->addColumn('date');
 $table->addColumn('salary', new \atk4\ui\TableColumn\Money());
 $table->addColumn('logo_url', [new \atk4\ui\TableColumn\Image()], ['caption' => 'Our Logo']);
 
-$table->onHook('getHTMLTags', function ($table, atk4\data\Model $row) {
+$table->onHook(\atk4\ui\TableColumn\Generic::HOOK_GET_HTML_TAGS, function ($table, atk4\data\Model $row) {
     switch ($row->id) {
         case 1: $color = 'yellow';
 

--- a/demos/collection/table2.php
+++ b/demos/collection/table2.php
@@ -22,7 +22,7 @@ $table->template->appendHTML('SubHead', '<tr class="center aligned"><th colspan=
 $table->template->appendHTML('Body', '<tr class="center aligned"><td colspan=2>This is part of body, goes before other rows</td></tr>');
 
 // Hook can be used to display data before row. You can also inject and format extra rows.
-$table->onHook('beforeRow', function (atk4\ui\Table $table) {
+$table->onHook(\atk4\ui\Lister::HOOK_BEFORE_ROW, function (atk4\ui\Table $table) {
     if ($table->current_id === 2) {
         $table->template->appendHTML('Body', '<tr class="center aligned"><td colspan=2>This goes above row with ID=2 (' . $table->current_row->get('action') . ')</th></tr>');
     } elseif ($table->current_row->get('action') === 'Tax') {

--- a/demos/database.php
+++ b/demos/database.php
@@ -126,7 +126,7 @@ class Stat extends \atk4\data\Model
         $this->addField('is_commercial', ['type' => 'boolean']);
         $this->addField('currency', ['enum' => ['EUR', 'USD', 'GBP']]);
         $this->addField('currency_symbol', ['never_persist' => true]);
-        $this->onHook('afterLoad', function (atk4\data\Model $m) {
+        $this->onHook(atk4\data\Model::HOOK_AFTER_LOAD, function (atk4\data\Model $m) {
             /* implementation for "intl"
             $locale='en-UK';
             $fmt = new \NumberFormatter( $locale."@currency=".$m->get('currency'), NumberFormatter::CURRENCY );

--- a/demos/database.php
+++ b/demos/database.php
@@ -53,7 +53,7 @@ class Country extends \atk4\data\Model
         $this->addField('numcode', ['caption' => 'ISO Numeric Code', 'type' => 'number', 'required' => true]);
         $this->addField('phonecode', ['caption' => 'Phone Prefix', 'type' => 'number', 'required' => true]);
 
-        $this->onHook('beforeSave', function (atk4\data\Model $m) {
+        $this->onHook(atk4\data\Model::HOOK_BEFORE_SAVE, function (atk4\data\Model $m) {
             if (!$m->get('sys_name')) {
                 $m->set('sys_name', mb_strtoupper($m->get('name')));
             }

--- a/demos/database.php
+++ b/demos/database.php
@@ -53,7 +53,7 @@ class Country extends \atk4\data\Model
         $this->addField('numcode', ['caption' => 'ISO Numeric Code', 'type' => 'number', 'required' => true]);
         $this->addField('phonecode', ['caption' => 'Phone Prefix', 'type' => 'number', 'required' => true]);
 
-        $this->onHook(atk4\data\Model::HOOK_BEFORE_SAVE, function (atk4\data\Model $m) {
+        $this->onHook(\atk4\data\Model::HOOK_BEFORE_SAVE, function (atk4\data\Model $m) {
             if (!$m->get('sys_name')) {
                 $m->set('sys_name', mb_strtoupper($m->get('name')));
             }
@@ -126,7 +126,7 @@ class Stat extends \atk4\data\Model
         $this->addField('is_commercial', ['type' => 'boolean']);
         $this->addField('currency', ['enum' => ['EUR', 'USD', 'GBP']]);
         $this->addField('currency_symbol', ['never_persist' => true]);
-        $this->onHook(atk4\data\Model::HOOK_AFTER_LOAD, function (atk4\data\Model $m) {
+        $this->onHook(\atk4\data\Model::HOOK_AFTER_LOAD, function (atk4\data\Model $m) {
             /* implementation for "intl"
             $locale='en-UK';
             $fmt = new \NumberFormatter( $locale."@currency=".$m->get('currency'), NumberFormatter::CURRENCY );

--- a/demos/interactive/scroll-container.php
+++ b/demos/interactive/scroll-container.php
@@ -19,7 +19,7 @@ $lister_template = '<div id="{$_id}">{List}<div id="{$_id}" class="ui segment" s
 $lister_container = \atk4\ui\View::addTo($scroll_container, ['template' => new \atk4\ui\Template($lister_template)]);
 
 $l = \atk4\ui\Lister::addTo($lister_container, [], ['List']);
-$l->onHook('beforeRow', function (atk4\ui\Lister $lister) {
+$l->onHook(\atk4\ui\Lister::HOOK_BEFORE_ROW, function (atk4\ui\Lister $lister) {
     $lister->current_row->set('iso', mb_strtolower($lister->current_row->get('iso')));
 });
 $l->setModel(new Country($db));

--- a/demos/interactive/scroll-lister.php
+++ b/demos/interactive/scroll-lister.php
@@ -15,7 +15,7 @@ $v = \atk4\ui\View::addTo($container, ['template' => new \atk4\ui\Template('
 {$Content}')]);
 
 $l = \atk4\ui\Lister::addTo($v, [], ['List']);
-$l->onHook('beforeRow', function (atk4\ui\Lister $lister) {
+$l->onHook(\atk4\ui\Lister::HOOK_BEFORE_ROW, function (atk4\ui\Lister $lister) {
     $lister->current_row->set('iso', mb_strtolower($lister->current_row->get('iso')));
 });
 

--- a/demos/javascript/vue-component.php
+++ b/demos/javascript/vue-component.php
@@ -40,7 +40,7 @@ $view = \atk4\ui\View::addTo($app);
 $search = \atk4\ui\Component\ItemSearch::addTo($view, ['ui' => 'ui compact segment']);
 $lister_container = \atk4\ui\View::addTo($view, ['template' => $lister_template]);
 $lister = \atk4\ui\Lister::addTo($lister_container, [], ['List']);
-$lister->onHook('beforeRow', function (atk4\ui\Lister $lister) {
+$lister->onHook(\atk4\ui\Lister::HOOK_BEFORE_ROW, function (atk4\ui\Lister $lister) {
     ++$lister->ipp;
     $lister->current_row->set('iso', mb_strtolower($lister->current_row->get('iso')));
     if ($lister->ipp === $lister->model->limit[0]) {

--- a/docs/label.rst
+++ b/docs/label.rst
@@ -122,7 +122,7 @@ Added labels into Table
 You can even use label inside a table, but because table renders itself by repeating periodically, then
 the following code is needed::
 
-    $table->onHook('getHTMLTags', function ($table, Model $row) {
+    $table->onHook(\atk4\ui\TableColumn\Generic::HOOK_GET_HTML_TAGS, function ($table, Model $row) {
         if ($row->id == 1) {
             return [
                 'name'=> $table->app->getTag('div', ['class'=>'ui ribbon label'], $row->get('name')),

--- a/docs/lister.rst
+++ b/docs/lister.rst
@@ -96,7 +96,7 @@ Tweaking the output
 Output is formatted using the standard :ref:`ui_persistence` routine, but you can also fine-tune the content
 of your tags like this::
 
-    $lister->onHook('beforeRow', function(\atk4\ui\Lister $lister){
+    $lister->onHook(\atk4\ui\Lister::HOOK_BEFORE_ROW, function(\atk4\ui\Lister $lister){
         $lister->current_row->set('iso', mb_strtolower($lister->current_row->get('iso')));
     })
 

--- a/src/ActionExecutor/Basic.php
+++ b/src/ActionExecutor/Basic.php
@@ -12,6 +12,9 @@ class Basic extends \atk4\ui\View implements Interface_
 {
     use HookTrait;
 
+    /** @const string */
+    public const HOOK_AFTER_EXECUTE = self::class . '@afterExecute';
+
     /**
      * @var \atk4\data\UserAction\Generic
      */
@@ -146,7 +149,7 @@ class Basic extends \atk4\ui\View implements Interface_
 
         $success = is_callable($this->jsSuccess) ? call_user_func_array($this->jsSuccess, [$this, $this->action->owner]) : $this->jsSuccess;
 
-        return ($this->hook('afterExecute', [$return]) ?: $success) ?: new jsToast('Success' . (is_string($return) ? (': ' . $return) : ''));
+        return ($this->hook(self::HOOK_AFTER_EXECUTE, [$return]) ?: $success) ?: new jsToast('Success' . (is_string($return) ? (': ' . $return) : ''));
     }
 
     /**

--- a/src/ActionExecutor/UserAction.php
+++ b/src/ActionExecutor/UserAction.php
@@ -331,7 +331,7 @@ class UserAction extends Modal implements Interface_, jsInterface_
         $this->jsSetSubmitBtn($modal, $f, $this->step);
         $this->jsSetPrevHandler($modal, $this->step);
 
-        if (!$f->hookHasCallbacks('submit')) {
+        if (!$f->hookHasCallbacks(Form::HOOK_SUBMIT)) {
             $f->onSubmit(function (Form $form) {
                 // collect fields.
                 $form_fields = $form->model->get();

--- a/src/ActionExecutor/UserAction.php
+++ b/src/ActionExecutor/UserAction.php
@@ -37,6 +37,9 @@ class UserAction extends Modal implements Interface_, jsInterface_
 {
     use HookTrait;
 
+    /** @const string */
+    public const HOOK_STEP = self::class . '@onStep';
+
     /**
      * @var jsExpressionable array|callable jsExpression to return if action was successful, e.g "new jsToast('Thank you')"
      */
@@ -539,7 +542,7 @@ class UserAction extends Modal implements Interface_, jsInterface_
         foreach ($fields as $k => $val) {
             $form->getField($k)->set($val);
         }
-        $this->hook('onStep', [$step, $form]);
+        $this->hook(self::HOOK_STEP, [$step, $form]);
 
         return $form;
     }

--- a/src/ActionExecutor/UserAction.php
+++ b/src/ActionExecutor/UserAction.php
@@ -437,7 +437,7 @@ class UserAction extends Modal implements Interface_, jsInterface_
 
         return [
             $this->hide(),
-            $this->hook('afterExecute', [$obj, $id]) ?:
+            $this->hook(Basic::HOOK_AFTER_EXECUTE, [$obj, $id]) ?:
             $success ?: new jsToast('Success' . (is_string($obj) ? (': ' . $obj) : '')),
             $this->loader->jsClearStoreData(true),
         ];

--- a/src/ActionExecutor/UserConfirmation.php
+++ b/src/ActionExecutor/UserConfirmation.php
@@ -238,7 +238,7 @@ class UserConfirmation extends Modal implements jsInterface_, Interface_
             $this->hide(),
             $this->ok->js(true)->off(),
             $this->cancel->js(true)->off(),
-            $this->hook('afterExecute', [$obj, $id]) ?: $success ?: new jsToast('Success' . (is_string($obj) ? (': ' . $obj) : '')),
+            $this->hook(Basic::HOOK_AFTER_EXECUTE, [$obj, $id]) ?: $success ?: new jsToast('Success' . (is_string($obj) ? (': ' . $obj) : '')),
         ];
     }
 

--- a/src/ActionExecutor/jsArgumentForm.php
+++ b/src/ActionExecutor/jsArgumentForm.php
@@ -14,6 +14,9 @@ class jsArgumentForm extends jsModal
 {
     use HookTrait;
 
+    /** @const string not used, make it public if needed or drop it */
+    private const HOOK_FORM_INIT = self::class . '@formInit';
+
     public $vp;
     public $action;
     public $form;
@@ -46,7 +49,7 @@ class jsArgumentForm extends jsModal
             // TODO How do we know if argument is need over model field in action?
             $form->setModel($this->action->owner);
 
-            $form->hook('formInit');
+            $form->hook(self::HOOK_FORM_INIT);
 
             $form->onSubmit(function (\atk4\ui\Form $form) {
                 $this->action->fields = array_keys($form->model->getFields('editable'));

--- a/src/ActionExecutor/jsArgumentForm.php
+++ b/src/ActionExecutor/jsArgumentForm.php
@@ -54,7 +54,7 @@ class jsArgumentForm extends jsModal
 
                 $js = [
                     new jsExpression('$(".atk-dialog-content").trigger("close")'),
-                    $this->hook('afterExecute', [$return]) ?: new jsToast('Success' . (is_string($return) ? (': ' . $return) : '')),
+                    $this->hook(Basic::HOOK_AFTER_EXECUTE, [$return]) ?: new jsToast('Success' . (is_string($return) ? (': ' . $return) : '')),
                 ];
 
                 return $js;

--- a/src/ActionExecutor/jsEvent.php
+++ b/src/ActionExecutor/jsEvent.php
@@ -141,7 +141,7 @@ class jsEvent implements jsExpressionable
                 $return = $this->action->execute(...$args);
                 $success = is_callable($this->jsSuccess) ? call_user_func_array($this->jsSuccess, [$this, $this->action->owner, $id]) : $this->jsSuccess;
 
-                $js = $this->hook('afterExecute', [$return, $id]) ?: $success ?: new jsToast('Success' . (is_string($return) ? (': ' . $return) : ''));
+                $js = $this->hook(Basic::HOOK_AFTER_EXECUTE, [$return, $id]) ?: $success ?: new jsToast('Success' . (is_string($return) ? (': ' . $return) : ''));
             }
 
             return $js;

--- a/src/ActionExecutor/jsUserAction.php
+++ b/src/ActionExecutor/jsUserAction.php
@@ -88,7 +88,7 @@ class jsUserAction extends jsCallback implements Interface_
                 $return = $this->action->execute(...$args);
                 $success = is_callable($this->jsSuccess) ? call_user_func_array($this->jsSuccess, [$this, $this->action->owner, $id, $return]) : $this->jsSuccess;
 
-                $js = $this->hook('afterExecute', [$return, $id]) ?: $success ?: new jsToast('Success' . (is_string($return) ? (': ' . $return) : ''));
+                $js = $this->hook(Basic::HOOK_AFTER_EXECUTE, [$return, $id]) ?: $success ?: new jsToast('Success' . (is_string($return) ? (': ' . $return) : ''));
             }
 
             return $js;

--- a/src/App.php
+++ b/src/App.php
@@ -20,12 +20,18 @@ class App
     use InitializerTrait {
         init as _init;
     }
-
     use HookTrait;
     use DynamicMethodTrait;
     use FactoryTrait;
     use AppScopeTrait;
     use DIContainerTrait;
+
+    /** @const string */
+    public const HOOK_BEFORE_EXIT = self::class . '@beforeExit';
+    /** @const string */
+    public const HOOK_BEFORE_RENDER = self::class . '@beforeRender';
+    /** @const string not used, make it public if needed or drop it */
+    private const HOOK_BEFORE_OUTPUT = self::class . '@beforeOutput';
 
     /** @const string */
     protected const HEADER_STATUS_CODE = 'atk4-status-code';
@@ -220,7 +226,7 @@ class App
     {
         if (!$this->exit_called) {
             $this->exit_called = true;
-            $this->hook('beforeExit');
+            $this->hook(self::HOOK_BEFORE_EXIT);
         }
 
         if ($for_shutdown) {
@@ -524,7 +530,7 @@ class App
         try {
             ob_start();
             $this->run_called = true;
-            $this->hook('beforeRender');
+            $this->hook(self::HOOK_BEFORE_RENDER);
             $this->is_rendering = true;
 
             // if no App layout set
@@ -536,7 +542,7 @@ class App
             $this->html->renderAll();
             $this->html->template->appendHTML('HEAD', $this->html->getJS());
             $this->is_rendering = false;
-            $this->hook('beforeOutput');
+            $this->hook(self::HOOK_BEFORE_OUTPUT);
 
             if (isset($_GET['__atk_callback']) && $this->catch_runaway_callbacks) {
                 $this->terminate(

--- a/src/CRUD.php
+++ b/src/CRUD.php
@@ -158,7 +158,7 @@ class CRUD extends Grid
 
         if ($executor instanceof UserAction) {
             foreach ($this->onActions as $k => $onAction) {
-                $executor->onHook('onStep', function ($ex, $step, $form) use ($onAction, $action) {
+                $executor->onHook(UserAction::HOOK_STEP, function ($ex, $step, $form) use ($onAction, $action) {
                     $key = key($onAction);
                     if ($key === $action->short_name && $step === 'fields') {
                         return call_user_func($onAction[$key], $form, $ex);

--- a/src/CRUD.php
+++ b/src/CRUD.php
@@ -152,7 +152,7 @@ class CRUD extends Grid
     protected function initActionExecutor(Generic $action)
     {
         $executor = $this->getExecutor($action);
-        $executor->onHook('afterExecute', function ($ex, $return, $id) use ($action) {
+        $executor->onHook(ActionExecutor\Basic::HOOK_AFTER_EXECUTE, function ($ex, $return, $id) use ($action) {
             return $this->jsExecute($return, $action);
         });
 
@@ -250,7 +250,7 @@ class CRUD extends Grid
     /**
      * Return proper action executor base on model action.
      *
-     *@throws \atk4\core\Exception
+     * @throws \atk4\core\Exception
      *
      * @return object
      */

--- a/src/CallbackLater.php
+++ b/src/CallbackLater.php
@@ -29,7 +29,7 @@ class CallbackLater extends Callback
             return parent::set($callback, $args);
         }
 
-        $this->app->onHook('beforeRender', function (...$args) use ($callback) {
+        $this->app->onHook(App::HOOK_BEFORE_RENDER, function (...$args) use ($callback) {
             array_shift($args); // Hook will have first argument pointing to the app. We don't need that.
             return parent::set($callback, $args);
         }, $args);

--- a/src/CardDeck.php
+++ b/src/CardDeck.php
@@ -230,7 +230,7 @@ class CardDeck extends View
                 return $this->jsExecute($return, $action);
             };
         } else {
-            $executor->onHook('afterExecute', function ($ex, $return, $id) use ($action) {
+            $executor->onHook(ActionExecutor\Basic::HOOK_AFTER_EXECUTE, function ($ex, $return, $id) use ($action) {
                 return $this->jsExecute($return, $action);
             });
         }

--- a/src/Form.php
+++ b/src/Form.php
@@ -14,6 +14,12 @@ class Form extends View
 
     /** @const string Executed when form is submitted */
     public const HOOK_SUBMIT = self::class . '@submit';
+    /** @const string Executed when form is submitted */
+    public const HOOK_DISPLAY_ERROR = self::class . '@displayError';
+    /** @const string Executed when form is submitted */
+    public const HOOK_DISPLAY_SUCCESS = self::class . '@displaySuccess';
+    /** @const string Executed when self::loadPOST() method is called. */
+    public const HOOK_LOAD_POST = self::class . '@loadPOST';
 
     // {{{ Properties
 
@@ -279,8 +285,8 @@ class Form extends View
     public function error($fieldName, $str)
     {
         // by using this hook you can overwrite default behavior of this method
-        if ($this->hookHasCallbacks('displayError')) {
-            return $this->hook('displayError', [$fieldName, $str]);
+        if ($this->hookHasCallbacks(self::HOOK_DISPLAY_ERROR)) {
+            return $this->hook(self::HOOK_DISPLAY_ERROR, [$fieldName, $str]);
         }
 
         $jsError = [$this->js()->form('add prompt', $fieldName, $str)];
@@ -304,8 +310,8 @@ class Form extends View
     {
         $response = null;
         // by using this hook you can overwrite default behavior of this method
-        if ($this->hookHasCallbacks('displaySuccess')) {
-            return $this->hook('displaySuccess', [$success, $sub_header]);
+        if ($this->hookHasCallbacks(self::HOOK_DISPLAY_SUCCESS)) {
+            return $this->hook(self::HOOK_DISPLAY_SUCCESS, [$success, $sub_header]);
         }
 
         if ($success instanceof View) {
@@ -507,7 +513,7 @@ class Form extends View
     {
         $post = $_POST;
 
-        $this->hook('loadPOST', [&$post]);
+        $this->hook(self::HOOK_LOAD_POST, [&$post]);
         $errors = [];
 
         foreach ($this->fields as $key => $field) {

--- a/src/Form.php
+++ b/src/Form.php
@@ -12,6 +12,9 @@ class Form extends View
 {
     use \atk4\core\HookTrait;
 
+    /** @const string Executed when form is submitted */
+    public const HOOK_SUBMIT = self::class . '@submit';
+
     // {{{ Properties
 
     public $ui = 'form';
@@ -244,10 +247,12 @@ class Form extends View
 
     /**
      * Adds callback in submit hook.
+     *
+     * @return $this
      */
-    public function onSubmit(callable $callback)
+    public function onSubmit(\Closure $callback)
     {
-        $this->onHook('submit', $callback);
+        $this->onHook(self::HOOK_SUBMIT, $callback);
 
         return $this;
     }
@@ -580,7 +585,7 @@ class Form extends View
             try {
                 ob_start();
                 $this->loadPOST();
-                $response = $this->hook('submit');
+                $response = $this->hook(self::HOOK_SUBMIT);
                 $output = ob_get_clean();
 
                 if ($output) {

--- a/src/Form.php
+++ b/src/Form.php
@@ -8,7 +8,7 @@ use atk4\data\Reference\ContainsMany;
 /**
  * Implements a form.
  */
-class Form extends View //implements \ArrayAccess - temporarily so that our build script dont' complain
+class Form extends View
 {
     use \atk4\core\HookTrait;
 

--- a/src/FormField/CheckBox.php
+++ b/src/FormField/CheckBox.php
@@ -47,7 +47,7 @@ class CheckBox extends Generic
         // not ticked. We assume they are ticked and sent boolean "false" as a
         // workaround. Otherwise send boolean "true".
         if ($this->form) {
-            $this->form->onHook('loadPOST', function ($form, &$post) {
+            $this->form->onHook(Form::HOOK_LOAD_POST, function ($form, &$post) {
                 $post[$this->field->short_name] = isset($post[$this->field->short_name]);
             });
         }

--- a/src/FormField/MultiLine.php
+++ b/src/FormField/MultiLine.php
@@ -244,7 +244,7 @@ class MultiLine extends Generic
         $this->cb = \atk4\ui\jsCallback::addTo($this);
 
         // load the data associated with this input and validate it.
-        $this->form->onHook('loadPOST', function ($form) {
+        $this->form->onHook(\atk4\ui\Form::HOOK_LOAD_POST, function ($form) {
             $this->rowData = json_decode($_POST[$this->short_name], true);
             if ($this->rowData) {
                 $this->rowErrors = $this->validate($this->rowData);

--- a/src/FormField/MultiLine.php
+++ b/src/FormField/MultiLine.php
@@ -254,7 +254,7 @@ class MultiLine extends Generic
         });
 
         // Change form error handling.
-        $this->form->onHook('displayError', function ($form, $fieldName, $str) {
+        $this->form->onHook(\atk4\ui\Form::HOOK_DISPLAY_ERROR, function ($form, $fieldName, $str) {
             // When errors are coming from this Multiline field, then notify Multiline component about them.
             // Otherwise use normal field error.
             if ($fieldName === $this->short_name) {

--- a/src/FormField/MultiLine.php
+++ b/src/FormField/MultiLine.php
@@ -72,6 +72,7 @@ use atk4\data\Model;
 use atk4\data\Reference\HasOne;
 use atk4\data\ValidationException;
 use atk4\ui\Exception;
+use atk4\ui\Form;
 use atk4\ui\jsExpression;
 use atk4\ui\jsFunction;
 use atk4\ui\jsVueService;

--- a/src/FormField/Radio.php
+++ b/src/FormField/Radio.php
@@ -55,7 +55,7 @@ class Radio extends Generic
             $this->addClass('disabled');
         }
 
-        $this->lister->onHook('beforeRow', function (\atk4\ui\Lister $lister) use ($value) {
+        $this->lister->onHook(\atk4\ui\Lister::HOOK_BEFORE_ROW, function (\atk4\ui\Lister $lister) use ($value) {
             if ($this->readonly) {
                 $lister->t_row->set('disabled', $value !== (string) $lister->model->id ? 'disabled="disabled"' : '');
             } elseif ($this->disabled) {

--- a/src/FormLayout/Section/Accordion.php
+++ b/src/FormLayout/Section/Accordion.php
@@ -18,7 +18,7 @@ class Accordion extends \atk4\ui\Accordion
     {
         parent::init();
 
-        $this->form->onHook('displayError', function ($form, $fieldName, $str) {
+        $this->form->onHook(\atk4\ui\Form::HOOK_DISPLAY_ERROR, function ($form, $fieldName, $str) {
             // default behavior
             $jsError = [$form->js()->form('add prompt', $fieldName, $str)];
 

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -12,6 +12,10 @@ use atk4\ui\ActionExecutor\Basic;
 class Grid extends View
 {
     use HookTrait;
+
+    /** @const string not used, make it public if needed or drop it */
+    private const HOOK_ON_USER_ACTION = self::class . '@onUserAction';
+
     /**
      * Will be initialized to Menu object, however you can set this to false to disable menu.
      *
@@ -574,7 +578,7 @@ class Grid extends View
         $this->addModalAction($button, $title, function ($page, $id) use ($action, $executor) {
             $page->add($executor);
 
-            $this->hook('onUserAction', [$page, $executor]);
+            $this->hook(self::HOOK_ON_USER_ACTION, [$page, $executor]);
 
             $action->owner->load($id);
 

--- a/src/Lister.php
+++ b/src/Lister.php
@@ -6,6 +6,9 @@ class Lister extends View
 {
     use \atk4\core\HookTrait;
 
+    /** @const string */
+    public const HOOK_BEFORE_ROW = self::class . '@beforeRow';
+
     /**
      * Lister repeats part of it's template. This property will contain
      * the repeating part. Clones from {row}. If your template does not
@@ -137,7 +140,7 @@ class Lister extends View
         // Iterate data rows
         $this->_rendered_rows_count = 0;
         foreach ($this->model as $this->current_id => $this->current_row) {
-            if ($this->hook('beforeRow') === false) {
+            if ($this->hook(self::HOOK_BEFORE_ROW) === false) {
                 continue;
             }
 

--- a/src/Lister.php
+++ b/src/Lister.php
@@ -8,6 +8,8 @@ class Lister extends View
 
     /** @const string */
     public const HOOK_BEFORE_ROW = self::class . '@beforeRow';
+    /** @const string */
+    public const HOOK_AFTER_ROW = self::class . '@afterRow';
 
     /**
      * Lister repeats part of it's template. This property will contain

--- a/src/Table.php
+++ b/src/Table.php
@@ -501,7 +501,7 @@ class Table extends Lister
 
             ++$this->_rendered_rows_count;
 
-            if ($this->hook('afterRow') === false) {
+            if ($this->hook(self::HOOK_AFTER_ROW) === false) {
                 continue;
             }
         }

--- a/src/Table.php
+++ b/src/Table.php
@@ -536,7 +536,7 @@ class Table extends Lister
             // Prepare row-specific HTML tags.
             $html_tags = [];
 
-            foreach ($this->hook('getHTMLTags', [$this->model]) as $ret) {
+            foreach ($this->hook(TableColumn\Generic::HOOK_GET_HTML_TAGS, [$this->model]) as $ret) {
                 if (is_array($ret)) {
                     $html_tags = array_merge($html_tags, $ret);
                 }

--- a/src/Table.php
+++ b/src/Table.php
@@ -489,7 +489,7 @@ class Table extends Lister
         $this->_rendered_rows_count = 0;
         foreach ($this->model as $this->current_id => $tmp) {
             $this->current_row = $this->model->get();
-            if ($this->hook('beforeRow') === false) {
+            if ($this->hook(self::HOOK_BEFORE_ROW) === false) {
                 continue;
             }
 

--- a/src/TableColumn/FilterModel/Generic.php
+++ b/src/TableColumn/FilterModel/Generic.php
@@ -110,7 +110,7 @@ class Generic extends Model
             }
 
             // Add hook in order to persist data in session.
-            $this->onHook('afterSave', function ($m) {
+            $this->onHook(Model::HOOK_AFTER_SAVE, function ($m) {
                 $this->memorize('data', $m->get());
             });
         }

--- a/src/TableColumn/Generic.php
+++ b/src/TableColumn/Generic.php
@@ -370,7 +370,7 @@ class Generic
      * will also be formatted before inserting, see UI Persistence formatting in the documentation.
      *
      * This method will be executed only once per table rendering, if you need to format data manually,
-     * you should use $this->table->onHook('formatRow');
+     * you should use $this->table->onHook('formatRow', ...);
      *
      * @param Field $field
      * @param array $extra_tags

--- a/src/TableColumn/Generic.php
+++ b/src/TableColumn/Generic.php
@@ -21,6 +21,9 @@ class Generic
     use \atk4\core\TrackableTrait;
     use \atk4\core\DIContainerTrait;
 
+    /** @const string */
+    public const HOOK_GET_HTML_TAGS = self::class . '@getHTMLTags';
+
     /**
      * Link back to the table, where column is used.
      *

--- a/src/TableColumn/Generic.php
+++ b/src/TableColumn/Generic.php
@@ -24,7 +24,7 @@ class Generic
     /** @const string */
     public const HOOK_GET_HTML_TAGS = self::class . '@getHTMLTags';
     /** @const string not used, make it public if needed or drop it */
-    private const HOOK_GET_HADER_CELL_HTML = self::class . '@getHeaderCellHTML';
+    private const HOOK_GET_HEADER_CELL_HTML = self::class . '@getHeaderCellHTML';
 
     /**
      * Link back to the table, where column is used.
@@ -307,7 +307,7 @@ class Generic
             throw new \atk4\ui\Exception(['How $table could not be set??', 'field' => $field, 'value' => $value]);
         }
 
-        if ($tags = $this->table->hook(self::HOOK_GET_HADER_CELL_HTML, [$this, $field, $value])) {
+        if ($tags = $this->table->hook(self::HOOK_GET_HEADER_CELL_HTML, [$this, $field, $value])) {
             return reset($tags);
         }
 

--- a/src/TableColumn/Generic.php
+++ b/src/TableColumn/Generic.php
@@ -23,6 +23,8 @@ class Generic
 
     /** @const string */
     public const HOOK_GET_HTML_TAGS = self::class . '@getHTMLTags';
+    /** @const string not used, make it public if needed or drop it */
+    private const HOOK_GET_HADER_CELL_HTML = self::class . '@getHeaderCellHTML';
 
     /**
      * Link back to the table, where column is used.
@@ -305,7 +307,7 @@ class Generic
             throw new \atk4\ui\Exception(['How $table could not be set??', 'field' => $field, 'value' => $value]);
         }
 
-        if ($tags = $this->table->hook('getColumnHeaderCell', [$this, $field, $value])) {
+        if ($tags = $this->table->hook(self::HOOK_GET_HADER_CELL_HTML, [$this, $field, $value])) {
             return reset($tags);
         }
 

--- a/src/TableColumn/Generic.php
+++ b/src/TableColumn/Generic.php
@@ -373,7 +373,7 @@ class Generic
      * will also be formatted before inserting, see UI Persistence formatting in the documentation.
      *
      * This method will be executed only once per table rendering, if you need to format data manually,
-     * you should use $this->table->onHook('formatRow', ...);
+     * you should use $this->table->onHook('beforeRow' or 'afterRow', ...);
      *
      * @param Field $field
      * @param array $extra_tags

--- a/src/jsSSE.php
+++ b/src/jsSSE.php
@@ -11,6 +11,9 @@ class jsSSE extends jsCallback
 {
     use HookTrait;
 
+    /** @const string Executed when user aborted, or disconnect browser, when using this SSE. */
+    public const HOOK_ABORTED = self::class . '@connection_aborted';
+
     /** @var bool Allows us to fall-back to standard functionality of jsCallback if browser does not support SSE. */
     public $browserSupport = false;
 
@@ -34,14 +37,6 @@ class jsSSE extends jsCallback
             $this->browserSupport = true;
             $this->initSse();
         }
-    }
-
-    /**
-     * A function that get execute when user aborted, or disconnect browser, when using this sse.
-     */
-    public function onAborted(callable $fx)
-    {
-        $this->onHook('aborted', $fx);
     }
 
     public function jsRender()
@@ -130,7 +125,7 @@ class jsSSE extends jsCallback
     public function sendBlock(string $id, string $data, string $name = null): void
     {
         if (connection_aborted()) {
-            $this->hook('aborted');
+            $this->hook(self::HOOK_ABORTED);
 
             // stop execution when aborted if not keepAlive.
             if (!$this->keepAlive) {


### PR DESCRIPTION
merge after https://github.com/atk4/data/pull/597

REVERT FIRST COMMIT BEFORE MERGE

only cleanup, only changes in `atk4/data` were required, compatible with current `atk4/core`

using more specific names, names should be never used directly (the HOOK_xxx constants should theoretically have any unique name without functional change)

Regex to locate old names:
```
['"](afterExecute|onStep|beforeExit|beforeRender|submit|displayError|displaySuccess|loadPOST|beforeRow|afterRow|getHTMLTags|aborted)['"]
```

New hook names:
```
'afterExecute' => \atk4\ui\ActionExecutor/Basic::HOOK_AFTER_EXECUTE

'onStep' => \atk4\ui\ActionExecutor/UserAction::HOOK_STEP

'beforeExit' => \atk4\ui\App::HOOK_BEFORE_EXIT
'beforeRender' => \atk4\ui\App::HOOK_BEFORE_RENDER

'submit' => \atk4\ui\Form::HOOK_SUBMIT
'displayError' => \atk4\ui\Form::HOOK_DISPLAY_ERROR
'displaySuccess' => \atk4\ui\Form::HOOK_DISPLAY_SUCCESS
'loadPOST' => \atk4\ui\Form::HOOK_LOAD_POST

'beforeRow' => \atk4\ui\Lister::HOOK_BEFORE_ROW
'afterRow' => \atk4\ui\Lister::HOOK_AFTER_ROW

'getHTMLTags' => \atk4\ui\TableColumn\Generic::HOOK_GET_HTML_TAGS

'aborted' => \atk4\ui\jsSSE::HOOK_ABORTED
```