### PR TITLE
No app/global sticky Callback

### DIFF
--- a/demos/interactive/loader.php
+++ b/demos/interactive/loader.php
@@ -18,7 +18,7 @@ ViewTester::addTo($app);
 // Example 1 - Basic usage of a Loader.
 \atk4\ui\Loader::addTo($app)->set(function ($p) {
     //set your time expensive function here.
-    sleep(2);
+    sleep(1);
     \atk4\ui\Header::addTo($p, ['Loader #1']);
     \atk4\ui\LoremIpsum::addTo($p, ['size' => 1]);
 
@@ -32,7 +32,7 @@ ViewTester::addTo($app);
     $loader->loadEvent = false;
     $loader->set(function ($p) {
         // You may pass arguments to the loader, in this case it's "color"
-        sleep(3);
+        sleep(1);
         \atk4\ui\Header::addTo($p, ['Loader #1b - ' . $_GET['color']]);
         \atk4\ui\LoremIpsum::addTo(\atk4\ui\View::addTo($p, ['ui' => $_GET['color'] . ' segment']), ['size' => 1]);
 
@@ -40,12 +40,12 @@ ViewTester::addTo($app);
         $p->app->stickyGet('color');
         ViewTester::addTo($p);
 
-        // This loader takes 5s to load because it needs to go through 2 sleep statements.
+        // This loader takes 2s to load because it needs to go through 2 sleep statements.
     });
 
     // button may contain load event.
-    \atk4\ui\Button::addTo($p, ['Load Segment Manually (5s)', 'red'])->js('click', $loader->jsLoad(['color' => 'red']));
-    \atk4\ui\Button::addTo($p, ['Load Segment Manually (5s)', 'blue'])->js('click', $loader->jsLoad(['color' => 'blue']));
+    \atk4\ui\Button::addTo($p, ['Load Segment Manually (2s)', 'red'])->js('click', $loader->jsLoad(['color' => 'red']));
+    \atk4\ui\Button::addTo($p, ['Load Segment Manually (2s)', 'blue'])->js('click', $loader->jsLoad(['color' => 'blue']));
 });
 
 // Example 2 - Loader with custom body.
@@ -57,6 +57,6 @@ ViewTester::addTo($app);
         'red',
     ],
 ])->set(function ($p) {
-    sleep(1);
+    usleep(500 * 1000);
     \atk4\ui\LoremIpsum::addTo($p, ['size' => 2]);
 });

--- a/src/AbstractView.php
+++ b/src/AbstractView.php
@@ -169,19 +169,19 @@ abstract class AbstractView
             $stickyArgs = $this->stickyArgs;
         }
 
-        /** @var self $overrideArgsView */
-        $overrideArgsView = $this->mergeStickyArgsFromChildView();
-        if ($overrideArgsView !== null) {
+        /** @var self $childView */
+        $childView = $this->mergeStickyArgsFromChildView();
+        if ($childView !== null && (!($childView instanceof Callback) || $childView->isTriggered())) {
             $trace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS);
             $alreadyCalled = false;
             foreach ($trace as $frame) {
-                if ($overrideArgsView === ($frame['object'] ?? null) && $frame['function'] === '_getStickyArgs') {
+                if ($childView === ($frame['object'] ?? null) && $frame['function'] === '_getStickyArgs') {
                     $alreadyCalled = true;
                 }
             }
 
             if (!$alreadyCalled) {
-                $stickyArgs = array_merge($stickyArgs, $overrideArgsView->_getStickyArgs());
+                $stickyArgs = array_merge($stickyArgs, $childView->_getStickyArgs());
             }
         }
 

--- a/src/AbstractView.php
+++ b/src/AbstractView.php
@@ -169,7 +169,28 @@ abstract class AbstractView
             $stickyArgs = $this->stickyArgs;
         }
 
+        /** @var self $overrideArgsView */
+        $overrideArgsView = $this->mergeStickyArgsFromChildView();
+        if ($overrideArgsView !== null) {
+            $trace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS);
+            $alreadyCalled = false;
+            foreach ($trace as $frame) {
+                if ($overrideArgsView === ($frame['object'] ?? null) && $frame['function'] === '_getStickyArgs') {
+                    $alreadyCalled = true;
+                }
+            }
+
+            if (!$alreadyCalled) {
+                $stickyArgs = array_merge($stickyArgs, $overrideArgsView->_getStickyArgs());
+            }
+        }
+
         return $stickyArgs;
+    }
+
+    protected function mergeStickyArgsFromChildView(): ?self
+    {
+        return null;
     }
 
     /**

--- a/src/AbstractView.php
+++ b/src/AbstractView.php
@@ -172,9 +172,8 @@ abstract class AbstractView
         /** @var self $childView */
         $childView = $this->mergeStickyArgsFromChildView();
         if ($childView !== null && (!($childView instanceof Callback) || $childView->isTriggered())) {
-            $trace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS);
             $alreadyCalled = false;
-            foreach ($trace as $frame) {
+            foreach (debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS) as $frame) {
                 if ($childView === ($frame['object'] ?? null) && $frame['function'] === '_getStickyArgs') {
                     $alreadyCalled = true;
                 }

--- a/src/Callback.php
+++ b/src/Callback.php
@@ -25,9 +25,6 @@ class Callback extends AbstractView
     /** @var string Specify a custom GET trigger. */
     protected $urlTrigger;
 
-    /** @var bool Create app sticky trigger. */
-    public $isSticky = true;
-
     /** @var bool Allow this callback to trigger during a reload. */
     public $triggerOnReload = true;
 
@@ -48,9 +45,6 @@ class Callback extends AbstractView
     public function setUrlTrigger(string $trigger = null)
     {
         $this->urlTrigger = $trigger ?: $this->name;
-        if ($this->isSticky) {
-            $this->app->stickyGet($this->urlTrigger);
-        }
     }
 
     public function getUrlTrigger(): string

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -119,4 +119,9 @@ class Loader extends View
             'storeName' => $storeName ? $storeName : null,
         ]);
     }
+
+    protected function mergeStickyArgsFromChildView(): ?AbstractView
+    {
+        return $this->cb;
+    }
 }

--- a/src/Modal.php
+++ b/src/Modal.php
@@ -330,4 +330,12 @@ class Modal extends View
 
         parent::renderView();
     }
+
+    /** @var AbstractView */
+    public $viewForUrl;
+
+    protected function mergeStickyArgsFromChildView(): ?AbstractView
+    {
+        return $this->viewForUrl ?? $this->cb;
+    }
 }

--- a/src/Panel/Content.php
+++ b/src/Panel/Content.php
@@ -59,4 +59,9 @@ class Content extends View implements LoadableContent
     {
         return ['.atk-panel-content'];
     }
+
+    protected function mergeStickyArgsFromChildView(): ?\atk4\ui\AbstractView
+    {
+        return $this->cb;
+    }
 }

--- a/src/Panel/Right.php
+++ b/src/Panel/Right.php
@@ -211,4 +211,9 @@ class Right extends View implements Loadable
 
         $this->js(true, $this->service()->addPanel($this->getPanelOptions()));
     }
+
+    protected function mergeStickyArgsFromChildView(): ?\atk4\ui\AbstractView
+    {
+        return $this->dynamicContent;
+    }
 }

--- a/src/Popup.php
+++ b/src/Popup.php
@@ -293,4 +293,9 @@ class Popup extends View
 
         parent::renderView();
     }
+
+    protected function mergeStickyArgsFromChildView(): ?AbstractView
+    {
+        return $this->cb;
+    }
 }

--- a/src/View.php
+++ b/src/View.php
@@ -1061,7 +1061,9 @@ class View extends AbstractView implements JsExpressionable
             if ($ex instanceof self && $ex instanceof UserAction\JsExecutorInterface) {
                 //Executor may already had been add to layout. Like in CardDeck.
                 if (!isset($this->app->html->elements[$ex->short_name])) {
-                    $ex->viewForUrl = $this; // very dirty hack
+                    // very dirty hack, @TODO, attach modals in the standard render tree
+                    // but only render the result to a different place/html DOM
+                    $ex->viewForUrl = $this;
                     $ex = $this->app->html->add($ex, 'Modals')->setAction($action);
                 }
                 if (isset($arguments[0])) {

--- a/src/View.php
+++ b/src/View.php
@@ -1061,6 +1061,7 @@ class View extends AbstractView implements JsExpressionable
             if ($ex instanceof self && $ex instanceof UserAction\JsExecutorInterface) {
                 //Executor may already had been add to layout. Like in CardDeck.
                 if (!isset($this->app->html->elements[$ex->short_name])) {
+                    $ex->viewForUrl = $this; // very dirty hack
                     $ex = $this->app->html->add($ex, 'Modals')->setAction($action);
                 }
                 if (isset($arguments[0])) {

--- a/src/VirtualPage.php
+++ b/src/VirtualPage.php
@@ -163,4 +163,9 @@ class VirtualPage extends View
             $this->app->terminateHtml($this->app->html->template);
         });
     }
+
+    protected function mergeStickyArgsFromChildView(): ?AbstractView
+    {
+        return $this->cb;
+    }
 }

--- a/src/Wizard.php
+++ b/src/Wizard.php
@@ -212,4 +212,9 @@ class Wizard extends View
 
         parent::renderView();
     }
+
+    protected function mergeStickyArgsFromChildView(): ?AbstractView
+    {
+        return $this->stepCallback;
+    }
 }


### PR DESCRIPTION
fixes: #1385

BC break: GET sticky args are no longer globally sticky, they are sticky only within the element where defined and its subtree

still semi-global, as cb sticky args are usually used for owning component