### PR TITLE
Fix form selector for Lookup with dependency support

### DIFF
--- a/src/Form/Control/Lookup.php
+++ b/src/Form/Control/Lookup.php
@@ -408,7 +408,7 @@ class Lookup extends Input
 
         if ($this->dependency) {
             $this->apiConfig['data'] = array_merge([
-                'form' => new JsFunction([new JsExpression('return []', [$this->js()->closest('form')->serialize()])]),
+                'form' => new JsFunction([new JsExpression('return []', [$this->form->formElement->js()->serialize()])]),
             ], $this->apiConfig['data'] ?? []);
         }
 


### PR DESCRIPTION
this PR fixes the original selector that was relying on jQuery

bug introduced in https://github.com/atk4/ui/pull/1275