### PR TITLE
Allow upload multiple

### DIFF
--- a/demos/form-control/upload.php
+++ b/demos/form-control/upload.php
@@ -30,13 +30,13 @@ $img->onDelete(function ($fileId) use ($img) {
     ]);
 });
 
-$img->onUpload(function ($files) use ($form, $img) {
-    if ($files === 'error') {
+$img->onUpload(function ($postFile) use ($form, $img) {
+    if ($postFile['error'] !== 0) {
         return $form->error('img', 'Error uploading image.');
     }
 
     $img->setThumbnailSrc('./images/logo.png');
-    $img->set('123456', $files['name'] . ' (token: 123456)');
+    $img->set('123456', $postFile['name'] . ' (token: 123456)');
 
     //Do file processing here...
 

--- a/docs/fileupload.rst
+++ b/docs/fileupload.rst
@@ -53,7 +53,7 @@ When adding an Upload or UploadImage field to a form, onUpload and onDelete call
 
     $img = $form->addControl('img', [\atk4\ui\Form\Control\UploadImage::class, ['defaultSrc' => './images/default.png', 'placeholder' => 'Click to add an image.']]);
 
-    $img->onUpload(function ($files) {
+    $img->onUpload(function ($postFile) {
         //callback action here...
     });
 
@@ -66,8 +66,7 @@ onUpload
 --------
 
 The onUpload callback get called as soon as the upload process is finished. This callback
-function will receive the `$_FILES['upfile']` array as function parameter (see https://php.net/manual/en/features.file-upload.php),
-or '$error' string if there was problem during upload.
+function will receive the `$_FILES['upfile']` array as function parameter (see https://php.net/manual/en/features.file-upload.php).
 
 The onUpload callback function is a good place to:
 
@@ -80,8 +79,8 @@ The onUpload callback function is a good place to:
 
 Example showing the onUpload callback on the UploadImage field::
 
-    $img->onUpload(function ($files) use ($form, $img) {
-        if ($files === 'error') {
+    $img->onUpload(function ($postFile) use ($form, $img) {
+        if ($postFile['error'] !== 0) {
             return $form->error('img', 'Error uploading image.');
         }
 

--- a/src/Form/Control/Upload.php
+++ b/src/Form/Control/Upload.php
@@ -171,7 +171,7 @@ class Upload extends Input
                 $this->_isCbRunning = true;
 
                 $postFiles = [];
-                for ($i = 0;; $i++) {
+                for ($i = 0;; ++$i) {
                     $k = 'file' . ($i > 0 ? '-' . $i : '');
                     if (!isset($_FILES[$k])) {
                         break;
@@ -234,6 +234,7 @@ class Upload extends Input
         if (!$this->_isCbRunning && (!$this->hasUploadCb || !$this->hasDeleteCb)) {
             throw new Exception('onUpload and onDelete callback must be called to use file upload. Missing one or both of them.');
         }
+
         if (!empty($this->accept)) {
             $this->template->trySet('accept', implode(',', $this->accept));
         }

--- a/src/Form/Control/Upload.php
+++ b/src/Form/Control/Upload.php
@@ -171,25 +171,31 @@ class Upload extends Input
             $this->cb->set(function () use ($fx) {
                 $this->_isCbRunning = true;
 
-                $files = [];
+                $postFiles = [];
                 for ($i = 0;; $i++) {
                     $k = 'file' . ($i > 0 ? '-' . $i : '');
                     if (!isset($_FILES[$k])) {
                         break;
                     }
-                    $files[] = $_FILES[$k];
+
+                    $postFile = $_FILES[$k];
+                    if ($postFile['error'] !== 0) {
+                        // unset all details on upload error
+                        $postFile = array_intersect_key($postFile, array_flip('error', 'name'));
+                    }
+                    $postFiles[] = $postFile;
                 }
 
-                if (count($files) > 0) {
+                if (count($postFiles) > 0) {
                     //set fileId to file name as default.
-                    $this->fileId = reset($files)['name'];
+                    $this->fileId = reset($postFiles)['name'];
                     // display file name to user as default.
                     $this->setInput($this->fileId);
                 }
 
-                $this->addJsAction($fx(...$files));
+                $this->addJsAction($fx(...$postFiles));
 
-                if (count($files) > 0 && reset($files)['error'] === 0) {
+                if (count($postFiles) > 0 && reset($postFiles)['error'] === 0) {
                     $this->addJsAction([
                         $this->js()->atkFileUpload('updateField', [$this->fileId, $this->getInputValue()]),
                     ]);

--- a/src/Form/Control/Upload.php
+++ b/src/Form/Control/Upload.php
@@ -166,8 +166,7 @@ class Upload extends Input
     public function onUpload(\Closure $fx)
     {
         $this->hasUploadCb = true;
-        $action = $_POST['action'] ?? null;
-        if ($action === 'upload') {
+        if (($_POST['action'] ?? null) === 'upload') {
             $this->cb->set(function () use ($fx) {
                 $this->_isCbRunning = true;
 
@@ -212,8 +211,7 @@ class Upload extends Input
     public function onDelete(\Closure $fx)
     {
         $this->hasDeleteCb = true;
-        $action = $_POST['action'] ?? null;
-        if ($action === 'delete') {
+        if (($_POST['action'] ?? null) === 'delete') {
             $this->cb->set(function () use ($fx) {
                 $this->_isCbRunning = true;
 

--- a/src/Form/Control/Upload.php
+++ b/src/Form/Control/Upload.php
@@ -227,7 +227,7 @@ class Upload extends Input
             $this->template->trySet('accept', implode(',', $this->accept));
         }
         if ($this->multiple) {
-            //$this->template->trySet('multiple', 'multiple');
+            $this->template->trySet('multiple', 'multiple');
         }
 
         if ($this->placeholder) {

--- a/src/Form/Control/Upload.php
+++ b/src/Form/Control/Upload.php
@@ -161,24 +161,6 @@ class Upload extends Input
     }
 
     /**
-     * Call when user is removing an already upload file.
-     */
-    public function onDelete(\Closure $fx)
-    {
-        $this->hasDeleteCb = true;
-        $action = $_POST['action'] ?? null;
-        if ($this->cb->triggered() && $action === 'delete') {
-            $this->_isCbRunning = true;
-            $fileName = $_POST['f_name'] ?? null;
-            $this->cb->set(function () use ($fx, $fileName) {
-                $this->addJsAction($fx($fileName));
-
-                return $this->jsActions;
-            });
-        }
-    }
-
-    /**
      * Call when user is uploading a file.
      */
     public function onUpload(\Closure $fx)
@@ -209,6 +191,24 @@ class Upload extends Input
                     return $fx('error');
                 });
             }
+        }
+    }
+
+    /**
+     * Call when user is removing an already upload file.
+     */
+    public function onDelete(\Closure $fx)
+    {
+        $this->hasDeleteCb = true;
+        $action = $_POST['action'] ?? null;
+        if ($this->cb->triggered() && $action === 'delete') {
+            $this->_isCbRunning = true;
+            $fileName = $_POST['f_name'] ?? null;
+            $this->cb->set(function () use ($fx, $fileName) {
+                $this->addJsAction($fx($fileName));
+
+                return $this->jsActions;
+            });
         }
     }
 


### PR DESCRIPTION
this PR adds support to multiple files to be uploaded, but only uploaded - the Upload control still remains for one file only

original fx signatures remains - now only more files can be passed

marking as BC breaks as no special "error" string param is passed anymore