### PR TITLE
Always convert large (>= 2^53) integers to string in JSON output

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -1015,12 +1015,12 @@ class App
         // replace large integers only, do not replace anything in JSON/JS strings
         $json = preg_replace_callback('~(?:"(?:[^"\\\\]+|\\\\.)*")?+\K|(?:\'(?:[^\'\\\\]+|\\\\.)*\')?+\K|(?:^|[{\[,:])'
             . '[ \n\r\t]*\K-?[1-9]\d{15,}(?=[ \n\r\t]*(?:$|[}\],:]))~s', function ($matches) { // strlen(1 << 53) = 16
-            if ($matches[0] === '' || abs((int) $matches[0]) < (1 << 53)) {
-                return $matches[0];
-            }
+                if ($matches[0] === '' || abs((int) $matches[0]) < (1 << 53)) {
+                    return $matches[0];
+                }
 
-            return '"' . $matches[0] . '"';
-        }, $json);
+                return '"' . $matches[0] . '"';
+            }, $json);
 
         return $json;
     }

--- a/src/App.php
+++ b/src/App.php
@@ -1012,7 +1012,8 @@ class App
         }
 
         // IMPORTANT: always convert large integers to string, otherwise numbers can be rounded by JS
-        $json = preg_replace_callback('~(?:"(?:[^"\\\\]+|\\\\.)*")?+\K|(?:^|[{\[,:])[ \n\r\t]*\K-?[1-9]\d{15,}(?=[ \n\r\t]*(?:$|[}\],:]))~s', function($matches) {
+        // replace large integers only, do not replace anything in JSON/JS strings
+        $json = preg_replace_callback('~(?:"(?:[^"\\\\]+|\\\\.)*")?+\K|(?:\'(?:[^\'\\\\]+|\\\\.)*\')?+\K|(?:^|[{\[,:])[ \n\r\t]*\K-?[1-9]\d{15,}(?=[ \n\r\t]*(?:$|[}\],:]))~s', function ($matches) {
             if ($matches[0] === '' || abs((int) $matches[0]) < (1 << 53)) { // strlen(1 << 53) = 16
                 return $matches[0];
             }

--- a/src/App.php
+++ b/src/App.php
@@ -1013,12 +1013,13 @@ class App
 
         // IMPORTANT: always convert large integers to string, otherwise numbers can be rounded by JS
         // replace large integers only, do not replace anything in JSON/JS strings
-        $json = preg_replace_callback('~(?:"(?:[^"\\\\]+|\\\\.)*")?+\K|(?:\'(?:[^\'\\\\]+|\\\\.)*\')?+\K|(?:^|[{\[,:])[ \n\r\t]*\K-?[1-9]\d{15,}(?=[ \n\r\t]*(?:$|[}\],:]))~s', function ($matches) {
-            if ($matches[0] === '' || abs((int) $matches[0]) < (1 << 53)) { // strlen(1 << 53) = 16
+        $json = preg_replace_callback('~(?:"(?:[^"\\\\]+|\\\\.)*")?+\K|(?:\'(?:[^\'\\\\]+|\\\\.)*\')?+\K|(?:^|[{\[,:])'
+            . '[ \n\r\t]*\K-?[1-9]\d{15,}(?=[ \n\r\t]*(?:$|[}\],:]))~s', function ($matches) { // strlen(1 << 53) = 16
+            if ($matches[0] === '' || abs((int) $matches[0]) < (1 << 53)) {
                 return $matches[0];
             }
 
-            return '"' . $matches[0] . "'";
+            return '"' . $matches[0] . '"';
         }, $json);
 
         return $json;

--- a/src/App.php
+++ b/src/App.php
@@ -1013,14 +1013,16 @@ class App
 
         // IMPORTANT: always convert large integers to string, otherwise numbers can be rounded by JS
         // replace large JSON integers only, do not replace anything in JSON/JS strings
-        $json = preg_replace_callback('~(?:"(?:[^"\\\\]+|\\\\.)*")?+\K|(?:\'(?:[^\'\\\\]+|\\\\.)*\')?+\K|(?:^|[{\[,:])'
-            . '[ \n\r\t]*\K-?[1-9]\d{15,}(?=[ \n\r\t]*(?:$|[}\],:]))~s', function ($matches) { // strlen(1 << 53) = 16
-                if ($matches[0] === '' || abs((int) $matches[0]) < (1 << 53)) {
-                    return $matches[0];
-                }
+        if ($this->isJsRequest()) {
+            $json = preg_replace_callback('~(?:"(?:[^"\\\\]+|\\\\.)*")?+\K|(?:\'(?:[^\'\\\\]+|\\\\.)*\')?+\K|(?:^|[{\[,:])'
+                . '[ \n\r\t]*\K-?[1-9]\d{15,}(?=[ \n\r\t]*(?:$|[}\],:]))~s', function ($matches) { // strlen(1 << 53) = 16
+                    if ($matches[0] === '' || abs((int) $matches[0]) < (1 << 53)) {
+                        return $matches[0];
+                    }
 
-                return '"' . $matches[0] . '"';
-            }, $json);
+                    return '"' . $matches[0] . '"';
+                }, $json);
+        }
 
         return $json;
     }

--- a/src/App.php
+++ b/src/App.php
@@ -1012,7 +1012,7 @@ class App
         }
 
         // IMPORTANT: always convert large integers to string, otherwise numbers can be rounded by JS
-        // replace large integers only, do not replace anything in JSON/JS strings
+        // replace large JSON integers only, do not replace anything in JSON/JS strings
         $json = preg_replace_callback('~(?:"(?:[^"\\\\]+|\\\\.)*")?+\K|(?:\'(?:[^\'\\\\]+|\\\\.)*\')?+\K|(?:^|[{\[,:])'
             . '[ \n\r\t]*\K-?[1-9]\d{15,}(?=[ \n\r\t]*(?:$|[}\],:]))~s', function ($matches) { // strlen(1 << 53) = 16
                 if ($matches[0] === '' || abs((int) $matches[0]) < (1 << 53)) {

--- a/src/App.php
+++ b/src/App.php
@@ -1013,16 +1013,14 @@ class App
 
         // IMPORTANT: always convert large integers to string, otherwise numbers can be rounded by JS
         // replace large JSON integers only, do not replace anything in JSON/JS strings
-        if ($this->isJsRequest()) {
-            $json = preg_replace_callback('~(?:"(?:[^"\\\\]+|\\\\.)*")?+\K|(?:\'(?:[^\'\\\\]+|\\\\.)*\')?+\K|(?:^|[{\[,:])'
-                . '[ \n\r\t]*\K-?[1-9]\d{15,}(?=[ \n\r\t]*(?:$|[}\],:]))~s', function ($matches) { // strlen(1 << 53) = 16
-                    if ($matches[0] === '' || abs((int) $matches[0]) < (1 << 53)) {
-                        return $matches[0];
-                    }
+        $json = preg_replace_callback('~(?:"(?:[^"\\\\]+|\\\\.)*")?+\K|(?:\'(?:[^\'\\\\]+|\\\\.)*\')?+\K|(?:^|[{\[,:])'
+            . '[ \n\r\t]*\K-?[1-9]\d{15,}(?=[ \n\r\t]*(?:$|[}\],:]))~s', function ($matches) { // strlen(1 << 53) = 16
+                if ($matches[0] === '' || abs((int) $matches[0]) < (1 << 53)) {
+                    return $matches[0];
+                }
 
-                    return '"' . $matches[0] . '"';
-                }, $json);
-        }
+                return '"' . $matches[0] . '"';
+            }, $json);
 
         return $json;
     }

--- a/src/App.php
+++ b/src/App.php
@@ -750,10 +750,8 @@ class App
 
     /**
      * Request was made using App::jsURL().
-     *
-     * @return bool
      */
-    public function isJsUrlRequest()
+    public function isJsUrlRequest(): bool
     {
         return isset($_GET['__atk_json']) && $_GET['__atk_json'] !== '0';
     }

--- a/src/App.php
+++ b/src/App.php
@@ -269,7 +269,7 @@ class App
         // remove header
         $this->layout->template->tryDel('Header');
 
-        if (($this->isJsRequest() || strtolower($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '') === 'xmlhttprequest')
+        if (($this->isJsUrlRequest() || strtolower($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '') === 'xmlhttprequest')
                 && !isset($_GET['__atk_tab'])) {
             $this->outputResponseJSON([
                 'success' => false,
@@ -547,7 +547,7 @@ class App
         }
 
         $output = ob_get_clean();
-        if ($this->isJsRequest()) {
+        if ($this->isJsUrlRequest()) {
             $this->outputResponseJSON($output);
         } else {
             $this->outputResponseHTML($output);
@@ -753,7 +753,7 @@ class App
      *
      * @return bool
      */
-    public function isJsRequest()
+    public function isJsUrlRequest()
     {
         return isset($_GET['__atk_json']) && $_GET['__atk_json'] !== '0';
     }

--- a/src/App.php
+++ b/src/App.php
@@ -1014,7 +1014,7 @@ class App
         // IMPORTANT: always convert large integers to string, otherwise numbers can be rounded by JS
         // replace large JSON integers only, do not replace anything in JSON/JS strings
         $json = preg_replace_callback('~(?:"(?:[^"\\\\]+|\\\\.)*")?+\K|(?:\'(?:[^\'\\\\]+|\\\\.)*\')?+\K|(?:^|[{\[,:])'
-            . '[ \n\r\t]*\K-?[1-9]\d{15,}(?=[ \n\r\t]*(?:$|[}\],:]))~s', function ($matches) { // strlen(1 << 53) = 16
+            . '[ \n\r\t]*\K-?[1-9]\d{15,}(?=[ \n\r\t]*(?:$|[}\],:]))~s', function ($matches) {
                 if ($matches[0] === '' || abs((int) $matches[0]) < (1 << 53)) {
                     return $matches[0];
                 }

--- a/src/App.php
+++ b/src/App.php
@@ -1011,6 +1011,15 @@ class App
             throw new Exception('JSON encode error: ' . json_last_error_msg());
         }
 
+        // IMPORTANT: always convert large integers to string, otherwise numbers can be rounded by JS
+        $json = preg_replace_callback('~(?:"(?:[^"\\\\]+|\\\\.)*")?+\K|(?:^|[{\[,:])[ \n\r\t]*\K-?[1-9]\d{15,}(?=[ \n\r\t]*(?:$|[}\],:]))~s', function($matches) {
+            if ($matches[0] === '' || abs((int) $matches[0]) < (1 << 53)) { // strlen(1 << 53) = 16
+                return $matches[0];
+            }
+
+            return '"' . $matches[0] . "'";
+        }, $json);
+
         return $json;
     }
 

--- a/tests/jsTest.php
+++ b/tests/jsTest.php
@@ -32,6 +32,23 @@ class jsTest extends AtkPhpunit\TestCase
             [true, 'true'],
         ] as [$in, $expected]) {
             $this->assertSame($expected, (new jsExpression('[]', [$in]))->jsRender());
+
+            // test JSON renderer in App too
+            // test extensively because of (possibly fragile) custom regex impl
+            $app = new \atk4\ui\App();
+            foreach ([
+                [$expected, $in], // direct value
+                [[$expected => 'x'], [$in => 'x']], // as key
+                [[$expected], [$in]], // as value in JSON array
+                [['x' => $expected], ['x' => $in]], // as value in JSON object
+            ] as [$expectedData, $inData]) {
+                $expectedDataJson = json_encode($expectedData);
+                $this->assertJsonStringEqualsJsonString($expectedDataJson, $app->encodeJson($inData));
+
+                // do not change any numbers to string in JSON/JS strings
+                $inDataJson = json_encode($inData);
+                $this->assertSame(json_encode(['x' => $inDataJson]), $app->encodeJson(['x' => $inDataJson]));
+            }
         }
     }
 

--- a/tests/jsTest.php
+++ b/tests/jsTest.php
@@ -36,18 +36,18 @@ class jsTest extends AtkPhpunit\TestCase
             // test JSON renderer in App too
             // test extensively because of (possibly fragile) custom regex impl
             $app = new \atk4\ui\App();
+            $expectedRaw = json_decode($expected);
             foreach ([
-                [$expected, $in], // direct value
-                [[$expected => 'x'], [$in => 'x']], // as key
-                [[$expected], [$in]], // as value in JSON array
-                [['x' => $expected], ['x' => $in]], // as value in JSON object
+                [$expectedRaw, $in], // direct value
+                [[$expectedRaw => 'x'], [$in => 'x']], // as key
+                [[$expectedRaw], [$in]], // as value in JSON array
+                [['x' => $expectedRaw], ['x' => $in]], // as value in JSON object
             ] as [$expectedData, $inData]) {
-                $expectedDataJson = json_encode($expectedData);
-                $this->assertJsonStringEqualsJsonString($expectedDataJson, $app->encodeJson($inData));
+                $this->assertSame(json_encode($expectedData), preg_replace('~\s+~', '', $app->encodeJson($inData)));
 
                 // do not change any numbers to string in JSON/JS strings
                 $inDataJson = json_encode($inData);
-                $this->assertSame(json_encode(['x' => $inDataJson]), $app->encodeJson(['x' => $inDataJson]));
+                $this->assertSame(json_encode(['x' => $inDataJson]), preg_replace('~\s+~', '', $app->encodeJson(['x' => $inDataJson])));
             }
         }
     }

--- a/tests/jsTest.php
+++ b/tests/jsTest.php
@@ -35,12 +35,7 @@ class jsTest extends AtkPhpunit\TestCase
 
             // test JSON renderer in App too
             // test extensively because of (possibly fragile) custom regex impl
-            $app = new class() extends \atk4\ui\App {
-                public function isJsRequest()
-                {
-                    return true;
-                }
-            };
+            $app = new \atk4\ui\App();
             $expectedRaw = json_decode($expected);
             foreach ([
                 [$expectedRaw, $in], // direct value

--- a/tests/jsTest.php
+++ b/tests/jsTest.php
@@ -35,7 +35,12 @@ class jsTest extends AtkPhpunit\TestCase
 
             // test JSON renderer in App too
             // test extensively because of (possibly fragile) custom regex impl
-            $app = new \atk4\ui\App();
+            $app = new class() extends \atk4\ui\App {
+                public function isJsRequest()
+                {
+                    return true;
+                }
+            };
             $expectedRaw = json_decode($expected);
             foreach ([
                 [$expectedRaw, $in], // direct value


### PR DESCRIPTION
fixes https://github.com/atk4/ui/issues/1258 , issue reintroduced in https://github.com/atk4/ui/issues/1258

Very hackery, but intended as `App::encodeJson()` can be called with array with JsonSerializable objects which can produce JS functions (in theory anything) which is no longer valid JSON to reparse.

This approach should safe for JSON/JS strings (ie. nothing is converted in them).

BC breaking changes:
- (>= 2^53) integers in JSON output are always converted to strings to be safe in JS
- method `App::isJsRequest()` was renamed to `App::isJsUrlRequest()`