### PR TITLE
Always convert large (>= 2^53) integers to string for JS

### DIFF
--- a/src/FormField/Lookup.php
+++ b/src/FormField/Lookup.php
@@ -220,10 +220,9 @@ class Lookup extends Input
         $id_field = $field->id_field ?: $row->id_field;
         $title_field = $field->title_field ?: $row->title_field;
 
-        // IMPORTANT: always convert data to string, otherwise numbers can be rounded by JS
         return [
-            'value' => (string) $row->get($id_field),
-            'title' => (string) $row->get($title_field),
+            'value' => $row->get($id_field),
+            'title' => $row->get($title_field),
         ];
     }
 

--- a/src/jsExpression.php
+++ b/src/jsExpression.php
@@ -128,7 +128,10 @@ class jsExpression implements jsExpressionable
             $string = '"' . $this->_safe_js_string($arg) . '"';
         } elseif (is_bool($arg)) {
             $string = json_encode($arg);
-        } elseif (is_numeric($arg)) {
+        } elseif (is_int($arg)) {
+            // IMPORTANT: always convert large integers to string, otherwise numbers can be rounded by JS
+            $string = json_encode(abs($arg) < (1 << 53) ? $arg : (string) $arg);
+        } elseif (is_float($arg)) {
             $string = json_encode($arg);
         } elseif ($arg === null) {
             $string = json_encode($arg);

--- a/tests/jsTest.php
+++ b/tests/jsTest.php
@@ -19,6 +19,22 @@ class jsTest extends AtkPhpunit\TestCase
         $this->assertSame('3+4', (new jsExpression('[]+[]', [3, 4]))->jsRender());
     }
 
+    public function testNumbers()
+    {
+        foreach ([
+            [10, '10'],
+            [9007199254740991, '9007199254740991'],
+            [9007199254740992, '"9007199254740992"'],
+            [-9007199254740991, '-9007199254740991'],
+            [-9007199254740992, '"-9007199254740992"'],
+            [1.5, '1.5'],
+            [false, 'false'],
+            [true, 'true'],
+        ] as [$in, $expected]) {
+            $this->assertSame($expected, (new jsExpression('[]', [$in]))->jsRender());
+        }
+    }
+
     public function testNestedExpressions()
     {
         $this->assertSame(


### PR DESCRIPTION
Important as IDs are often integers and they must never be rounded.

see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER