### PR TITLE
Fix demos autoload if not installed as a main composer project

### DIFF
--- a/demos/atk-init.php
+++ b/demos/atk-init.php
@@ -2,7 +2,14 @@
 
 namespace atk4\ui\demo;
 
-require_once __DIR__ . '/../vendor/autoload.php';
+if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+    require_once __DIR__ . '/../vendor/autoload.php';
+} else {
+    require_once __DIR__ . '/../../../../vendor/autoload.php';
+    if (!class_exists(\atk4\ui\tests\ViewTest::class)) {
+        throw new \Error('Demos can be run only if atk4/ui is a main composer project or if dev files are autoloaded');
+    }
+}
 
 date_default_timezone_set('UTC');
 

--- a/demos/atk-init.php
+++ b/demos/atk-init.php
@@ -15,7 +15,7 @@ date_default_timezone_set('UTC');
 
 // START - PHPUNIT & COVERAGE SETUP
 if (file_exists(__DIR__ . '/coverage.php')) {
-    include_once __DIR__ . '/coverage.php';
+    require_once __DIR__ . '/coverage.php';
 }
 
 require_once __DIR__ . '/database.php';

--- a/demos/index.php
+++ b/demos/index.php
@@ -2,7 +2,7 @@
 
 namespace atk4\ui\demo;
 
-include_once __DIR__ . '/atk-init.php';
+require_once __DIR__ . '/atk-init.php';
 
 \atk4\ui\Header::addTo($app)->set('Welcome to Agile Toolkit Demo!!');
 

--- a/demos/layout/layouts_admin.php
+++ b/demos/layout/layouts_admin.php
@@ -2,9 +2,7 @@
 
 namespace atk4\ui\demo;
 
-// Demonstrates how to use layouts.
-chdir('..');
-include_once '../vendor/autoload.php';
+require_once __DIR__ . '/../atk-init.php';
 
 try {
     $app = new \atk4\ui\App('Agile Toolkit Demo App');

--- a/demos/layout/layouts_manual.php
+++ b/demos/layout/layouts_manual.php
@@ -2,9 +2,7 @@
 
 namespace atk4\ui\demo;
 
-// Demonstrates how to use layouts.
-chdir('..');
-include_once '../vendor/autoload.php';
+require_once __DIR__ . '/../atk-init.php';
 include_once '_includes/somedatadef.php';
 
 date_default_timezone_set('UTC');

--- a/demos/layout/layouts_manual.php
+++ b/demos/layout/layouts_manual.php
@@ -3,7 +3,7 @@
 namespace atk4\ui\demo;
 
 require_once __DIR__ . '/../atk-init.php';
-include_once '_includes/somedatadef.php';
+include_once __DIR__ . '/../_includes/somedatadef.php';
 
 date_default_timezone_set('UTC');
 

--- a/demos/layout/layouts_manual.php
+++ b/demos/layout/layouts_manual.php
@@ -3,7 +3,7 @@
 namespace atk4\ui\demo;
 
 require_once __DIR__ . '/../atk-init.php';
-include_once __DIR__ . '/../_includes/somedatadef.php';
+require_once __DIR__ . '/../_includes/somedatadef.php';
 
 date_default_timezone_set('UTC');
 

--- a/demos/layout/layouts_manual.php
+++ b/demos/layout/layouts_manual.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/../_includes/somedatadef.php';
 
 date_default_timezone_set('UTC');
 
-$layout = new \atk4\ui\Layout\Generic(['defaultTemplate' => './templates/layout1.html']);
+$layout = new \atk4\ui\Layout\Generic(['defaultTemplate' => __DIR__ . '/../templates/layout1.html']);
 
 try {
     \atk4\ui\Lister::addTo($layout, [], ['Report'])

--- a/demos/layout/layouts_nolayout.php
+++ b/demos/layout/layouts_nolayout.php
@@ -2,8 +2,7 @@
 
 namespace atk4\ui\demo;
 
-chdir('..');
-include_once '../vendor/autoload.php';
+require_once __DIR__ . '/../atk-init.php';
 
 // nothing to do with Agile UI - will not use any Layout
 $a = new \atk4\ui\LoremIpsum();

--- a/src/App.php
+++ b/src/App.php
@@ -101,9 +101,6 @@ class App
     public $exit_called = false;
 
     /** @var bool */
-    public $_cwd_restore = true;
-
-    /** @var bool */
     public $is_rendering = false;
 
     /** @var UI */
@@ -1014,16 +1011,8 @@ class App
 
     protected function setupAlwaysRun(): void
     {
-        if ($this->_cwd_restore) {
-            $this->_cwd_restore = getcwd();
-        }
-
         register_shutdown_function(
             function () {
-                if (is_string($this->_cwd_restore)) {
-                    chdir($this->_cwd_restore);
-                }
-
                 if (!$this->run_called) {
                     try {
                         $this->run();

--- a/src/Template.php
+++ b/src/Template.php
@@ -630,7 +630,6 @@ class Template implements \ArrayAccess
         }
 
         throw (new Exception('Unable to read template from file'))
-            ->addMoreInfo('cwd', getcwd())
             ->addMoreInfo('file', $filename);
     }
 

--- a/tools/get-assets.php
+++ b/tools/get-assets.php
@@ -1,6 +1,7 @@
 <?php
 
-include_once __DIR__ . '/vendor/autoload.php';
+require_once __DIR__ . '/../vendor/autoload.php';
+
 class GetAssets extends \atk4\ui\App
 {
     public $always_run = false;


### PR DESCRIPTION
now we can run demos/tests even if this repo is within parent project (is in vendor dir)

in parent project you require the dev dependencies like:
```
    "require-dev": {
        "friendsofphp/php-cs-fixer": "^2.16",
        "guzzlehttp/guzzle": "^6.3",
        "phpunit/phpcov": "*",
        "phpunit/phpunit": "^9.0",
        "symfony/process": "^4.3 || ^5.0"
    },
    "autoload-dev": {
        "psr-4": {
            "atk4\\ui\\tests\\": "vendor/atk4/ui/tests/"
        }
    }
```

This PR also removes no longer needed `App::_cwd_restore` prop.