### PR TITLE
Use DockerHub registry instead of CFCR

### DIFF
--- a/.codefresh/ui-build-deploy.yaml
+++ b/.codefresh/ui-build-deploy.yaml
@@ -23,7 +23,9 @@ steps:
     type: build
     stage: build
     image_name: atk4/ui-demo
+    registry: crcf
     dockerfile: demos/Dockerfile
+
   push:
     type: push
     stage: push

--- a/.codefresh/ui-build-deploy.yaml
+++ b/.codefresh/ui-build-deploy.yaml
@@ -23,7 +23,7 @@ steps:
     type: build
     stage: build
     image_name: atk4/ui-demo
-    registry: crcf
+    registry: atk4
     dockerfile: demos/Dockerfile
 
   push:


### PR DESCRIPTION
ui.agiletoolkit.org deploy pipeline fails now for a few days because of depreciation in codefresh component. (CFCR is being depreciated).

This PR switches to Docker Hub as the registry:

<img width="1176" alt="Screenshot 2020-07-03 at 10 41 58" src="https://user-images.githubusercontent.com/453929/86456360-dbf01d80-bd19-11ea-869a-bcfe2789bc92.png">



