### PR TITLE
Use native and/or in Vue Scope builder internally

### DIFF
--- a/js/src/components/query-builder/query-builder.component.vue
+++ b/js/src/components/query-builder/query-builder.component.vue
@@ -54,8 +54,8 @@
         return Object.assign({
           matchType: "Match Type",
           matchTypes: [
-            {id: "all", label: "And"},
-            {id: "any", label: "Or"}
+            {id: "AND", label: "And"},
+            {id: "OR", label: "Or"}
           ],
           addRule: "Add Rule",
           removeRule: "small icon times",

--- a/src/Form/Control/ScopeBuilder.php
+++ b/src/Form/Control/ScopeBuilder.php
@@ -436,7 +436,7 @@ class ScopeBuilder extends Control
         switch ($type) {
             case 'query-builder-group':
                 $components = array_map([static::class, 'queryToScope'], (array) $query['children']);
-                $scope = $query['logicalOperator'] === 'all' ? Scope::createAnd(...$components) : Scope::createOr(...$components);
+                $scope = new Scope($components, $query['logicalOperator']);
 
                 break;
             case 'query-builder-rule':
@@ -521,7 +521,7 @@ class ScopeBuilder extends Control
             $query = [
                 'type' => 'query-builder-group',
                 'query' => [
-                    'logicalOperator' => $scope->isAnd() ? 'all' : 'any',
+                    'logicalOperator' => $scope->getJunction(),
                     'children' => $children,
                 ],
             ];


### PR DESCRIPTION
also, if possible, internal representation (even in browser) should never be stored in text (like "equals" vs "=")