### PR TITLE
Do not use deprecated properties to check trait presence

### DIFF
--- a/src/TableColumn/FilterModel/Generic.php
+++ b/src/TableColumn/FilterModel/Generic.php
@@ -97,23 +97,21 @@ class Generic extends Model
     {
         $this->addField('name', ['default' => $this->lookupField->short_name, 'system' => true]);
 
-        if (isset($this->_sessionTrait) && $this->_sessionTrait) {
-            // create a name for our filter model to save as session data.
-            $this->name = 'filter_model_' . $this->lookupField->short_name;
+        // create a name for our filter model to save as session data.
+        $this->name = 'filter_model_' . $this->lookupField->short_name;
 
-            if ($_GET['atk_clear_filter'] ?? false) {
-                $this->forget();
-            }
-
-            if ($data = $this->recallData()) {
-                $this->persistence->data['data'][] = $data;
-            }
-
-            // Add hook in order to persist data in session.
-            $this->onHook(Model::HOOK_AFTER_SAVE, function ($m) {
-                $this->memorize('data', $m->get());
-            });
+        if ($_GET['atk_clear_filter'] ?? false) {
+            $this->forget();
         }
+
+        if ($data = $this->recallData()) {
+            $this->persistence->data['data'][] = $data;
+        }
+
+        // Add hook in order to persist data in session.
+        $this->onHook(Model::HOOK_AFTER_SAVE, function ($m) {
+            $this->memorize('data', $m->get());
+        });
     }
 
     /**

--- a/src/View.php
+++ b/src/View.php
@@ -423,16 +423,7 @@ class View implements jsExpressionable
                     ->addMoreInfo('region_type', gettype($region));
             }
 
-            if (isset($object->_DIContainerTrait)) {
-                $object->setDefaults(['region' => $region]);
-            } else {
-                if (!property_exists($object, 'region')) {
-                    throw (new Exception('Region property is not defined'))
-                        ->addMoreInfo('object_class', get_class($object));
-                }
-
-                $object->region = $region;
-            }
+            $object->setDefaults(['region' => $region]);
         }
 
         // will call init() of the object


### PR DESCRIPTION
related with https://github.com/atk4/core/pull/227

- DIContainer is highly expected on added objects
- Sesstion trait check was redundand (checked only on `$this`, but a few lines above the trait was added to that class)