### PR TITLE
Add phpdoc to anonymous classes in demos

### DIFF
--- a/demos/_unit-test/console_run.php
+++ b/demos/_unit-test/console_run.php
@@ -9,6 +9,7 @@ use atk4\ui\jsSSE;
 /** @var \atk4\ui\App $app */
 require_once __DIR__ . '/../init-app.php';
 
+/** @var \atk4\ui\View $testRunClass */
 $testRunClass = get_class(new class() extends \atk4\ui\View {
     use \atk4\core\DebugTrait;
 

--- a/demos/basic/button.php
+++ b/demos/basic/button.php
@@ -54,6 +54,8 @@ Button::addTo($bar, ['icon' => 'upload', 'disabled' => true]);
 \atk4\ui\Header::addTo($app, ['Forks Button Component', 'size' => 2]);
 
 // Creating your own button component example
+
+/** @var Button $forkButtonClass */
 $forkButtonClass = get_class(new class(0) extends Button { // need 0 argument here for constructor
     public function __construct($n)
     {

--- a/demos/basic/columns.php
+++ b/demos/basic/columns.php
@@ -68,6 +68,8 @@ $r = $c->addRow();
 /**
  * Example box component with some content, good for putting into columns.
  */
+
+/** @var \atk4\ui\View $boxClass */
 $boxClass = get_class(new class() extends \atk4\ui\View {
     public $ui = 'segment';
     public $content = false;

--- a/demos/collection/crud.php
+++ b/demos/collection/crud.php
@@ -69,6 +69,7 @@ $crud->addModalAction(['icon' => 'cogs'], 'Details', function ($p, $id) use ($cr
 $cc = $c->addColumn();
 \atk4\ui\Header::addTo($cc, ['Cutomizations']);
 
+/** @var \atk4\ui\ActionExecutor\UserAction $myExecutorClass */
 $myExecutorClass = get_class(new class() extends \atk4\ui\ActionExecutor\UserAction {
     public function addFormTo(\atk4\ui\View $view): \atk4\ui\Form
     {

--- a/demos/collection/crud3.php
+++ b/demos/collection/crud3.php
@@ -7,6 +7,7 @@ namespace atk4\ui\demo;
 /** @var \atk4\ui\App $app */
 require_once __DIR__ . '/../init-app.php';
 
+/** @var \atk4\data\Model $modelClass */
 $modelClass = get_class(new class() extends \atk4\data\Model {
     use ModelLockTrait;
 

--- a/demos/collection/multitable.php
+++ b/demos/collection/multitable.php
@@ -8,6 +8,8 @@ namespace atk4\ui\demo;
 require_once __DIR__ . '/../init-app.php';
 
 // Re-usable component implementing counter
+
+/** @var \atk4\ui\Columns $finderClass */
 $finderClass = get_class(new class() extends \atk4\ui\Columns {
     public $route = [];
 

--- a/demos/collection/tablecolumns.php
+++ b/demos/collection/tablecolumns.php
@@ -7,6 +7,7 @@ namespace atk4\ui\demo;
 /** @var \atk4\ui\App $app */
 require_once __DIR__ . '/../init-app.php';
 
+/** @var \atk4\data\Model $modelColorClass */
 $modelColorClass = get_class(new class() extends \atk4\data\Model {
     public function init(): void
     {

--- a/demos/form/form2.php
+++ b/demos/form/form2.php
@@ -72,6 +72,7 @@ $form->onSubmit(function (\atk4\ui\Form $form) {
 
 // ======
 
+/** @var \atk4\data\Model $personClass */
 $personClass = get_class(new class() extends \atk4\data\Model {
     public $table = 'person';
 

--- a/demos/input/multiline.php
+++ b/demos/input/multiline.php
@@ -12,6 +12,7 @@ require_once __DIR__ . '/../init-app.php';
 
 \atk4\ui\Header::addTo($app, ['MultiLine form field', 'icon' => 'database', 'subHeader' => 'Collect/Edit multiple rows of table record.']);
 
+/** @var \atk4\data\Model $inventoryItemClass */
 $inventoryItemClass = get_class(new class() extends \atk4\data\Model {
     public function init(): void
     {

--- a/demos/interactive/console.php
+++ b/demos/interactive/console.php
@@ -7,6 +7,7 @@ namespace atk4\ui\demo;
 /** @var \atk4\ui\App $app */
 require_once __DIR__ . '/../init-app.php';
 
+/** @var \atk4\ui\View $testRunClass */
 $testRunClass = get_class(new class() extends \atk4\ui\View {
     use \atk4\core\DebugTrait;
 

--- a/demos/interactive/popup.php
+++ b/demos/interactive/popup.php
@@ -15,6 +15,8 @@ require_once __DIR__ . '/../init-app.php';
  * Cart will memorize and restore its items into session. Cart will also
  * render the items.
  */
+
+/** @var \atk4\ui\Lister $cartClass */
 $cartClass = get_class(new class() extends \atk4\ui\Lister {
     use \atk4\core\SessionTrait;
     public $items = [];
@@ -80,6 +82,8 @@ $cartClass = get_class(new class() extends \atk4\ui\Lister {
  * Method linkCart allow you to link ItemShelf with Cart. Clicking on a shelf item will place that
  * item inside a cart reloading it afterwards.
  */
+
+/** @var \atk4\ui\View $itemShelfClass */
 $itemShelfClass = get_class(new class() extends \atk4\ui\View {
     public $ui = 'green segment';
 

--- a/demos/obsolete/notify2.php
+++ b/demos/obsolete/notify2.php
@@ -7,6 +7,7 @@ namespace atk4\ui\demo;
 /** @var \atk4\ui\App $app */
 require_once __DIR__ . '/../init-app.php';
 
+/** @var \atk4\data\Model $notifierClass */
 $notifierClass = get_class(new class() extends \atk4\data\Model {
     public $table = 'notifier';
 

--- a/demos/others/recursive.php
+++ b/demos/others/recursive.php
@@ -7,6 +7,7 @@ namespace atk4\ui\demo;
 /** @var \atk4\ui\App $app */
 require_once __DIR__ . '/../init-app.php';
 
+/** @var \atk4\ui\View $mySwitcherClass */
 $mySwitcherClass = get_class(new class() extends \atk4\ui\View {
     public function init(): void
     {

--- a/demos/others/sticky.php
+++ b/demos/others/sticky.php
@@ -14,6 +14,7 @@ require_once __DIR__ . '/../init-app.php';
     'ui' => 'ignored info message',
 ]);
 
+/** @var \atk4\ui\Button $myButtonClass */
 $myButtonClass = get_class(new class() extends \atk4\ui\Button {
     public function renderView()
     {


### PR DESCRIPTION
partially fixes https://github.com/atk4/ui/issues/1236

I would still prefer moving these classes within `_includes`, but only for shorter per page code and possibly reuse across demos, but this PR solves the hinting/refactoring issue.

Also, the hint type is wrong/fake, it is `string` in reality...