### PR TITLE
[fix] Date picker popup style

### DIFF
--- a/public/agileui.css
+++ b/public/agileui.css
@@ -197,6 +197,9 @@ i.atk-panel-warning.atk-visible {
 .ui.sortable.table thead th:not(.sortable) {
   cursor: default;
 }
+.ui.input .ui.popup.calendar {
+  padding: 0px;
+}
 .ui.step,
 .ui.steps .step {
   user-select: none;

--- a/public/agileui.less
+++ b/public/agileui.less
@@ -307,6 +307,10 @@ i.atk-panel-warning {
     cursor: default;
 }
 
+// input calendar fix.
+.ui.input .ui.popup.calendar {
+  padding: 0px;
+}
 
 // Components
 

--- a/public/agileui.less
+++ b/public/agileui.less
@@ -308,6 +308,7 @@ i.atk-panel-warning {
 }
 
 // input calendar fix.
+// see https://github.com/atk4/ui/issues/1376
 .ui.input .ui.popup.calendar {
   padding: 0px;
 }


### PR DESCRIPTION
Fix #1376 

<img width="678" alt="Screen Shot 2020-08-28 at 2 26 08 PM" src="https://user-images.githubusercontent.com/2204478/91603161-7f386a00-e93a-11ea-9fef-02d49f2c8961.png">
