### PR TITLE
Fix Action button icon

### DIFF
--- a/src/Table/Column/ActionButtons.php
+++ b/src/Table/Column/ActionButtons.php
@@ -84,10 +84,6 @@ class ActionButtons extends Table\Column
             $button = $this->factory([\atk4\ui\Button::class], $this->mergeSeeds($button, ['id' => false]));
         }
 
-        if ($button->icon && !is_object($button->icon)) {
-            $button->icon = $this->factory([\atk4\ui\Icon::class], $this->mergeSeeds($button->icon, ['id' => false]));
-        }
-
         $button->app = $this->table->app;
 
         $this->buttons[$name] = $button->addClass('{$_' . $name . '_disabled} compact b_' . $name);


### PR DESCRIPTION
`Button` class already takes care of icons so no need to (wrongly) do that again in ActionButtons class.

Consider example:
```
// create ActionButtons column without title
$column = $this->crud->table->addColumn(null, [ActionButtons::class, 'caption' => '']);

// see 1st parameter - seed for Button class, icon name passed as string
$column->addModal(['icon' => 'key'], 'Change Password', function ($v, $id) {...});
```
