### PR TITLE
Pass value with correct escaping, not embed

### DIFF
--- a/demos/collection/tablefilter.php
+++ b/demos/collection/tablefilter.php
@@ -7,7 +7,7 @@ $view = \atk4\ui\View::addTo($app, ['ui' => 'basic segment']);
 $g = \atk4\ui\Grid::addTo($view);
 
 $m = new CountryLock($db);
-$m->addExpression('is_uk', 'if([iso] = [gb], 1, 0)', ['gb'=>'GB'])->type = 'boolean';
+$m->addExpression('is_uk', 'if([iso] = [gb], 1, 0)', ['gb' => 'GB'])->type = 'boolean';
 
 $g->setModel($m);
 $g->addFilterColumn();

--- a/demos/collection/tablefilter.php
+++ b/demos/collection/tablefilter.php
@@ -7,7 +7,7 @@ $view = \atk4\ui\View::addTo($app, ['ui' => 'basic segment']);
 $g = \atk4\ui\Grid::addTo($view);
 
 $m = new CountryLock($db);
-$m->addExpression('is_uk', 'if([iso] = "GB", 1, 0)')->type = 'boolean';
+$m->addExpression('is_uk', 'if([iso] = [gb], 1, 0)', ['gb'=>'GB'])->type = 'boolean';
 
 $g->setModel($m);
 $g->addFilterColumn();

--- a/demos/collection/tablefilter.php
+++ b/demos/collection/tablefilter.php
@@ -7,7 +7,7 @@ $view = \atk4\ui\View::addTo($app, ['ui' => 'basic segment']);
 $g = \atk4\ui\Grid::addTo($view);
 
 $m = new CountryLock($db);
-$m->addExpression('is_uk', 'if([iso] = [gb], 1, 0)', ['gb' => 'GB'])->type = 'boolean';
+$m->addExpression('is_uk', $m->expr('if([iso] = [country], 1, 0)', ['country'=>'GB']))->type = 'boolean';
 
 $g->setModel($m);
 $g->addFilterColumn();

--- a/demos/collection/tablefilter.php
+++ b/demos/collection/tablefilter.php
@@ -7,7 +7,7 @@ $view = \atk4\ui\View::addTo($app, ['ui' => 'basic segment']);
 $g = \atk4\ui\Grid::addTo($view);
 
 $m = new CountryLock($db);
-$m->addExpression('is_uk', $m->expr('if([iso] = [country], 1, 0)', ['country'=>'GB']))->type = 'boolean';
+$m->addExpression('is_uk', $m->expr('if([iso] = [country], 1, 0)', ['country' => 'GB']))->type = 'boolean';
 
 $g->setModel($m);
 $g->addFilterColumn();


### PR DESCRIPTION
URGENT - error appearing on https://ui.agiletoolkit.org/demos/collection/tablefilter.php right now:

<img width="1206" alt="Screenshot 2020-05-19 at 13 24 07" src="https://user-images.githubusercontent.com/453929/82325976-0721e600-99d4-11ea-9cca-72565d0566eb.png">

Looks like value is embedded into the expression. 

```
$m->addExpression('is_uk', 'if([iso] = "GB", 1, 0)')->type = 'boolean';
```

It should use a proper escaping.
