### PR TITLE
Optimize Travis composer install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,9 @@ before_script:
 
     - (cd js; npm install --loglevel=error; npm run build)
     - lessc public/agileui.less public/agileui.css --clean-css="--s1 --advanced" --source-map
+
+    - composer remove --no-interaction --no-update phpunit/phpunit phpunit/phpcov --dev
+    - composer remove --no-interaction --no-update friendsofphp/php-cs-fixer --dev
     - composer install --no-suggest --ansi --prefer-dist --no-interaction --no-progress --optimize-autoloader
 
 script:


### PR DESCRIPTION
It reduces install time from about 35 to 20 seconds.

But still prefer to move Behat to GH actions... :)