### PR TITLE
Upgrade to Fomantic UI 2.8.5

### DIFF
--- a/demos/interactive/tabs.php
+++ b/demos/interactive/tabs.php
@@ -23,8 +23,8 @@ $t->addTab('Default Active Tab', function ($tab) {
 // dynamic tab
 $t->addTab('Dynamic Lorem Ipsum', function ($tab) {
     \atk4\ui\Message::addTo($tab, ['Every time you come to this tab, you will see a different text']);
-    \atk4\ui\LoremIpsum::addTo($tab, ['size' => 2]);
-});
+    \atk4\ui\LoremIpsum::addTo($tab, ['size' => (int) $_GET['size'] ?? 1]);
+}, ['apiSettings' => ['data' => ['size' => random_int(1, 4)]]]);
 
 // modal tab
 $t->addTab('Modal popup', function ($tab) {

--- a/src/App.php
+++ b/src/App.php
@@ -41,7 +41,7 @@ class App
         'atk' => 'https://ui.agiletoolkit.org/public', // develop branch
         'jquery' => 'https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1',
         'serialize-object' => 'https://cdnjs.cloudflare.com/ajax/libs/jquery-serialize-object/2.5.0',
-        'semantic-ui' => 'https://cdn.jsdelivr.net/npm/fomantic-ui@2.7.4/dist',
+        'semantic-ui' => 'https://cdnjs.cloudflare.com/ajax/libs/fomantic-ui/2.8.5',
     ];
 
     /** @var string Version of Agile UI */

--- a/src/FormLayout/Section/Tabs.php
+++ b/src/FormLayout/Section/Tabs.php
@@ -12,7 +12,7 @@ class Tabs extends \atk4\ui\Tabs
      *
      * @param string|Tab $name     Name of tab or Tab object
      * @param callable   $callback Callback action or URL (or array with url + parameters)
-     * @param callable   $settings  Tab settings.
+     * @param callable   $settings tab settings
      *
      * @throws Exception
      *

--- a/src/FormLayout/Section/Tabs.php
+++ b/src/FormLayout/Section/Tabs.php
@@ -12,14 +12,15 @@ class Tabs extends \atk4\ui\Tabs
      *
      * @param string|Tab $name     Name of tab or Tab object
      * @param callable   $callback Callback action or URL (or array with url + parameters)
+     * @param callable   $settings  Tab settings.
      *
      * @throws Exception
      *
      * @return \atk4\ui\FormLayout\Generic
      */
-    public function addTab($name, $callback = null)
+    public function addTab($name, $callback = null, $settings = [])
     {
-        $c = parent::addTab($name, $callback);
+        $c = parent::addTab($name, $callback, $settings);
 
         return $c->add([$this->formLayout, 'form' => $this->form]);
     }

--- a/src/Tab.php
+++ b/src/Tab.php
@@ -10,6 +10,9 @@ class Tab extends Item
     /** @var string */
     public $path;
 
+    /** @var array Tab settings */
+    public $settings = [];
+
     /**
      * Sets path for tab.
      *
@@ -29,13 +32,19 @@ class Tab extends Item
      */
     public function renderView()
     {
+        // Must setting for Fomantic-Ui tab since 2.8.5
+        $this->settings = array_merge($this->settings, ['autoTabActivation' => false]);
+
         if ($this->path) {
-            $this->js(true)->tab(
-                ['cache' => false, 'auto' => true, 'path' => $this->path, 'apiSettings' => ['data' => ['__atk_tab' => 1]]]
-            );
-        } else {
-            $this->js(true)->tab();
+            $this->settings = array_merge_recursive($this->settings, [
+                'cache' => false,
+                'auto' => true,
+                'path' => $this->path,
+                'apiSettings' => ['data' => ['__atk_tab' => 1]],
+            ]);
         }
+
+        $this->js(true)->tab($this->settings);
 
         if ($this->owner->activeTabName === $this->name) {
             $this->js(true)->click();

--- a/src/Tabs.php
+++ b/src/Tabs.php
@@ -18,14 +18,15 @@ class Tabs extends View
      *
      * @param string|Tab $name     Name of tab or Tab object
      * @param callable   $callback Callback action or URL (or array with url + parameters)
+     * @param array      $settings Tab setting
      *
-     * @throws Exception
+     *@throws Exception
      *
      * @return View
      */
-    public function addTab($name, $callback = null)
+    public function addTab($name, $callback = null, $settings = [])
     {
-        $item = $this->addTabMenuItem($name);
+        $item = $this->addTabMenuItem($name, $settings);
         $sub = $this->addSubView($item->name);
 
         // if there is callback action, then use VirtualPage
@@ -43,14 +44,15 @@ class Tabs extends View
      * Adds dynamic tab in tabs widget which will load a separate
      * page/url when activated.
      *
-     * @param string|Tab   $name Name of tab or Tab object
-     * @param string|array $url  URL to open inside a tab
+     * @param string|Tab   $name     Name of tab or Tab object
+     * @param string|array $url      URL to open inside a tab
+     * @param array        $settings Tab setting
      *
      * @throws Exception
      */
-    public function addTabURL($name, $url)
+    public function addTabURL($name, $url, $settings = [])
     {
-        $item = $this->addTabMenuItem($name);
+        $item = $this->addTabMenuItem($name, $settings);
         $this->addSubView($item->name);
 
         $item->setPath($url);
@@ -59,13 +61,14 @@ class Tabs extends View
     /**
      * Add a tab menu item.
      *
-     * @param string|Tab $name name of tab or Tab object
+     * @param string|Tab $name     name of tab or Tab object
+     * @param array      $settings Tab settings
      *
      * @throws Exception
      *
      * @return Tab|View tab menu item view
      */
-    protected function addTabMenuItem($name)
+    protected function addTabMenuItem($name, $settings)
     {
         if (is_object($name)) {
             $tab = $name;
@@ -73,7 +76,7 @@ class Tabs extends View
             $tab = new Tab($name);
         }
 
-        $tab = $this->add([$tab, 'class' => ['item']], 'Menu')
+        $tab = $this->add([$tab, 'class' => ['item'], 'settings' => $settings], 'Menu')
             ->setElement('a')
             ->setAttr('data-tab', $tab->name);
 

--- a/src/jsToast.php
+++ b/src/jsToast.php
@@ -31,6 +31,7 @@ class jsToast implements jsExpressionable
             $this->settings['message'] = $settings;
         }
 
+        // set defautl css class.
         if (!array_key_exists('class', $this->settings)) {
             $this->settings['class'] = $this->defaultCss;
         }

--- a/src/jsToast.php
+++ b/src/jsToast.php
@@ -20,12 +20,19 @@ class jsToast implements jsExpressionable
      */
     public $settings = [];
 
+    /** @var string default css class for toast */
+    public $defaultCss = 'success';
+
     public function __construct($settings = null)
     {
         if ($settings && is_array($settings)) {
             $this->settings = $settings;
         } elseif (is_string($settings)) {
             $this->settings['message'] = $settings;
+        }
+
+        if (!array_key_exists('class', $this->settings)) {
+            $this->settings['class'] = $this->defaultCss;
         }
     }
 


### PR DESCRIPTION
Update to Fomantic 2.8.5
 - Add the possibility to set Fomantic-UI tab settings when adding them.

fixes #992
fixes #1044

Example when you need to pass an argument for the callback:
```
$t->addTab('Dynamic Lorem Ipsum', function ($tab) {
    \atk4\ui\Message::addTo($tab, ['Every time you come to this tab, you will see a different text']);
    \atk4\ui\LoremIpsum::addTo($tab, ['size' => (int) $_GET['size'] ?? 1]);
}, ['apiSettings' => ['data' => ['size' => random_int(1, 4)]]]);
````
