### PR TITLE
Drop App::dbConnect() method

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -567,24 +567,6 @@ class App
             ->addMoreInfo('template_dir', $this->template_dir);
     }
 
-    /**
-     * Connects database.
-     *
-     * @param string $dsn      Format as PDO DSN or use "mysql://user:pass@host/db;option=blah", leaving user and password arguments = null
-     * @param string $user
-     * @param string $password
-     * @param array  $args
-     *
-     * @return Persistence
-     */
-    public function dbConnect($dsn, $user = null, $password = null, $args = [])
-    {
-        $this->db = Persistence::connect($dsn, $user, $password, $args);
-        $this->db->app = $this;
-
-        return $this->db;
-    }
-
     protected function getRequestUrl()
     {
         if (isset($_SERVER['HTTP_X_REWRITE_URL'])) { // IIS


### PR DESCRIPTION
related with https://github.com/atk4/data/pull/654

`App::dbConnect() method` was not even used anywhere in ui/demos, DB should be created by/added to App like:
```
$app->db = Persistence::connect($dsn, $user, $password, $args);
```
