### PR TITLE
Render console exceptions using standard HTML exception renderer

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -1026,14 +1026,6 @@ class App
         return (string) new \atk4\core\ExceptionRenderer\HTML($exception);
     }
 
-    /**
-     * Similar to Exception::getColorfulText() but will use raw HTML for outputting colors.
-     */
-    public function renderExceptionHTMLText(\Throwable $exception): string
-    {
-        return (string) new \atk4\core\ExceptionRenderer\HTMLText($exception);
-    }
-
     protected function setupAlwaysRun(): void
     {
         if ($this->_cwd_restore) {

--- a/src/Console.php
+++ b/src/Console.php
@@ -158,20 +158,16 @@ class Console extends View implements \Psr\Log\LoggerInterface
      *
      * @todo Use $message as template and fill values from $context in there.
      *
-     * @param string $message
-     * @param array  $context
-     *
      * @return $this
      */
-    public function outputHTML($message, $context = [])
+    public function outputHTML(string $message, array $context = [])
     {
         $message = preg_replace_callback('/{([a-z0-9_-]+)}/i', function ($match) use ($context) {
-            if (isset($context[$match[1]]) && is_string($context[$match[1]])) {
+            if (isset($context[$match[1]])) {
                 return $context[$match[1]];
             }
 
-            // don't change the original message
-            return '{' . $match[1] . '}';
+            return '{' . $match[1] . '}'; // don't change the original message
         }, $message);
 
         $this->_output_bypass = true;
@@ -378,7 +374,7 @@ class Console extends View implements \Psr\Log\LoggerInterface
      */
     public function emergency($message, array $context = [])
     {
-        $this->outputHTML("<font color='pink'>" . htmlspecialchars($message) . '</font>', $context);
+        $this->outputHTML('<font color="pink">' . htmlspecialchars($message) . '</font>', $context);
     }
 
     /**
@@ -388,7 +384,7 @@ class Console extends View implements \Psr\Log\LoggerInterface
      */
     public function alert($message, array $context = [])
     {
-        $this->outputHTML("<font color='pink'>" . htmlspecialchars($message) . '</font>', $context);
+        $this->outputHTML('<font color="pink">' . htmlspecialchars($message) . '</font>', $context);
     }
 
     /**
@@ -398,7 +394,7 @@ class Console extends View implements \Psr\Log\LoggerInterface
      */
     public function critical($message, array $context = [])
     {
-        $this->outputHTML("<font color='pink'>" . htmlspecialchars($message) . '</font>', $context);
+        $this->outputHTML('<font color="pink">' . htmlspecialchars($message) . '</font>', $context);
     }
 
     /**
@@ -409,7 +405,7 @@ class Console extends View implements \Psr\Log\LoggerInterface
      */
     public function error($message, array $context = [])
     {
-        $this->outputHTML("<font color='pink'>" . htmlspecialchars($message) . '</font>', $context);
+        $this->outputHTML('<font color="pink">' . htmlspecialchars($message) . '</font>', $context);
     }
 
     /**
@@ -419,7 +415,7 @@ class Console extends View implements \Psr\Log\LoggerInterface
      */
     public function warning($message, array $context = [])
     {
-        $this->outputHTML("<font color='pink'>" . htmlspecialchars($message) . '</font>', $context);
+        $this->outputHTML('<font color="pink">' . htmlspecialchars($message) . '</font>', $context);
     }
 
     /**
@@ -429,7 +425,7 @@ class Console extends View implements \Psr\Log\LoggerInterface
      */
     public function notice($message, array $context = [])
     {
-        $this->outputHTML("<font color='yellow'>" . htmlspecialchars($message) . '</font>', $context);
+        $this->outputHTML('<font color="yellow">' . htmlspecialchars($message) . '</font>', $context);
     }
 
     /**
@@ -439,7 +435,7 @@ class Console extends View implements \Psr\Log\LoggerInterface
      */
     public function info($message, array $context = [])
     {
-        $this->outputHTML("<font color='gray'>" . htmlspecialchars($message) . '</font>', $context);
+        $this->outputHTML('<font color="gray">' . htmlspecialchars($message) . '</font>', $context);
     }
 
     /**
@@ -449,7 +445,7 @@ class Console extends View implements \Psr\Log\LoggerInterface
      */
     public function debug($message, array $context = [])
     {
-        $this->outputHTML("<font color='cyan'>" . htmlspecialchars($message) . '</font>', $context);
+        $this->outputHTML('<font color="cyan">' . htmlspecialchars($message) . '</font>', $context);
     }
 
     /**

--- a/src/Console.php
+++ b/src/Console.php
@@ -108,7 +108,8 @@ class Console extends View implements \Psr\Log\LoggerInterface
 
                 call_user_func($callback, $this);
             } catch (\Throwable $e) {
-                $this->outputHTML('<div style="white-space: normal; font-family: Lato,\'Helvetica Neue\',Arial,Helvetica,sans-serif;">{0}</div>', [$this->app->renderExceptionHTML($e)]);
+                $this->output('');
+                $this->outputHTML('<div class="ui segment" style="white-space: normal; font-family: Lato,\'Helvetica Neue\',Arial,Helvetica,sans-serif;">{0}</div>', [$this->app->renderExceptionHTML($e)]);
             }
 
             if (isset($this->app)) {

--- a/src/Console.php
+++ b/src/Console.php
@@ -108,7 +108,7 @@ class Console extends View implements \Psr\Log\LoggerInterface
 
                 call_user_func($callback, $this);
             } catch (\Throwable $e) {
-                $this->outputHTML('<div style="white-space: normal;">{0}</div>', [$this->app->renderExceptionHTML($e)]);
+                $this->outputHTML('<div style="white-space: normal; font-family: Lato,\'Helvetica Neue\',Arial,Helvetica,sans-serif;">{0}</div>', [$this->app->renderExceptionHTML($e)]);
             }
 
             if (isset($this->app)) {

--- a/src/Console.php
+++ b/src/Console.php
@@ -108,7 +108,7 @@ class Console extends View implements \Psr\Log\LoggerInterface
 
                 call_user_func($callback, $this);
             } catch (\Throwable $e) {
-                $this->outputHTML('{0}', [$this->app->renderExceptionHTML($e)]);
+                $this->outputHTML('<div style="white-space: normal;">{0}</div>', [$this->app->renderExceptionHTML($e)]);
             }
 
             if (isset($this->app)) {

--- a/src/Console.php
+++ b/src/Console.php
@@ -108,11 +108,7 @@ class Console extends View implements \Psr\Log\LoggerInterface
 
                 call_user_func($callback, $this);
             } catch (\Throwable $e) {
-                $lines = preg_split('~\r?\n|\r~', $this->app->renderExceptionHTMLText($e));
-
-                foreach ($lines as $line) {
-                    $this->outputHTML($line);
-                }
+                $this->outputHTML('{0}', [$this->app->renderExceptionHTML($e)]);
             }
 
             if (isset($this->app)) {


### PR DESCRIPTION
Reuse HTML table rendering for outputting console stack traces, technically improving code reuse.

## Current behaviour:

<img width="1470" alt="Screenshot 2020-06-08 at 15 46 09" src="https://user-images.githubusercontent.com/453929/84044236-360df500-a99f-11ea-8c24-fa01f7075d24.png">


## Example after change:
![image](https://user-images.githubusercontent.com/2228672/83938850-59d30e80-a7d8-11ea-85f3-e196d09f0cb5.png)

## Other info

no BC break from code point of view (only different UX)

`App::renderExceptionHTMLText()` was introduced not that long by my in another refactoring...
