### PR TITLE
Detect unwanted output before App::outputResponse()

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -1095,6 +1095,7 @@ class App
             if ($status['buffer_used'] !== 0) {
                 if (!headers_sent()) {
                     http_response_code(500);
+                    header('Content-Type: text/plain');
                 }
                 echo $this->buildLateErrorStr('Unexpected output detected.');
                 exit;

--- a/src/App.php
+++ b/src/App.php
@@ -1099,23 +1099,23 @@ class App
         if (count($headersNew) > 0 && headers_sent()) {
             echo "\n" . '!! ATK4 UI ERROR: Headers already sent, more headers can not be set at this stage. !!' . "\n";
             exit;
-        } else {
-            foreach ($headersNew as $k => $v) {
-                if ($k === self::HEADER_STATUS_CODE) {
-                    http_response_code($v);
-                } else {
-                    $kCamelCase = preg_replace_callback('~(?<![a-zA-Z])[a-z]~', function ($matches) {
-                        return strtoupper($matches[0]);
-                    }, $k);
+        }
 
-                    header($kCamelCase . ': ' . $v);
-                }
+        foreach ($headersNew as $k => $v) {
+            if ($k === self::HEADER_STATUS_CODE) {
+                http_response_code($v);
+            } else {
+                $kCamelCase = preg_replace_callback('~(?<![a-zA-Z])[a-z]~', function ($matches) {
+                    return strtoupper($matches[0]);
+                }, $k);
 
-                self::$_sentHeaders[$k] = $v;
+                header($kCamelCase . ': ' . $v);
             }
 
-            echo $data;
+            self::$_sentHeaders[$k] = $v;
         }
+
+        echo $data;
     }
 
     /**

--- a/src/App.php
+++ b/src/App.php
@@ -1086,8 +1086,19 @@ class App
         $headersAll = array_merge($this->response_headers, $this->normalizeHeaders($headers));
         $headersNew = array_diff_assoc($headersAll, self::$_sentHeaders);
 
+        foreach (ob_get_status(true) as $status) {
+            if ($status['buffer_used'] !== 0) {
+                if (!headers_sent()) {
+                    http_response_code(500);
+                }
+                echo "\n" . '!! ATK4 UI ERROR: Unexpected output detected. !!' . "\n";
+                exit;
+            }
+        }
+
         if (count($headersNew) > 0 && headers_sent()) {
             echo "\n" . '!! ATK4 UI ERROR: Headers already sent, more headers can not be set at this stage. !!' . "\n";
+            exit;
         } else {
             foreach ($headersNew as $k => $v) {
                 if ($k === self::HEADER_STATUS_CODE) {

--- a/src/App.php
+++ b/src/App.php
@@ -542,7 +542,7 @@ class App
 
             if (isset($_GET['__atk_callback']) && $this->catch_runaway_callbacks) {
                 $this->terminate(
-                    "\n" . '!! ATK4 UI ERROR: Callback requested, but never reached. You may be missing some arguments in request URL. !!' . "\n",
+                    $this->buildLateErrorStr('Callback requested, but never reached. You may be missing some arguments in request URL.'),
                     ['content-type' => 'text/plain', self::HEADER_STATUS_CODE => 500]
                 );
             }
@@ -1072,6 +1072,11 @@ class App
 
     // RESPONSES
 
+    private function buildLateErrorStr(string $msg): string
+    {
+        return "\n" . '!! ATK4 UI ERROR: ' . $msg . ' !!' . "\n";
+    }
+
     /** @var string[] */
     private static $_sentHeaders = [];
 
@@ -1091,13 +1096,13 @@ class App
                 if (!headers_sent()) {
                     http_response_code(500);
                 }
-                echo "\n" . '!! ATK4 UI ERROR: Unexpected output detected. !!' . "\n";
+                echo $this->buildLateErrorStr('Unexpected output detected.');
                 exit;
             }
         }
 
         if (count($headersNew) > 0 && headers_sent()) {
-            echo "\n" . '!! ATK4 UI ERROR: Headers already sent, more headers can not be set at this stage. !!' . "\n";
+            echo $this->buildLateErrorStr('Headers already sent, more headers can not be set at this stage.');
             exit;
         }
 

--- a/src/CRUD.php
+++ b/src/CRUD.php
@@ -60,13 +60,15 @@ class CRUD extends Grid
 
     /**
      * @var array Action name container that will reload Table after executing
-     * @deprecated Use action modifier instead.
+     *
+     * @deprecated use action modifier instead
      */
     public $reloadTableActions = [];
 
     /**
      * @var array Action name container that will remove the corresponding table row after executing
-     * @deprecated Use action modifier instead.
+     *
+     * @deprecated use action modifier instead
      */
     public $removeRowActions = [];
 


### PR DESCRIPTION
Until now it was detected only if the output was >= than `output_buffering` php.ini threshold and thus already detected by `headers_sent()` few lines below

no BC break for normal code