### PR TITLE
Fix type check

### DIFF
--- a/src/Form/Control/DropdownCascade.php
+++ b/src/Form/Control/DropdownCascade.php
@@ -43,7 +43,7 @@ class DropdownCascade extends Dropdown
 
         $this->cascadeInput = is_string($this->cascadeFrom) ? $this->form->getControl($this->cascadeFrom) : $this->cascadeFrom;
 
-        if (!$this->cascadeInput instanceof Field) {
+        if (!$this->cascadeInput->field instanceof Field) {
             throw new Exception('cascadeFrom property should be an instance of ' . Field::class);
         }
 


### PR DESCRIPTION
The type check returns a control, not a field, and will always fail. It has to be checked on the field object belonging to the control instead. Tested and working.