### PR TITLE
Refactor render methods

### DIFF
--- a/demos/interactive/popup.php
+++ b/demos/interactive/popup.php
@@ -67,13 +67,13 @@ $cartClass = get_class(new class() extends \atk4\ui\Lister {
     /**
      * renders as a regular lister, but source is the items.
      */
-    public function renderView()
+    protected function renderView(): void
     {
         // memorize items
 
         $this->setSource($this->items);
 
-        return parent::renderView();
+        parent::renderView();
     }
 });
 

--- a/demos/others/sticky.php
+++ b/demos/others/sticky.php
@@ -16,12 +16,12 @@ require_once __DIR__ . '/../init-app.php';
 
 /** @var \atk4\ui\Button $myButtonClass */
 $myButtonClass = get_class(new class() extends \atk4\ui\Button {
-    public function renderView()
+    protected function renderView(): void
     {
         $this->link($this->content);
         $this->addClass('green');
 
-        return parent::renderView();
+        parent::renderView();
     }
 });
 

--- a/docs/view.rst
+++ b/docs/view.rst
@@ -317,7 +317,8 @@ of this view.
 
 You should override this method when necessary and don't forget to execute parent::renderView()::
 
-    function renderView() {
+    protected function renderView(): void
+    {
         if (str_len($this->info) > 100) {
              $this->addClass('tiny');
         }
@@ -368,7 +369,8 @@ Here is a best practice for using custom template::
 
         public $title = 'Default Title';
 
-        function renderView() {
+        protected function renderView(): void
+        {
             parent::renderView();
             $this->template['title'] = $this->title;
         }

--- a/src/Accordion.php
+++ b/src/Accordion.php
@@ -156,7 +156,7 @@ class Accordion extends View
     /**
      * {@inheritdoc}
      */
-    public function renderView()
+    protected function renderView(): void
     {
         if ($this->type) {
             $this->addClass($this->type);

--- a/src/AccordionSection.php
+++ b/src/AccordionSection.php
@@ -30,7 +30,7 @@ class AccordionSection extends View
     /**
      * {@inheritdoc}
      */
-    public function renderView()
+    protected function renderView(): void
     {
         parent::renderView();
 

--- a/src/App.php
+++ b/src/App.php
@@ -399,7 +399,7 @@ class App
     public function terminateJson($output, array $headers = []): void
     {
         if ($output instanceof View) {
-            $output = $output->renderJson();
+            $output = $output->renderToJsonArr();
         }
 
         $this->terminate(

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -63,7 +63,7 @@ class Breadcrumb extends Lister
     /**
      * Renders view.
      */
-    public function renderView()
+    protected function renderView(): void
     {
         $this->setSource($this->path);
 

--- a/src/Button.php
+++ b/src/Button.php
@@ -27,7 +27,7 @@ class Button extends View
      */
     public $iconRight;
 
-    public function renderView()
+    protected function renderView(): void
     {
         if ($this->icon) {
             if (!is_object($this->icon)) {

--- a/src/CardDeck.php
+++ b/src/CardDeck.php
@@ -419,7 +419,7 @@ class CardDeck extends View
         return $this->factory($executor);
     }
 
-    public function renderView()
+    protected function renderView(): void
     {
         if (($this->menu && count($this->menuActions) > 0) || $this->search !== false) {
             View::addTo($this, ['ui' => 'divider'], ['Divider']);

--- a/src/Columns.php
+++ b/src/Columns.php
@@ -73,7 +73,7 @@ class Columns extends View
         return static::addTo($this, [$width, 'ui' => false])->addClass('row');
     }
 
-    public function renderView()
+    protected function renderView(): void
     {
         $width = $this->width ?: $this->calculated_width;
         if ($this->content) {

--- a/src/Component/InlineEdit.php
+++ b/src/Component/InlineEdit.php
@@ -187,7 +187,7 @@ class InlineEdit extends View
     /**
      * Renders View.
      */
-    public function renderView()
+    protected function renderView(): void
     {
         parent::renderView();
 

--- a/src/Component/ItemSearch.php
+++ b/src/Component/ItemSearch.php
@@ -82,7 +82,7 @@ class ItemSearch extends View
         return $model;
     }
 
-    public function renderView()
+    protected function renderView(): void
     {
         $this->class = [];
         $this->template->set('inputCss', $this->inputCss);

--- a/src/Console.php
+++ b/src/Console.php
@@ -179,11 +179,11 @@ class Console extends View implements \Psr\Log\LoggerInterface
         return $this;
     }
 
-    public function renderView()
+    protected function renderView(): void
     {
         $this->addStyle('overflow-x', 'auto');
 
-        return parent::renderView();
+        parent::renderView();
     }
 
     /**

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -62,7 +62,7 @@ class Dropdown extends Lister
         }, ['item' => 'value']);
     }
 
-    public function renderView()
+    protected function renderView(): void
     {
         if (isset($this->js)) {
             $this->js(true)->dropdown($this->js);
@@ -70,6 +70,6 @@ class Dropdown extends Lister
             $this->js(true)->dropdown();
         }
 
-        return parent::renderView();
+        parent::renderView();
     }
 }

--- a/src/Form.php
+++ b/src/Form.php
@@ -608,10 +608,7 @@ class Form extends View
         }
     }
 
-    /**
-     * Renders view.
-     */
-    public function renderView()
+    protected function renderView(): void
     {
         $this->ajaxSubmit();
         if (!empty($this->controlDisplayRules)) {
@@ -619,7 +616,7 @@ class Form extends View
             $this->js(true, new JsConditionalForm($this, $this->fieldsDisplayRules ?: $this->controlDisplayRules, $this->fieldDisplaySelector ?: $this->controlDisplaySelector));
         }
 
-        return parent::renderView();
+        parent::renderView();
     }
 
     /**

--- a/src/Form/Control.php
+++ b/src/Form/Control.php
@@ -118,7 +118,7 @@ class Control extends View
      * It only makes sense to have "name" property inside a field if
      * it was used inside a form.
      */
-    public function renderView()
+    protected function renderView(): void
     {
         if ($this->form) {
             $this->template->trySet('name', $this->short_name);

--- a/src/Form/Control/Calendar.php
+++ b/src/Form/Control/Calendar.php
@@ -38,7 +38,7 @@ class Calendar extends Input
         $this->options[$name] = $value;
     }
 
-    public function renderView()
+    protected function renderView(): void
     {
         if (!$this->icon) {
             switch ($this->type) {

--- a/src/Form/Control/Checkbox.php
+++ b/src/Form/Control/Checkbox.php
@@ -74,7 +74,7 @@ class Checkbox extends Form\Control
     /**
      * Render view.
      */
-    public function renderView()
+    protected function renderView(): void
     {
         $this->template['label'] = $this->label ?: $this->caption;
 
@@ -100,7 +100,7 @@ class Checkbox extends Form\Control
 
         $this->content = null; // no content again
 
-        return parent::renderView();
+        parent::renderView();
     }
 
     /**

--- a/src/Form/Control/Dropdown.php
+++ b/src/Form/Control/Dropdown.php
@@ -272,7 +272,7 @@ class Dropdown extends Input
     /**
      * Renders view.
      */
-    public function renderView()
+    protected function renderView(): void
     {
         if ($this->isMultiple) {
             $this->defaultClass = $this->defaultClass . ' multiple';

--- a/src/Form/Control/DropdownCascade.php
+++ b/src/Form/Control/DropdownCascade.php
@@ -131,7 +131,7 @@ class DropdownCascade extends Dropdown
     {
     }
 
-    public function renderView()
+    protected function renderView(): void
     {
         // can't be multiple selection.
         $this->isMultiple = false;

--- a/src/Form/Control/Input.php
+++ b/src/Form/Control/Input.php
@@ -176,10 +176,7 @@ class Input extends Form\Control
         return $button;
     }
 
-    /**
-     * Renders view.
-     */
-    public function renderView()
+    protected function renderView(): void
     {
         // TODO: I don't think we need the loading state at all.
         if ($this->loading) {

--- a/src/Form/Control/Lookup.php
+++ b/src/Form/Control/Lookup.php
@@ -382,7 +382,7 @@ class Lookup extends Input
         $chain->dropdown($settings);
     }
 
-    public function renderView()
+    protected function renderView(): void
     {
         $this->callback = \atk4\ui\Callback::addTo($this);
         $this->callback->set([$this, 'outputApiResponse']);

--- a/src/Form/Control/Money.php
+++ b/src/Form/Control/Money.php
@@ -20,7 +20,7 @@ class Money extends Input
         return number_format($v, $this->app->ui_persistence->currency_decimals);
     }
 
-    public function renderView()
+    protected function renderView(): void
     {
         if ($this->label === null) {
             $this->label = $this->app->ui_persistence->currency;

--- a/src/Form/Control/Multiline.php
+++ b/src/Form/Control/Multiline.php
@@ -677,7 +677,7 @@ class Multiline extends Form\Control
         return [];
     }
 
-    public function renderView()
+    protected function renderView(): void
     {
         if (!$this->getModel()) {
             throw new Exception('Multiline field needs to have it\'s model setup.');

--- a/src/Form/Control/Radio.php
+++ b/src/Form/Control/Radio.php
@@ -40,10 +40,7 @@ class Radio extends Form\Control
         $this->lister->t_row['_name'] = $this->short_name;
     }
 
-    /**
-     * Renders view.
-     */
-    public function renderView()
+    protected function renderView(): void
     {
         if (!$this->model) {
             $p = new \atk4\data\Persistence\Static_($this->values);
@@ -69,7 +66,7 @@ class Radio extends Form\Control
             $lister->t_row->set('checked', $value === (string) $lister->model->id ? 'checked' : '');
         });
 
-        return parent::renderView();
+        parent::renderView();
     }
 
     /**

--- a/src/Form/Control/TreeItemSelector.php
+++ b/src/Form/Control/TreeItemSelector.php
@@ -145,7 +145,7 @@ class TreeItemSelector extends Form\Control
         return $this->app->ui_persistence->typecastSaveField($this->field, $this->field->get());
     }
 
-    public function renderView()
+    protected function renderView(): void
     {
         parent::renderView();
 

--- a/src/Form/Control/Upload.php
+++ b/src/Form/Control/Upload.php
@@ -222,10 +222,7 @@ class Upload extends Input
         }
     }
 
-    /**
-     * Rendering view.
-     */
-    public function renderView()
+    protected function renderView(): void
     {
         //need before parent rendering.
         if ($this->disabled) {

--- a/src/Form/Layout.php
+++ b/src/Form/Layout.php
@@ -135,7 +135,7 @@ class Layout extends AbstractLayout
     /**
      * Recursively renders this view.
      */
-    public function recursiveRender()
+    protected function recursiveRender(): void
     {
         $labeledControl = $this->inputTemplate->cloneRegion('LabeledControl');
         $noLabelControl = $this->inputTemplate->cloneRegion('NoLabelControl');

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -660,22 +660,20 @@ class Grid extends View
     }
 
     /**
-     * Renders view.
-     *
      * Before rendering take care of data sorting.
      */
-    public function renderView()
+    protected function renderView(): void
     {
         // take care of sorting
         $this->applySort();
 
-        return parent::renderView();
+        parent::renderView();
     }
 
     /**
      * Recursively renders view.
      */
-    public function recursiveRender()
+    protected function recursiveRender(): void
     {
         // bind with paginator
         if ($this->paginator) {
@@ -688,7 +686,7 @@ class Grid extends View
             }
         }
 
-        return parent::recursiveRender();
+        parent::recursiveRender();
     }
 
     /**

--- a/src/Header.php
+++ b/src/Header.php
@@ -57,7 +57,7 @@ class Header extends View
 
     public $defaultTemplate = 'header.html';
 
-    public function renderView()
+    protected function renderView(): void
     {
         if ($this->size) {
             if (is_numeric($this->size)) {
@@ -92,6 +92,6 @@ class Header extends View
             $this->template->set('title', $this->content);
         }
 
-        return parent::renderView();
+        parent::renderView();
     }
 }

--- a/src/Item.php
+++ b/src/Item.php
@@ -23,7 +23,7 @@ class Item extends View
      */
     public $icon;
 
-    public function renderView()
+    protected function renderView(): void
     {
         if ($this->label) {
             Label::addTo($this, [$this->label]);

--- a/src/ItemsPerPageSelector.php
+++ b/src/ItemsPerPageSelector.php
@@ -92,7 +92,7 @@ class ItemsPerPageSelector extends View
         }
     }
 
-    public function renderView()
+    protected function renderView(): void
     {
         $menuItems = [];
         foreach ($this->pageLengthItems as $key => $item) {

--- a/src/JsSearch.php
+++ b/src/JsSearch.php
@@ -77,7 +77,7 @@ class JsSearch extends View
         //$this->input = Form\Control\Line::addTo($this, ['iconLeft' => 'filter',  'action' => new Button(['icon' => 'search', 'ui' => 'button atk-action'])]);
     }
 
-    public function renderView()
+    protected function renderView(): void
     {
         if ($this->placeHolder) {
             $this->template->trySet('Placeholder', $this->placeHolder);

--- a/src/Label.php
+++ b/src/Label.php
@@ -51,7 +51,7 @@ class Label extends View
 
     public $defaultTemplate = 'label.html';
 
-    public function renderView()
+    protected function renderView(): void
     {
         if ($this->icon) {
             $this->icon = Icon::addTo($this, [$this->icon], ['BeforeContent']);
@@ -75,6 +75,6 @@ class Label extends View
             $this->addClass('image');
         }
 
-        return parent::renderView();
+        parent::renderView();
     }
 }

--- a/src/Layout/Admin.php
+++ b/src/Layout/Admin.php
@@ -99,10 +99,7 @@ class Admin extends \atk4\ui\Layout implements NavigableInterface
         return $this->menuLeft->addItem($name, $action);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function renderView()
+    protected function renderView(): void
     {
         if ($this->menuLeft) {
             if (count($this->menuLeft->elements) === 0) {

--- a/src/Layout/Centered.php
+++ b/src/Layout/Centered.php
@@ -43,7 +43,7 @@ class Centered extends \atk4\ui\Layout
         $this->template->trySet('title', $this->app->title);
     }
 
-    public function renderView()
+    protected function renderView(): void
     {
         if ($this->image) {
             $this->template->trySetHtml('HeaderImage', '<img class="ui image" src="' . $this->image . '" alt="' . $this->image_alt . '" />');

--- a/src/Layout/Maestro.php
+++ b/src/Layout/Maestro.php
@@ -36,7 +36,7 @@ class Maestro extends Admin
         return $i;
     }
 
-    public function renderView()
+    protected function renderView(): void
     {
         parent::renderView();
 

--- a/src/Lister.php
+++ b/src/Lister.php
@@ -128,7 +128,7 @@ class Lister extends View
     /** @var int This will count how many rows are rendered. Needed for JsPaginator for example. */
     protected $_rendered_rows_count = 0;
 
-    public function renderView()
+    protected function renderView(): void
     {
         if (!$this->template) {
             throw new Exception('Lister requires you to specify template explicitly');
@@ -136,7 +136,9 @@ class Lister extends View
 
         // if no model is set, don't show anything (even warning)
         if (!$this->model) {
-            return parent::renderView();
+            parent::renderView();
+
+            return;
         }
 
         // Generate template for data row
@@ -172,7 +174,7 @@ class Lister extends View
             $this->jsPaginator->jsIdle();
         }
 
-        return parent::renderView(); //$this->template->render();
+        parent::renderView();
     }
 
     /**

--- a/src/Lister.php
+++ b/src/Lister.php
@@ -109,17 +109,15 @@ class Lister extends View
             $this->model->setLimit($ipp, ($p - 1) * $ipp);
 
             // render this View (it will count rendered records !)
-            $json = $this->renderJson(true, $scrollRegion);
+            $jsonArr = $this->renderToJsonArr(true, $scrollRegion);
 
             // if there will be no more pages, then replace message=Success to let JS know that there are no more records
             if ($this->_rendered_rows_count < $ipp) {
-                $json = json_decode($json, true);
-                $json['message'] = 'Done'; // Done status means - no more requests from JS side
-                $json = json_encode($json);
+                $jsonArr['message'] = 'Done'; // Done status means - no more requests from JS side
             }
 
             // return json response
-            $this->app->terminateJson($json);
+            $this->app->terminateJson($jsonArr);
         });
 
         return $this;

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -93,7 +93,7 @@ class Loader extends View
      * Automatically call the jsLoad on a supplied event unless it was already triggered
      * or if user have invoked jsLoad manually.
      */
-    public function renderView()
+    protected function renderView(): void
     {
         if (!$this->cb->triggered()) {
             if ($this->loadEvent) {
@@ -102,7 +102,7 @@ class Loader extends View
             $this->add($this->shim);
         }
 
-        return parent::renderView();
+        parent::renderView();
     }
 
     /**

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -186,10 +186,7 @@ class Menu extends View
         return parent::getHtml();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function renderView()
+    protected function renderView(): void
     {
         if ($this->activate_on_click && $this->ui === 'menu') {
             // Semantic UI need some JS magic

--- a/src/Message.php
+++ b/src/Message.php
@@ -55,7 +55,7 @@ class Message extends View
         }
     }
 
-    public function renderView()
+    protected function renderView(): void
     {
         if ($this->type) {
             $this->addClass($this->type);
@@ -74,6 +74,6 @@ class Message extends View
             $this->content = null;
         }
 
-        return parent::renderView();
+        parent::renderView();
     }
 }

--- a/src/Modal.php
+++ b/src/Modal.php
@@ -287,7 +287,7 @@ class Modal extends View
         return $this;
     }
 
-    public function renderView()
+    protected function renderView(): void
     {
         $data['type'] = $this->type;
         $data['label'] = $this->loading_label;

--- a/src/Paginator.php
+++ b/src/Paginator.php
@@ -199,7 +199,7 @@ class Paginator extends View
         $this->template->appendHtml('rows', $t->render());
     }
 
-    public function renderView()
+    protected function renderView(): void
     {
         $t_item = $this->template->cloneRegion('Item');
         $t_first = $this->template->hasTag('FirstItem') ? $this->template->cloneRegion('FirstItem') : $t_item;

--- a/src/Panel/Right.php
+++ b/src/Panel/Right.php
@@ -202,7 +202,7 @@ class Right extends View implements Loadable
         return $panel_options;
     }
 
-    public function renderView()
+    protected function renderView(): void
     {
         $this->template->trySet('WarningIcon', $this->warningIcon);
         $this->template->trySet('CloseIcon', $this->closeIcon);

--- a/src/Popup.php
+++ b/src/Popup.php
@@ -275,7 +275,7 @@ class Popup extends View
         return $chain;
     }
 
-    public function renderView()
+    protected function renderView(): void
     {
         if ($this->triggerBy) {
             $this->js(true, $this->jsPopup());

--- a/src/ProgressBar.php
+++ b/src/ProgressBar.php
@@ -47,11 +47,11 @@ class ProgressBar extends View
         parent::__construct($label, $class);
     }
 
-    public function renderView()
+    protected function renderView(): void
     {
         $this->js(true)->progress(['percent' => $this->value]);
 
-        return parent::renderView();
+        parent::renderView();
     }
 
     /**

--- a/src/Step.php
+++ b/src/Step.php
@@ -51,7 +51,7 @@ class Step extends View
         $this->title = $title;
     }
 
-    public function renderView()
+    protected function renderView(): void
     {
         $this->template->set('title', $this->title);
         $this->template->set('description', $this->description);

--- a/src/Tab.php
+++ b/src/Tab.php
@@ -32,7 +32,7 @@ class Tab extends Item
     /**
      * Rendering one tab view.
      */
-    public function renderView()
+    protected function renderView(): void
     {
         // Must setting for Fomantic-Ui tab since 2.8.5
         $this->settings = array_merge($this->settings, ['autoTabActivation' => false]);

--- a/src/Table.php
+++ b/src/Table.php
@@ -464,10 +464,7 @@ class Table extends Lister
         return $this->model;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function renderView()
+    protected function renderView(): void
     {
         if (!$this->columns) {
             throw (new Exception('Table does not have any columns defined'))
@@ -526,7 +523,7 @@ class Table extends Lister
             $this->jsPaginator->jsIdle();
         }
 
-        return View::renderView();
+        View::renderView();
     }
 
     /**

--- a/src/Tabs.php
+++ b/src/Tabs.php
@@ -95,10 +95,7 @@ class Tabs extends View
         return TabsSubview::addTo($this, ['dataTabName' => $name], ['Tabs']);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function renderView()
+    protected function renderView(): void
     {
         // use content as class name
         if ($this->content) {

--- a/src/TabsSubview.php
+++ b/src/TabsSubview.php
@@ -18,10 +18,7 @@ class TabsSubview extends View
         $this->owner->activeTabName = $this->dataTabName;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function renderView()
+    protected function renderView(): void
     {
         $this->setAttr('data-tab', $this->dataTabName);
 

--- a/src/Text.php
+++ b/src/Text.php
@@ -11,7 +11,7 @@ class Text extends View
 {
     public $defaultTemplate = false;
 
-    public function render($force_echo = true)
+    public function render($forceReturn = true): string
     {
         return $this->content;
     }

--- a/src/UserAction/BasicExecutor.php
+++ b/src/UserAction/BasicExecutor.php
@@ -81,7 +81,7 @@ class BasicExecutor extends \atk4\ui\View implements ExecutorInterface
         $this->arguments = array_merge($this->arguments, $arguments);
     }
 
-    public function recursiveRender()
+    protected function recursiveRender(): void
     {
         if (!$this->action) {
             throw new Exception('Action is not set. Use setAction()');

--- a/src/View.php
+++ b/src/View.php
@@ -746,7 +746,7 @@ class View implements JsExpressionable
     /**
      * This method is to render view to place inside a Fomantic-UI Tab.
      */
-    public function renderTab(): array
+    public function renderToTab(): array
     {
         $this->renderAll();
 

--- a/src/View.php
+++ b/src/View.php
@@ -731,6 +731,15 @@ class View implements JsExpressionable
     }
 
     /**
+     * To be overrided only to further update template render output if needed,
+     * do not call this method from your code.
+     */
+    protected function renderTemplateToHtml(string $region = null): string
+    {
+        return $this->template->render($region);
+    }
+
+    /**
      * This method is for those cases when developer want to simply render his
      * view and grab HTML himself.
      */
@@ -738,9 +747,8 @@ class View implements JsExpressionable
     {
         $this->renderAll();
 
-        return
-            $this->getJs($forceReturn) .
-            $this->template->render();
+        return $this->getJs($forceReturn)
+            . $this->renderTemplateToHtml();
     }
 
     /**
@@ -752,7 +760,7 @@ class View implements JsExpressionable
 
         return [
             'atkjs' => $this->getJsRenderActions(),
-            'html' => $this->template->render(),
+            'html' => $this->renderTemplateToHtml(),
         ];
     }
 
@@ -769,7 +777,7 @@ class View implements JsExpressionable
             'success' => true,
             'message' => 'Success',
             'atkjs' => $this->getJs($forceReturn),
-            'html' => $this->template->render($region),
+            'html' => $this->renderTemplateToHtml($region),
             'id' => $this->name,
         ];
     }
@@ -788,7 +796,7 @@ class View implements JsExpressionable
 
         $this->renderAll();
 
-        return $this->template->render();
+        return $this->renderTemplateToHtml();
     }
 
     // }}}

--- a/src/View.php
+++ b/src/View.php
@@ -760,20 +760,18 @@ class View implements JsExpressionable
      * Render View using json format.
      *
      * @param string $region a specific template region to render
-     *
-     * @return string
      */
-    public function renderJson(bool $forceReturn = true, $region = null)
+    public function renderToJsonArr(bool $forceReturn = true, $region = null): array
     {
         $this->renderAll();
 
-        return json_encode([
+        return [
             'success' => true,
             'message' => 'Success',
             'atkjs' => $this->getJs($forceReturn),
             'html' => $this->template->render($region),
             'id' => $this->name,
-        ]);
+        ];
     }
 
     /**

--- a/src/View.php
+++ b/src/View.php
@@ -647,7 +647,7 @@ class View implements JsExpressionable
      * NOTE: maybe in the future, SemanticUI-related stuff needs to go into
      * a separate class.
      */
-    public function renderView()
+    protected function renderView(): void
     {
         if ($this->class) {
             $this->template->append('class', implode(' ', $this->class));
@@ -693,7 +693,7 @@ class View implements JsExpressionable
      * Recursively render all children, placing their
      * output in our template.
      */
-    public function recursiveRender()
+    protected function recursiveRender(): void
     {
         foreach ($this->elements as $view) {
             if (!$view instanceof self) {
@@ -716,7 +716,7 @@ class View implements JsExpressionable
      * Render everything recursively, render ourselves but don't return
      * anything just yet.
      */
-    public function renderAll()
+    public function renderAll(): void
     {
         if (!$this->_initialized) {
             $this->init();
@@ -733,22 +733,20 @@ class View implements JsExpressionable
     /**
      * This method is for those cases when developer want to simply render his
      * view and grab HTML himself.
-     *
-     * @return string
      */
-    public function render(bool $force_echo = true)
+    public function render(bool $forceReturn = true): string
     {
         $this->renderAll();
 
         return
-            $this->getJs($force_echo) .
+            $this->getJs($forceReturn) .
             $this->template->render();
     }
 
     /**
      * This method is to render view to place inside a Fomantic-UI Tab.
      */
-    public function renderTab()
+    public function renderTab(): array
     {
         $this->renderAll();
 
@@ -765,14 +763,14 @@ class View implements JsExpressionable
      *
      * @return string
      */
-    public function renderJson(bool $force_echo = true, $region = null)
+    public function renderJson(bool $forceReturn = true, $region = null)
     {
         $this->renderAll();
 
         return json_encode([
             'success' => true,
             'message' => 'Success',
-            'atkjs' => $this->getJs($force_echo),
+            'atkjs' => $this->getJs($forceReturn),
             'html' => $this->template->render($region),
             'id' => $this->name,
         ]);
@@ -1231,7 +1229,7 @@ class View implements JsExpressionable
      *
      * @return string
      */
-    public function getJs(bool $force_echo = false)
+    public function getJs(bool $forceReturn = false)
     {
         $actions = [];
 
@@ -1247,7 +1245,7 @@ class View implements JsExpressionable
 
         $actions['indent'] = '';
 
-        if (!$force_echo && $this->app && $this->app->hasMethod('jsReady')) {
+        if (!$forceReturn && $this->app && $this->app->hasMethod('jsReady')) {
             $this->app->jsReady($actions);
 
             return '';

--- a/src/VirtualPage.php
+++ b/src/VirtualPage.php
@@ -128,7 +128,7 @@ class VirtualPage extends View
                 }
 
                 if (isset($_GET['__atk_tab'])) {
-                    $this->app->terminateHtml($this->renderTab());
+                    $this->app->terminateHtml($this->renderToTab());
                 }
 
                 // do not terminate if callback supplied (no cutting)

--- a/src/Wizard.php
+++ b/src/Wizard.php
@@ -180,7 +180,7 @@ class Wizard extends View
         return new JsExpression('document.location = []', [$this->urlNext()]);
     }
 
-    public function recursiveRender()
+    protected function recursiveRender(): void
     {
         if (!$this->steps) {
             $this->addStep(['No Steps Defined', 'icon' => 'configure', 'description' => 'use $wizard->addStep() now'], function ($p) {
@@ -195,7 +195,7 @@ class Wizard extends View
         parent::recursiveRender();
     }
 
-    public function renderView()
+    protected function renderView(): void
     {
         // Set proper width to the wizard
         $c = count($this->steps);


### PR DESCRIPTION
See commit messages for more

Historically, these render methods were not properly renamed and there is a lot of mess in it.

This PR fixes the major issues with minimal breaking impact.

Later, we should merge `render` and `getHtml` methods together.

typical action needed to update your code:
![image](https://user-images.githubusercontent.com/2228672/86912401-3247cc80-c11d-11ea-8dce-3d1cf23d3db1.png)

