### PR TITLE
Improve Fix/layout switching #1263

### DIFF
--- a/demos/atk-init.php
+++ b/demos/atk-init.php
@@ -45,8 +45,7 @@ if (file_exists(__DIR__ . '/../public/atkjs-ui.min.js')) {
 }
 
 // allow custom layout override
-$layoutClass = $app->stickyGET('layout') ? 'atk4\ui\Layout\\' . $app->stickyGET('layout') : \atk4\ui\Layout\Maestro::class;
-$app->initLayout(\atk4\ui\Layout\Generic::factory([$layoutClass]));
+$app->initLayout($app->stickyGET('layout') ? 'atk4\ui\Layout\\' . $app->stickyGET('layout') : \atk4\ui\Layout\Maestro::class);
 
 $layout = $app->layout;
 // Need for phpunit only for producing right url.

--- a/demos/atk-init.php
+++ b/demos/atk-init.php
@@ -44,9 +44,9 @@ if (file_exists(__DIR__ . '/../public/atkjs-ui.min.js')) {
     $app->cdn['atk'] = $rootUrl . 'public';
 }
 
-// enable layout change.
-$layout = '\\atk4\\ui\Layout\\' . ($app->stickyGET('layout') ?: 'Maestro');
-$app->initLayout(new $layout());
+// allow custom layout override
+$layoutClass = $app->stickyGET('layout') ? 'atk4\ui\Layout\\' . $app->stickyGET('layout') : \atk4\ui\Layout\Maestro::class;
+$app->initLayout(\atk4\ui\Layout\Generic::factory([$layoutClass]));
 
 $layout = $app->layout;
 // Need for phpunit only for producing right url.


### PR DESCRIPTION
PR good, but class paths must be always refered with ::class and never manupulated like strings/concated/prefixed

no functional change, leaving the URL input manually prefixed