### PR TITLE
Refactor Js Atk Bundle eventBus

### DIFF
--- a/demos/javascript/vue-component.php
+++ b/demos/javascript/vue-component.php
@@ -86,14 +86,11 @@ $clock_script = "
           data: function() {
             return {style : this.clock, currentIdx : 0}
           },
-          created: function() {
+          mounted: function() {
             // add a listener for changing clock style.
-            // this will listen to event 'update-style' emit on the eventBus.
-            atk.eventBus.on('clock-change-style', (data) => {
-              // make sure we are talking to the right component.
-              if (this.\$parent.\$el.id === data.id) {
+            // this will listen to event '-clock-change-style' emit on the eventBus.
+            atk.eventBus.on(this.\$root.\$el.id + '-clock-change-style', (payload) => {
                 this.onChangeStyle();
-              }
             });
           },
           computed: {
@@ -134,5 +131,5 @@ $clock_style = [
 $clock->vue('my-clock', ['clock' => $clock_style], 'myClock');
 
 $btn = \atk4\ui\Button::addTo($app, ['Change Style']);
-$btn->on('click', $clock->jsEmitEvent('clock-change-style'));
+$btn->on('click', $clock->jsEmitEvent($clock->name . '-clock-change-style'));
 \atk4\ui\View::addTo($app, ['element' => 'p', 'I am not part of the component but I can still change style using the eventBus.']);

--- a/demos/javascript/vue-component.php
+++ b/demos/javascript/vue-component.php
@@ -89,7 +89,7 @@ $clock_script = "
           created: function() {
             // add a listener for changing clock style.
             // this will listen to event 'update-style' emit on the eventBus.
-            atk.vueService.eventBus.\$on('change-style', (data) => {
+            atk.eventBus.on('clock-change-style', (data) => {
               // make sure we are talking to the right component.
               if (this.\$parent.\$el.id === data.id) {
                 this.onChangeStyle();
@@ -134,5 +134,5 @@ $clock_style = [
 $clock->vue('my-clock', ['clock' => $clock_style], 'myClock');
 
 $btn = \atk4\ui\Button::addTo($app, ['Change Style']);
-$btn->on('click', $clock->jsVueEmit('change-style'));
+$btn->on('click', $clock->jsEmitEvent('clock-change-style'));
 \atk4\ui\View::addTo($app, ['element' => 'p', 'I am not part of the component but I can still change style using the eventBus.']);

--- a/js/Release.md
+++ b/js/Release.md
@@ -1,5 +1,11 @@
 ## Release note
 
+### version 1.15.4 (2020-09-02)
+
+- add atk eventBus for listening and publishing event.
+    - replace deprecated Vue eventBus;
+- create atk-utils file for options and eventBus.
+
 ### version 1.15.3 (2020-08-27)
 
  - set proper debounce value in:

--- a/js/Release.md
+++ b/js/Release.md
@@ -1,10 +1,11 @@
 ## Release note
 
-### version 1.15.4 (2020-09-02)
+### version 1.15.4 (2020-09-08)
 
 - add atk eventBus for listening and publishing event.
     - replace deprecated Vue eventBus;
 - create atk-utils file for options and eventBus.
+- remove Vue component deprecated inline-template in v3.
 
 ### version 1.15.3 (2020-08-27)
 

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atkjs-ui",
-  "version": "1.15.3",
+  "version": "1.15.4",
   "description": "Agile Toolkit Javascript library.",
   "main": "lib/atkjs-ui.js",
   "scripts": {

--- a/js/package.json
+++ b/js/package.json
@@ -47,6 +47,7 @@
     "debounce": "^1.1.0",
     "locutus": "^2.0.11",
     "lodash.throttle": "^4.1.1",
+    "mitt": "^2.1.0",
     "semantic-ui-vue": "^0.11.0",
     "v-calendar": "^1.0.8",
     "vue": "^2.6.12",

--- a/js/src/agile-toolkit-ui.js
+++ b/js/src/agile-toolkit-ui.js
@@ -7,6 +7,7 @@ import 'helpers/url.helper';
 import date from 'locutus/php/datetime/date';
 import { tableDropdown } from './helpers/table-dropdown.helper';
 import { plugin, createAtkplugins } from './plugin';
+import { atkOptions, atkEventBus } from './atk-utils';
 import vueService from './services/vue.service';
 import dataService from './services/data.service';
 import panelService from './services/panel.service';
@@ -15,18 +16,8 @@ import panelService from './services/panel.service';
 createAtkplugins();
 // add version function to atk.
 atk.version = () => _ATKVERSION_;
-
-// Use closure for atk options property in order to keep them private.
-atk.options = (function () {
-    const options = {
-        // Value for debounce time out (in ms) that will be apply globally when set using atk.debounce.
-        debounceTimeout: null,
-    };
-    return {
-        set: (name, value) => { options[name] = value; },
-        get: (name) => options[name],
-    };
-}());
+atk.options = atkOptions;
+atk.eventBus = atkEventBus;
 
 atk.debounce = (fn, value) => {
     const timeOut = atk.options.get('debounceTimeout');

--- a/js/src/agile-toolkit-ui.js
+++ b/js/src/agile-toolkit-ui.js
@@ -6,14 +6,12 @@ import atk from 'atk-semantic-ui';
 import 'helpers/url.helper';
 import date from 'locutus/php/datetime/date';
 import { tableDropdown } from './helpers/table-dropdown.helper';
-import { plugin, createAtkplugins } from './plugin';
+import { plugin } from './plugin';
 import { atkOptions, atkEventBus } from './atk-utils';
 import vueService from './services/vue.service';
 import dataService from './services/data.service';
 import panelService from './services/panel.service';
 
-// Create atk plugins.
-createAtkplugins();
 // add version function to atk.
 atk.version = () => _ATKVERSION_;
 atk.options = atkOptions;

--- a/js/src/atk-utils.js
+++ b/js/src/atk-utils.js
@@ -29,7 +29,7 @@ const atkOptions = (function () {
 const atkEventBus = (function () {
     const eventBus = mitt();
     return {
-        emit: (event, data) => eventBus.emit(event, data),
+        emit: (event, payload) => eventBus.emit(event, payload),
         on: (event, ref) => eventBus.on(event, ref),
         off: (event, ref) => eventBus.off(event, ref),
         clearAll: () => eventBus.all.clear(),

--- a/js/src/atk-utils.js
+++ b/js/src/atk-utils.js
@@ -1,0 +1,39 @@
+import mitt from 'mitt';
+
+/**
+ * Define atk global options.
+ * In Js:
+ *  atk.options.set('name','value');
+ * In Php:
+ *  (new JsChain('atk.options')->set('name', 'value');
+ */
+const atkOptions = (function () {
+    const options = {
+    // Value for debounce time out (in ms) that will be apply globally when set using atk.debounce.
+        debounceTimeout: null,
+    };
+    return {
+        set: (name, value) => { options[name] = value; },
+        get: (name) => options[name],
+    };
+}());
+
+/**
+ * Subscribe too and publish events.
+ * listen to an event
+ *   atk.eventBus.on('foo', e => console.log('foo', e))
+ * Fire an event
+ *   atk.eventBus.emit('foo', { a: 'b' })
+ *
+ */
+const atkEventBus = (function () {
+    const eventBus = mitt();
+    return {
+        emit: (event, data) => eventBus.emit(event, data),
+        on: (event, ref) => eventBus.on(event, ref),
+        off: (event, ref) => eventBus.off(event, ref),
+        clearAll: () => eventBus.all.clear(),
+    };
+}());
+
+export { atkOptions, atkEventBus };

--- a/js/src/components/inline-edit.component.js
+++ b/js/src/components/inline-edit.component.js
@@ -5,8 +5,6 @@ import $ from 'jquery';
  * Allow user to edit a db record inline and send
  * changes to server.
  *
- * Use an inline template.
- *
  * Properties need for this component are:
  *
  * context: string, a jQuery selector where the 'loading' class will be apply by semantic-ui;
@@ -16,16 +14,40 @@ import $ from 'jquery';
  *
  */
 
+const template = `
+<div class="inline field">
+      <div :class="options.inputCss" :style="{error: hasError, loading : isLoading}">
+            <input 
+            :class="options.inlineCss" 
+            :name="options.fieldName" 
+            :type="options.fieldType" 
+            v-model="value" 
+            @keyup="onKeyup" 
+            @focus="onFocus" 
+            @blur="onBlur"/><i class="icon"></i>
+      </div>
+</div>`;
+
 export default {
     name: 'atk-inline-edit',
+    template: template,
     props: {
         url: String,
         initValue: String,
         saveOnBlur: { type: Boolean, default: true },
+        options: {
+            type: Object,
+            default: () => ({
+                inputCss: '', inlineCss: '', fieldName: null, fieldType: 'text',
+            }),
+        },
     },
     data: function () {
         return {
-            value: this.initValue, temp: this.initValue, hasError: null, isLoading: false,
+            value: this.initValue,
+            temp: this.initValue,
+            hasError: null,
+            isLoading: false,
         };
     },
     computed: {
@@ -41,7 +63,7 @@ export default {
                 this.temp = this.value;
             }
         },
-        onKeyUp: function (e) {
+        onKeyup: function (e) {
             const key = e.keyCode;
             this.clearError();
             if (key === 13) {

--- a/js/src/components/inline-edit.component.js
+++ b/js/src/components/inline-edit.component.js
@@ -15,8 +15,7 @@ import $ from 'jquery';
  */
 
 const template = `
-<div class="inline field">
-      <div :class="options.inputCss" :style="{error: hasError, loading : isLoading}">
+      <div :class="[options.inputCss, hasError ? 'error' : '' ]">
             <input 
             :class="options.inlineCss" 
             :name="options.fieldName" 
@@ -25,8 +24,7 @@ const template = `
             @keyup="onKeyup" 
             @focus="onFocus" 
             @blur="onBlur"/><i class="icon"></i>
-      </div>
-</div>`;
+      </div>`;
 
 export default {
     name: 'atk-inline-edit',
@@ -46,8 +44,7 @@ export default {
         return {
             value: this.initValue,
             temp: this.initValue,
-            hasError: null,
-            isLoading: false,
+            hasError: false,
         };
     },
     computed: {
@@ -103,9 +100,7 @@ export default {
         },
         update: function () {
             const that = this;
-            const $obj = $(this.$el);
-            this.isLoading = true;
-            $obj.api({
+            $(this.$el).api({
                 on: 'now',
                 url: this.url,
                 data: { value: this.value },
@@ -116,7 +111,6 @@ export default {
                     } else {
                         that.temp = that.value;
                     }
-                    that.isLoading = false;
                 },
             });
         },

--- a/js/src/components/item-search.component.js
+++ b/js/src/components/item-search.component.js
@@ -6,8 +6,6 @@ import $ from 'jquery';
  * Request should filter the data and reload the data view.
  * The request is send using semantic-ui api.
  *
- * Template is done inline: item-search.html
- *
  * Properties need for this component are:
  *
  * context: string, a jQuery selector where the 'loading' class will be apply by semantic-ui;
@@ -17,8 +15,21 @@ import $ from 'jquery';
  * reload:  string, an Id selector for jQuery, '#' is append automatically.
  *
  */
+
+const template = `<div class="atk-item-search" :class="inputCss">
+      <input class="ui" 
+        v-model="query" 
+        type="text" placeholder="Search..." 
+        @keyup="onKeyup" 
+        @keyup.esc="onEscape" 
+        name="atk-vue-search"/>
+        <i class="atk-search-icon" :class="classIcon"></i><span style="width:12px;cursor:pointer" @click="onClear"></span>
+    </div>
+`;
+
 export default {
     name: 'atk-item-search',
+    template: template,
     props: {
         context: String,
         url: String,
@@ -27,7 +38,7 @@ export default {
         queryArg: String,
         options: {
             type: Object,
-            default: () => ({ inputTimeOut: 350 }),
+            default: () => ({ inputTimeOut: 350, inputCss: '' }),
         },
     },
     data: function () {
@@ -36,6 +47,7 @@ export default {
             temp: this.q,
             isActive: false,
             extraQuery: null,
+            inputCss: this.options.inputCss,
         };
     },
     computed: {
@@ -47,7 +59,7 @@ export default {
         },
     },
     methods: {
-        onChange: function () {
+        onKeyup: function () {
             atk.debounce((e) => {
                 if (this.query !== this.temp) {
                     if (this.query === '') {

--- a/js/src/components/multiline.component.js
+++ b/js/src/components/multiline.component.js
@@ -97,7 +97,7 @@ export default {
             }
         });
 
-        atk.vueService.eventBus.$on('atkml-row-error', (data) => {
+        atk.eventBus.on('multiline-rows-error', (data) => {
             if (this.$root.$el.id === data.id) {
                 this.errors = { ...data.errors };
             }

--- a/js/src/components/multiline/multiline-header.component.js
+++ b/js/src/components/multiline/multiline-header.component.js
@@ -25,7 +25,7 @@ export default {
     methods: {
         onToggleDeleteAll: function () {
             this.$nextTick(() => {
-                this.$root.$emit('toggle-delete-all', this.$refs.check.checked);
+                atk.eventBus.emit(this.$root.$el.id + '-toggle-delete-all', { isOn: this.$refs.check.checked });
             });
         },
         getTextAlign: function (column) {

--- a/js/src/components/multiline/multiline-row.component.js
+++ b/js/src/components/multiline/multiline-row.component.js
@@ -71,13 +71,13 @@ export default {
             this.isEditing = true;
         },
         onToggleDelete: function (e) {
-            this.$root.$emit('toggle-delete', this.rowId);
+            atk.eventBus.emit(this.$root.$el.id + '-toggle-delete', { rowId: this.rowId });
         },
         onUpdateValue: function (field, value) {
-            this.$root.$emit('update-row', this.rowId, field, value);
+            atk.eventBus.emit(this.$root.$el.id + '-update-row', { rowId: this.rowId, field: field, value: value });
         },
         onPostRow: function (field) {
-            this.$root.$emit('post-row', this.rowId, field);
+            atk.eventBus.emit(this.$root.$el.id + '-post-row', { rowId: this.rowId, field: field });
         },
         getReadOnlyValue: function (column) {
             if (!column.isEditable) {

--- a/js/src/components/multiline/multiline.component.js
+++ b/js/src/components/multiline/multiline.component.js
@@ -52,7 +52,6 @@ export default {
                 color: null,
                 columns: null,
             },
-            elementId: null,
             tableProp: { ...this.tableDefault, ...this.data.options },
         };
     },
@@ -61,13 +60,11 @@ export default {
         'atk-multiline-header': multilineHeader,
     },
     mounted: function () {
-        this.elementId = this.$root.$el.id;
-
-        atk.eventBus.on(this.elementId + '-update-row', (payload) => {
+        atk.eventBus.on(this.$root.$el.id + '-update-row', (payload) => {
             this.updateRow(payload.rowId, payload.field, payload.value);
         });
 
-        atk.eventBus.on(this.elementId + '-post-row', (payload) => {
+        atk.eventBus.on(this.$root.$el.id + '-post-row', (payload) => {
             if (this.hasExpression()) {
                 this.postRow(payload.rowId, payload.field);
             }
@@ -77,7 +74,7 @@ export default {
             }
         });
 
-        atk.eventBus.on(this.elementId + '-toggle-delete', (payload) => {
+        atk.eventBus.on(this.$root.$el.id + '-toggle-delete', (payload) => {
             const idx = this.deletables.indexOf(payload.rowId);
             if (idx > -1) {
                 this.deletables.splice(idx, 1);
@@ -86,7 +83,7 @@ export default {
             }
         });
 
-        atk.eventBus.on(this.elementId + '-toggle-delete-all', (payload) => {
+        atk.eventBus.on(this.$root.$el.id + '-toggle-delete-all', (payload) => {
             this.deletables = [];
             if (payload.isOn) {
                 this.rowData.forEach((row) => {
@@ -95,7 +92,7 @@ export default {
             }
         });
 
-        atk.eventBus.on(this.elementId + '-multiline-rows-error', (payload) => {
+        atk.eventBus.on(this.$root.$el.id + '-multiline-rows-error', (payload) => {
             this.errors = { ...payload.errors };
         });
     },

--- a/js/src/plugin.js
+++ b/js/src/plugin.js
@@ -78,7 +78,7 @@ function plugin(name, className, shortHand = false) {
 /**
  * Create all jQuery plugins need for atk.
  */
-function createAtkplugins() {
+(function () {
     const atkJqPlugins = [
         { name: 'Spinner', plugin: spinner, sh: false },
         { name: 'ReloadView', plugin: reloadView, sh: false },
@@ -99,6 +99,6 @@ function createAtkplugins() {
     atkJqPlugins.forEach((atkJqPlugin) => {
         plugin(atkJqPlugin.name, atkJqPlugin.plugin, atkJqPlugin.sh);
     });
-}
+}());
 
-export { plugin, createAtkplugins };
+export { plugin };

--- a/js/src/services/vue.service.js
+++ b/js/src/services/vue.service.js
@@ -4,7 +4,7 @@ import SuiVue from 'semantic-ui-vue';
 import DatePicker from 'v-calendar/lib/components/date-picker.umd';
 import atkInlineEdit from '../components/inline-edit.component';
 import itemSearch from '../components/item-search.component';
-import multiLine from '../components/multiline.component';
+import multiLine from '../components/multiline/multiline.component';
 import treeItemSelector from '../components/tree-item-selector/tree-item-selector.component';
 import atkClickOutside from '../directives/click-outside.directive';
 import VueQueryBuilder from '../components/query-builder/query-builder.component.vue';

--- a/js/src/services/vue.service.js
+++ b/js/src/services/vue.service.js
@@ -39,7 +39,6 @@ class VueService {
     constructor() {
         if (!VueService.instance) {
             this.vues = [];
-            this.eventBus = new Vue();
             this.vueMixins = {
                 methods: {
                     getData: function () {
@@ -97,17 +96,6 @@ class VueService {
                 mixins: [this.vueMixins],
             }),
         });
-    }
-
-    /**
-   * Emit an event to the eventBus.
-   * Listener to eventBus can respond to emitted event.
-   *
-   * @param event
-   * @param data
-   */
-    emitEvent(event, data = {}) {
-        this.eventBus.$emit(event, data);
     }
 
     /**

--- a/src/Component/InlineEdit.php
+++ b/src/Component/InlineEdit.php
@@ -200,14 +200,11 @@ class InlineEdit extends View
 
         $fieldName = $this->field ? $this->field : 'name';
 
-        $this->template->set('inputCss', $this->inputCss);
-        $this->template->trySet('fieldName', $fieldName);
-        $this->template->trySet('fieldType', $type);
-
         $this->vue('atk-inline-edit', [
             'initValue' => $initValue,
             'url' => $this->cb->getJsUrl(),
             'saveOnBlur' => $this->saveOnBlur,
+            'options' => ['fieldName' => $fieldName, 'fieldType' => $type, 'inputCss' => $this->inputCss],
         ]);
     }
 }

--- a/src/Component/ItemSearch.php
+++ b/src/Component/ItemSearch.php
@@ -93,7 +93,6 @@ class ItemSearch extends View
     protected function renderView(): void
     {
         $this->class = [];
-        $this->template->set('inputCss', $this->inputCss);
         parent::renderView();
 
         // reloadId is the view id selector name that need to be reload.
@@ -113,7 +112,10 @@ class ItemSearch extends View
                 'url' => $this->reload->jsUrl(),
                 'q' => $this->q,
                 'context' => $this->context,
-                'options' => ['inputTimeOut' => $this->inputTimeOut],
+                'options' => [
+                    'inputTimeOut' => $this->inputTimeOut,
+                    'inputCss' => $this->inputCss,
+                ],
             ]
         ));
     }

--- a/src/Form/Control/Multiline.php
+++ b/src/Form/Control/Multiline.php
@@ -75,7 +75,6 @@ use atk4\data\Reference\HasOne;
 use atk4\data\ValidationException;
 use atk4\ui\Exception;
 use atk4\ui\Form;
-use atk4\ui\JsVueService;
 use atk4\ui\Template;
 
 class Multiline extends Form\Control
@@ -252,7 +251,8 @@ class Multiline extends Form\Control
             // When errors are coming from this Multiline field, then notify Multiline component about them.
             // Otherwise use normal field error.
             if ($fieldName === $this->short_name) {
-                $jsError = [(new JsVueService())->emitEvent('atkml-row-error', ['id' => $this->multiLine->name, 'errors' => $this->rowErrors])];
+                // multiline.js component listen to 'multiline-rows-error' event.
+                $jsError = [$this->jsEmitEvent('multiline-rows-error', ['id' => $this->multiLine->name, 'errors' => $this->rowErrors])];
             } else {
                 $jsError = [$form->js()->form('add prompt', $fieldName, $str)];
             }

--- a/src/Form/Control/Multiline.php
+++ b/src/Form/Control/Multiline.php
@@ -252,7 +252,7 @@ class Multiline extends Form\Control
             // Otherwise use normal field error.
             if ($fieldName === $this->short_name) {
                 // multiline.js component listen to 'multiline-rows-error' event.
-                $jsError = [$this->jsEmitEvent('multiline-rows-error', ['id' => $this->multiLine->name, 'errors' => $this->rowErrors])];
+                $jsError = [$this->jsEmitEvent($this->multiLine->name . '-multiline-rows-error', ['errors' => $this->rowErrors])];
             } else {
                 $jsError = [$form->js()->form('add prompt', $fieldName, $str)];
             }

--- a/src/JsVueService.php
+++ b/src/JsVueService.php
@@ -51,19 +51,6 @@ class JsVueService
     }
 
     /**
-     * Emit an event that other component can listen too.
-     * Allow Vue instances to talk to each other.
-     *
-     * This output js: atk.vueService.emitEvent("eventName", {});
-     *
-     * @return mixed
-     */
-    public function emitEvent($eventName, array $data = [])
-    {
-        return $this->service->emitEvent($eventName, $data);
-    }
-
-    /**
      * Make Vue aware of externally loaded components.
      * The component name must be accessible in javascript using the window namespace.
      * ex: window['SemanticUIVue'].

--- a/src/View.php
+++ b/src/View.php
@@ -845,23 +845,12 @@ class View extends AbstractView implements JsExpressionable
     }
 
     /**
-     * Emit an event on the Vue event bus.
-     * vueService has a dedicated Vue instance for registering
-     * event that allow communication between external view like button,
-     * or even separate vue component, in order to communicate to each other.
+     * Emit an event on atkEvent bus.
      *
-     * Once a component is set for listening to a particular event,
-     * you can emit the event using this function.
+     * example of adding a listener on for an emit event.
      *
-     * Adding a listener is generally done via the created component method.
-     *
-     * example of adding a listener inside the created method.
-     *
-     *      atk.vueService.eventBus.$on('eventName', (data) => {
-     *          // make sure we are talking to the right component.
-     *          if (this.$parent.$el.id === data.id) {
-     *              this.doSomething();
-     *          }
+     *      atk.eventBus.on('eventName', (data) => {
+     *          console.log(data)
      *      });
      *
      * @param string $eventName the event name the will be emit
@@ -869,7 +858,7 @@ class View extends AbstractView implements JsExpressionable
      *
      * @return mixed
      */
-    public function jsVueEmit($eventName, $eventData = [])
+    public function jsEmitEvent($eventName, $eventData = [])
     {
         // adding this view id to data.
         // Usually, you would check if the event is emit for the right component.
@@ -877,7 +866,7 @@ class View extends AbstractView implements JsExpressionable
             $eventData['id'] = $this->name;
         }
 
-        return (new JsVueService())->emitEvent($eventName, $eventData);
+        return (new JsChain('atk.eventBus'))->emit($eventName, $eventData);
     }
 
     /**

--- a/src/View.php
+++ b/src/View.php
@@ -853,19 +853,12 @@ class View extends AbstractView implements JsExpressionable
      *          console.log(data)
      *      });
      *
-     * @param string $eventName the event name the will be emit
-     * @param array  $eventData $eventData   The data passed with the event
-     *
-     * @return mixed
+     * Note: In order to make sure your event is unique within atk, you can
+     * use the view name in it.
+     *    $this->jsEmitEvent($this->name . '-my-event', $data)
      */
-    public function jsEmitEvent($eventName, $eventData = [])
+    public function jsEmitEvent(string $eventName, array $eventData = []): JsChain
     {
-        // adding this view id to data.
-        // Usually, you would check if the event is emit for the right component.
-        if (!isset($eventData['id'])) {
-            $eventData['id'] = $this->name;
-        }
-
         return (new JsChain('atk.eventBus'))->emit($eventName, $eventData);
     }
 

--- a/template/semantic-ui/inline-edit.html
+++ b/template/semantic-ui/inline-edit.html
@@ -1,10 +1,4 @@
 
 <div class="{$_class} {$class}" id="{$_id}" style="{$style}">
-  <atk-inline-edit v-bind="initData" inline-template="inline-template">
-    <div class="inline field">
-      <div class="{$inputCss}" :class="{error: hasError, loading : isLoading}">
-        <input class="{$inlineEditClass}" name="{$fieldName}" type="{$fieldType}" v-model="value" @keyup="onKeyUp" @focus="onFocus" @blur="onBlur"/><i class="icon"></i>
-      </div>
-    </div>
-  </atk-inline-edit>
+  <atk-inline-edit v-bind="initData"></atk-inline-edit>
 </div>

--- a/template/semantic-ui/inline-edit.html
+++ b/template/semantic-ui/inline-edit.html
@@ -1,4 +1,6 @@
 
 <div class="{$_class} {$class}" id="{$_id}" style="{$style}">
-  <atk-inline-edit v-bind="initData"></atk-inline-edit>
+  <div class="inline field">
+    <atk-inline-edit v-bind="initData"></atk-inline-edit>
+  </div>
 </div>

--- a/template/semantic-ui/inline-edit.pug
+++ b/template/semantic-ui/inline-edit.pug
@@ -1,7 +1,3 @@
 div(id="{$_id}", class="{$_class} {$class}", style="{$style}")
-    atk-inline-edit(v-bind="initData" inline-template)
-        .inline.field
-            div(class="{$inputCss}" :class="{error: hasError, loading : isLoading}")
-                input(name="{$fieldName}" class="{$inlineEditClass}" type="{$fieldType}" v-model="value" @keyup="onKeyUp" @focus="onFocus" @blur="onBlur")
-                i.icon
+    atk-inline-edit(v-bind="initData")
 = "\n"

--- a/template/semantic-ui/inline-edit.pug
+++ b/template/semantic-ui/inline-edit.pug
@@ -1,3 +1,4 @@
 div(id="{$_id}", class="{$_class} {$class}", style="{$style}")
-    atk-inline-edit(v-bind="initData")
+    .inline.field
+        atk-inline-edit(v-bind="initData")
 = "\n"

--- a/template/semantic-ui/item-search.html
+++ b/template/semantic-ui/item-search.html
@@ -1,8 +1,4 @@
 
 <div class="{$_class} {$class}" id="{$_id}">
-  <atk-item-search v-bind="initData" inline-template="inline-template">
-    <div class="atk-item-search {$inputCss}">
-      <input class="ui" v-model="query" type="text" placeholder="Search..." @keyup="onChange" @keyup.esc="onEscape" name="atk-vue-search"/><i class="atk-search-icon" :class="classIcon"></i><span style="width:12px;cursor:pointer" @click="onClear"></span>
-    </div>
-  </atk-item-search>
+  <atk-item-search v-bind="initData"></atk-item-search>
 </div>

--- a/template/semantic-ui/item-search.pug
+++ b/template/semantic-ui/item-search.pug
@@ -1,7 +1,3 @@
 div(id="{$_id}", class="{$_class} {$class}")
-    atk-item-search(v-bind="initData" inline-template)
-        div(class="atk-item-search {$inputCss}")
-            input.ui(v-model="query" type='text', placeholder='Search...' @keyup="onChange" @keyup.esc="onEscape" name="atk-vue-search")
-            i(class="atk-search-icon" :class="classIcon")
-            span(style="width:12px;cursor:pointer" @click="onClear")
+    atk-item-search(v-bind="initData")
 = "\n"


### PR DESCRIPTION
- Create eventBus under atk namespace;
 - remove deprecated Vue eventBus (Vue v3)
 - remove deprecated inline-template (Vue v3)
- Move options to atk-utils.js


Small BC- Break:

Emitting an event was done using a Vue Instance from the vue service. Support for emitting/responding to event from a Vue instance will be removed in V3.

Emitting/responding to event is now perform at the atk bundle level using mitt package.

Breaking part:

- JsVueService::emitEvent() method has been remove completelly;
- View::jsVueEmit() method has been replace by View::jsEmitEvent()