### PR TITLE
Cache template files in memory

### DIFF
--- a/src/Template.php
+++ b/src/Template.php
@@ -18,6 +18,9 @@ class Template implements \ArrayAccess
     use \atk4\core\DIContainerTrait; // needed for StaticAddToTrait, removed once php7.2 support is dropped
     use \atk4\core\StaticAddToTrait;
 
+    /** @var array */
+    private static $_filesCache = [];
+
     // {{{ Properties of a template
 
     /**
@@ -644,17 +647,21 @@ class Template implements \ArrayAccess
      *
      * @return $this|false
      */
-    public function tryLoad($filename)
+    public function tryLoad(string $filename)
     {
-        if (is_readable($filename) && is_file($filename)) {
-            $str = preg_replace('~(?:\r\n?|\n)$~s', '', file_get_contents($filename)); // load file and trim end NL
-            $this->loadTemplateFromString($str);
-            $this->source = 'loaded from file: ' . $filename;
-
-            return $this;
+        if (!isset(self::$_filesCache[$filename])) {
+            self::$_filesCache[$filename] = is_file($filename) ? file_get_contents($filename) : false;
         }
 
-        return false;
+        if (self::$_filesCache[$filename] === false) {
+            return false;
+        }
+
+        $str = preg_replace('~(?:\r\n?|\n)$~s', '', self::$_filesCache[$filename]); // always trim end NL
+        $this->loadTemplateFromString($str);
+        $this->source = 'loaded from file: ' . $filename;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
This change cuts the testing time from 8.6 seconds to 1.2 seconds.

But it is not related with tests, it actually improves the total load time!

In reality, the effect is lower:
- as render tree is normally not that large as all demos rendered at once
- tested on Windows, php on linux has much lower FS overhead

But this PR is still great if it can cut the average load time to half with a few lines of code :D

Now we can also think about implementing rendering of tables etc. with full native templating power.

Effect can be measured by a few page refreshes, example on `/demos/collection/crud.php`:

![image](https://user-images.githubusercontent.com/2228672/85051400-bef31080-b197-11ea-927e-53c00188fecf.png)
