### PR TITLE
Delete .github_changelog_generator

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,4 +1,0 @@
-unreleased-only=true
-since-tag=1.5.7
-usernames-as-github-logins=true
-base=CHANGELOG.md


### PR DESCRIPTION
related with https://github.com/atk4/ui/pull/1234@romaninsh or is it still needed? (it is not in other repos)