### PR TITLE
Render full exception details on ModalExecutor error

### DIFF
--- a/src/UserAction/ModalExecutor.php
+++ b/src/UserAction/ModalExecutor.php
@@ -713,13 +713,10 @@ class ModalExecutor extends Modal implements JsExecutorInterface
         }
     }
 
-    /**
-     * Handle exception.
-     */
-    private function _handleException($e, $view, $step)
+    private function _handleException(\Throwable $exception, $view, $step)
     {
         $msg = Message::addTo($view, ['Error:', 'type' => 'error']);
-        $msg->text->addParagraph($e->getMessage());
+        $msg->text->addHtml($this->app->renderExceptionHtml($exception));
         $view->js(true, $this->nextStepBtn->js()->addClass('disabled'));
         if (!$this->isFirstStep($step)) {
             $this->jsSetPrevHandler($view, $step);


### PR DESCRIPTION
Fix missing info error info

We still want probably fix https://github.com/atk4/ui/pull/1328 as the Modal can still render in uncontrolled/buggy fashion, very dangerous to existing data as the modal can end up half initialized