### PR TITLE
Do not handle exception in UserAction executor

### DIFF
--- a/src/UserAction/ModalExecutor.php
+++ b/src/UserAction/ModalExecutor.php
@@ -187,27 +187,23 @@ class ModalExecutor extends Modal implements JsExecutorInterface
         $this->loader->set(function ($modal) {
             $this->jsSetBtnState($modal, $this->step);
 
-            try {
-                switch ($this->step) {
-                    case 'args':
-                        $this->doArgs($modal);
+            switch ($this->step) {
+                case 'args':
+                    $this->doArgs($modal);
 
-                        break;
-                    case 'fields':
-                        $this->doFields($modal);
+                    break;
+                case 'fields':
+                    $this->doFields($modal);
 
-                        break;
-                    case 'preview':
-                        $this->doPreview($modal);
+                    break;
+                case 'preview':
+                    $this->doPreview($modal);
 
-                        break;
-                    case 'final':
-                        $this->doFinal($modal);
+                    break;
+                case 'final':
+                    $this->doFinal($modal);
 
-                        break;
-                }
-            } catch (\Exception $e) {
-                $this->_handleException($e, $modal, $this->step);
+                    break;
             }
         });
     }
@@ -708,25 +704,6 @@ class ModalExecutor extends Modal implements JsExecutorInterface
             }
         } else {
             $view->js(true, $js);
-        }
-    }
-
-    /**
-     * Handle exception.
-     */
-    private function _handleException($e, $view, $step)
-    {
-        $msg = Message::addTo($view, ['Error:', 'type' => 'error']);
-        $msg->text->addParagraph($e->getMessage());
-        $view->js(true, $this->nextStepBtn->js()->addClass('disabled'));
-        if (!$this->isFirstStep($step)) {
-            $this->jsSetPrevHandler($view, $step);
-        }
-        if ($this->isLastStep($step)) {
-            $view->js(true, $this->execActionBtn->js()->addClass('disabled'));
-        }
-        if ($step === 'final') {
-            $this->jsSetPrevHandler($view, $this->steps[count($this->steps) - 1]);
         }
     }
 }


### PR DESCRIPTION
Opening this, because:

1. when modal is opened like with "Add xxx" button in CRUD for new record popup
2. and error is thrown during the action execution like when

like when model to add is defined like:
```
class ZInboundParcel extends \AppAtk4\MyModel {
...
    public function init(): void {
        parent::init();

        ...
        $this->addField('xxx', ['ui' => ['form' => [TextArea::class]]]);
        ...
    }
}
```

to replicate this issue like descibed, you need:
- unix OS (otherwise `TextArea.php` source will be loaded)
- to not use/load `Textarea` class before it
- maybe also no autoload optimalization in composer (not sure, it may normalize class names thus making it CI)

This issue is not about refactoring, it is about supressing great error trace with absolutely unhelpful text

Before:
![image](https://user-images.githubusercontent.com/2228672/85893838-e8ddb000-b7f3-11ea-8fe6-d6872f4a2015.png)


After:
![image](https://user-images.githubusercontent.com/2228672/85893770-cba8e180-b7f3-11ea-8c1f-4c4575900daa.png)

Also notice, that the form was previously rendered, but partly one - WE SHOULD NEVER ALLOW PARTIAL RENDER (and partial submit)

Need to be probably solved a little bit differently - handlers/steps should be reset, but exception handler/renderer from App should be used.