### PR TITLE
[fix] Dropdown using multiple in read only mode

### DIFF
--- a/src/Form/Control/Dropdown.php
+++ b/src/Form/Control/Dropdown.php
@@ -284,6 +284,9 @@ class Dropdown extends Input
             $this->setDropdownOption('showOnFocus', false);
             $this->setDropdownOption('allowTab', false);
             $this->removeClass('search');
+            if ($this->isMultiple) {
+                $this->js(true)->find('a i.delete.icon')->attr('class', 'disabled');
+            }
         }
 
         if ($this->disabled) {


### PR DESCRIPTION
fix: #1382 
- prevent option to be remove in readonly mode when using multiple.

<img width="407" alt="Screen Shot 2020-08-28 at 3 09 39 PM" src="https://user-images.githubusercontent.com/2204478/91606830-d8a39780-e940-11ea-9997-fd79ceeef80c.png">
