### PR TITLE
Normalize View->add() to always require a seed class like ->factory() already does

### DIFF
--- a/src/View.php
+++ b/src/View.php
@@ -411,16 +411,6 @@ class View implements jsExpressionable
         if (!is_object($object)) {
             // for BC do not throw
             // later consider to accept strictly objects only
-
-            // for BC:
-            // - use self/View class if no class name is defined in the seed
-            if (is_string($object)) {
-                $object = [$object];
-            }
-            if (!isset($object[0])) {
-                $object[0] = self::class;
-            }
-
             $object = self::addToWithClUnsafe($this, $object, [], true);
         }
 


### PR DESCRIPTION
Historically `View->add()` did not required a seed class but factory and other new methods like `addTo()` or `fromSeed` does - drop this old behaviour for consistency and prevent unwanted errors/confusions.

BC breaking of course, but ui is already fully compatible due past refactoring :)