### PR TITLE
Fix not freed objects/references

### DIFF
--- a/demos/init-app.php
+++ b/demos/init-app.php
@@ -24,6 +24,7 @@ if (file_exists(__DIR__ . '/coverage.php') && !class_exists(\PHPUnit\Framework\T
 $app = new \atk4\ui\App([
     'call_exit' => (bool) ($_GET['APP_CALL_EXIT'] ?? true),
     'catch_exceptions' => (bool) ($_GET['APP_CATCH_EXCEPTIONS'] ?? true),
+    'always_run' => (bool) ($_GET['APP_ALWAYS_RUN'] ?? true),
 ]);
 $app->title = 'Agile UI Demo v' . $app->version;
 

--- a/demos/interactive/accordion-nested.php
+++ b/demos/interactive/accordion-nested.php
@@ -15,8 +15,7 @@ require_once __DIR__ . '/../init-app.php';
 
 \atk4\ui\Header::addTo($app, ['Nested accordions']);
 
-function addAccordion($view, $maxDepth = 2, $level = 0)
-{
+$addAccordionFunc = function ($view, $maxDepth = 2, $level = 0) use (&$addAccordionFunc) {
     $accordion = \atk4\ui\Accordion::addTo($view, ['type' => ['styled', 'fluid']]);
 
     // static section
@@ -24,7 +23,7 @@ function addAccordion($view, $maxDepth = 2, $level = 0)
     \atk4\ui\Message::addTo($i1, ['This content is added on page loaded', 'ui' => 'tiny message']);
     \atk4\ui\LoremIpsum::addTo($i1, ['size' => 1]);
     if ($level < $maxDepth) {
-        addAccordion($i1, $maxDepth, $level + 1);
+        $addAccordionFunc($i1, $maxDepth, $level + 1);
     }
 
     // dynamic section - simple view
@@ -32,7 +31,7 @@ function addAccordion($view, $maxDepth = 2, $level = 0)
         \atk4\ui\Message::addTo($v, ['Every time you open this accordion item, you will see a different text', 'ui' => 'tiny message']);
         \atk4\ui\LoremIpsum::addTo($v, ['size' => 2]);
         if ($level < $maxDepth) {
-            addAccordion($v, $maxDepth, $level + 1);
+            $addAccordionFunc($v, $maxDepth, $level + 1);
         }
     });
 
@@ -46,10 +45,10 @@ function addAccordion($view, $maxDepth = 2, $level = 0)
         });
 
         if ($level < $maxDepth) {
-            addAccordion($v, $maxDepth, $level + 1);
+            $addAccordionFunc($v, $maxDepth, $level + 1);
         }
     });
-}
+};
 
 // add accordion structure
-$a = addAccordion($app);
+$a = $addAccordionFunc($app);

--- a/src/App.php
+++ b/src/App.php
@@ -145,7 +145,7 @@ class App
      *
      * @var int
      */
-    protected $catch_error_types = E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_USER_DEPRECATED;
+    protected $catch_error_types = E_ALL & ~E_NOTICE;
 
     /**
      * Constructor.

--- a/tests/CallbackTest.php
+++ b/tests/CallbackTest.php
@@ -35,7 +35,7 @@ class CallbackTest extends AtkPhpunit\TestCase
 
     protected function setUp(): void
     {
-        $this->app = new AppMock(['always_run' => false]);
+        $this->app = new AppMock(['always_run' => false, 'catch_exceptions' => false]);
         $this->app->initLayout([\atk4\ui\Layout\Centered::class]);
 
         // reset var, between tests

--- a/tests/DemosTest.php
+++ b/tests/DemosTest.php
@@ -26,7 +26,7 @@ class DemosTest extends AtkPhpunit\TestCase
     /** @var array */
     private static $_serverSuperglobalBackup;
 
-    /** @var App Initialized App instance with working DB connection */
+    /** @var Persistence Initialized DB connection */
     private static $_db;
 
     /** @var array */

--- a/tests/DemosTest.php
+++ b/tests/DemosTest.php
@@ -47,7 +47,7 @@ class DemosTest extends AtkPhpunit\TestCase
         if (self::$_db === null) {
             // load demos config
             $initVars = get_defined_vars();
-            $this->setSuperglobalsFromRequest(new Request('GET', 'http://localhost/demos/'));
+            $this->setSuperglobalsFromRequest(new Request('GET', 'http://localhost/demos/?APP_CALL_EXIT=0&APP_CATCH_EXCEPTIONS=0&APP_ALWAYS_RUN=0'));
 
             /** @var App $app */
             require_once static::DEMOS_DIR . '/init-app.php';
@@ -116,16 +116,9 @@ class DemosTest extends AtkPhpunit\TestCase
 
     protected function createTestingApp(): App
     {
-        $app = new class() extends App {
-            protected function setupAlwaysRun(): void
-            {
-                // no register_shutdown_function
-            }
-
+        $app = new class(['call_exit' => false, 'catch_exceptions' => false, 'always_run' => false]) extends App {
             public function callExit($for_shutdown = false): void
             {
-                // TODO is the shutdown hook called somewhere?
-
                 throw new DemosTestExitException();
             }
         };

--- a/tests/DemosTest.php
+++ b/tests/DemosTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace atk4\ui\tests;
 
 use atk4\core\AtkPhpunit;
+use atk4\data\Persistence;
 use atk4\ui\App;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Request;

--- a/tests/DemosTest.php
+++ b/tests/DemosTest.php
@@ -45,40 +45,22 @@ class DemosTest extends AtkPhpunit\TestCase
     protected function setUp(): void
     {
         if (self::$_db === null) {
-            (function () use (&$mem) {
-                // load demos config
-                $initVars = get_defined_vars();
-                $this->setSuperglobalsFromRequest(new Request('GET', 'http://localhost/demos/?APP_CALL_EXIT=0&APP_CATCH_EXCEPTIONS=0&APP_ALWAYS_RUN=0'));
+            // load demos config
+            $initVars = get_defined_vars();
+            $this->setSuperglobalsFromRequest(new Request('GET', 'http://localhost/demos/?APP_CALL_EXIT=0&APP_CATCH_EXCEPTIONS=0&APP_ALWAYS_RUN=0'));
 
-                /** @var App $app */
-                require_once static::DEMOS_DIR . '/init-app.php';
-                $initVars = array_diff_key(get_defined_vars(), $initVars + ['initVars' => true]);
+            /** @var App $app */
+            require_once static::DEMOS_DIR . '/init-app.php';
+            $initVars = array_diff_key(get_defined_vars(), $initVars + ['initVars' => true]);
 
-                if (array_keys($initVars) !== ['app']) {
-                    throw new \atk4\ui\Exception('Demos init must setup only $app variable');
-                }
-
-                self::$_db = $app->db;
-
-                // prevent $app to run on shutdown
-                $app->run_called = true;
-
-                gc_collect_cycles();
-                $mem = memory_get_usage();
-
-                $app->largedata = str_repeat('abcdefgh', 1024 * 1024 / 8);
-            })();
-
-            gc_collect_cycles();
-            $mem2 = memory_get_usage();
-
-            if ($mem2 > $mem) {
-                var_dump($mem);
-                var_dump($mem2);
-
-                echo 'Memory init leak!' . "\n";
-                exit;
+            if (array_keys($initVars) !== ['app']) {
+                throw new \atk4\ui\Exception('Demos init must setup only $app variable');
             }
+
+            self::$_db = $app->db;
+
+            // prevent $app to run on shutdown
+            $app->run_called = true;
         }
     }
 
@@ -157,43 +139,25 @@ class DemosTest extends AtkPhpunit\TestCase
 
             ob_start();
 
-            (function () use ($localPath, &$mem, &$body) {
-                try {
-                    $app = $this->createTestingApp();
-                    require $localPath;
+            try {
+                $app = $this->createTestingApp();
+                require $localPath;
 
-                    if (!$app->run_called) {
-                        $app->run();
-                    }
-                } catch (\Throwable $e) {
-                    // session_start() or ini_set() functions can be used only with native HTTP tests
-                    // override test expectation here to finish there tests cleanly (TODO better to make the code testable without calling these functions)
-                    if ($e instanceof \ErrorException && preg_match('~^(session_start|ini_set)\(\).* headers already sent$~', $e->getMessage())) {
-                        $this->expectExceptionObject($e);
-                    }
-
-                    if (!($e instanceof DemosTestExitException)) {
-                        throw $e;
-                    }
-                } finally {
-                    $body = ob_get_clean();
+                if (!$app->run_called) {
+                    $app->run();
+                }
+            } catch (\Throwable $e) {
+                // session_start() or ini_set() functions can be used only with native HTTP tests
+                // override test expectation here to finish there tests cleanly (TODO better to make the code testable without calling these functions)
+                if ($e instanceof \ErrorException && preg_match('~^(session_start|ini_set)\(\).* headers already sent$~', $e->getMessage())) {
+                    $this->expectExceptionObject($e);
                 }
 
-                gc_collect_cycles();
-                $mem = memory_get_usage();
-
-                $app->largedata = str_repeat('abcdefgh', 1024 * 1024 / 8);
-            })();
-
-            gc_collect_cycles();
-            $mem2 = memory_get_usage();
-
-            if ($mem2 > $mem) {
-                var_dump($mem);
-                var_dump($mem2);
-
-                echo 'Memory demo leak!' . "\n";
-                exit;
+                if (!($e instanceof DemosTestExitException)) {
+                    throw $e;
+                }
+            } finally {
+                $body = ob_get_clean();
             }
 
             [$statusCode, $headers] = \Closure::bind(function () {

--- a/tests/DemosTest.php
+++ b/tests/DemosTest.php
@@ -239,6 +239,12 @@ class DemosTest extends AtkPhpunit\TestCase
         $excludeDirs = ['_demo-data', '_includes', '_unit-test', 'special'];
         $excludeFiles = ['layout/layouts_error.php'];
 
+        // these tests require SessionTrait, more precisely session_start() which we do not support in non-HTTP testing
+        if (static::class === self::class) {
+            $excludeFiles[] = 'collection/tablefilter.php';
+            $excludeFiles[] = 'interactive/popup.php';
+        }
+
         $files = [];
         $files[] = ['index.php'];
         foreach (array_diff(scandir(static::DEMOS_DIR), ['.', '..'], $excludeDirs) as $dir) {
@@ -303,6 +309,13 @@ class DemosTest extends AtkPhpunit\TestCase
 
     public function testWizard(): void
     {
+        // this test requires SessionTrait, more precisely session_start() which we do not support in non-HTTP testing
+        if (static::class === self::class) {
+            $this->assertTrue(true);
+
+            return;
+        }
+
         $response = $this->getResponseFromRequest(
             'interactive/wizard.php?demo_wizard=1&w_form_submit=ajax&__atk_callback=1',
             ['form_params' => [
@@ -376,6 +389,13 @@ class DemosTest extends AtkPhpunit\TestCase
      */
     public function testDemoAssertSseResponse(string $uri): void
     {
+        // this test requires SessionTrait, more precisely session_start() which we do not support in non-HTTP testing
+        if (static::class === self::class) {
+            $this->assertTrue(true);
+
+            return;
+        }
+
         $response = $this->getResponseFromRequest($uri);
         $this->assertSame(200, $response->getStatusCode(), ' Status error on ' . $uri);
 


### PR DESCRIPTION
fixes https://github.com/atk4/ui/issues/1347

the issue was related with `App` which was not GCed as it remained referenced because of `register_shutdown_function` and other global handlers.

example after unit tests were run 5000x in the same process with this PR:
![image](https://user-images.githubusercontent.com/2228672/86532618-cf132b80-becb-11ea-8822-23fa9b86aad6.png)
(originally failed after a few runs...)