### PR TITLE
Dropdown refactor

### DIFF
--- a/demos/basic/menu.php
+++ b/demos/basic/menu.php
@@ -14,7 +14,7 @@ $menu = \atk4\ui\Menu::addTo($app);
 $menu->addItem('foo', 'foo.php');
 $menu->addItem('bar');
 $menu->addItem('baz');
-$dropdown = \atk4\ui\Dropdown::addTo($menu, ['With Callback', 'js' => ['on' => 'hover']]);
+$dropdown = \atk4\ui\Dropdown::addTo($menu, ['With Callback', 'dropdownOptions' => ['on' => 'hover']]);
 $dropdown->setSource(['a', 'b', 'c']);
 $dropdown->onChange(function ($item) {
     return 'New seleced item: ' . $item;

--- a/demos/basic/menu.php
+++ b/demos/basic/menu.php
@@ -16,8 +16,8 @@ $menu->addItem('bar');
 $menu->addItem('baz');
 $dropdown = \atk4\ui\Dropdown::addTo($menu, ['With Callback', 'dropdownOptions' => ['on' => 'hover']]);
 $dropdown->setSource(['a', 'b', 'c']);
-$dropdown->onChange(function ($item) {
-    return 'New seleced item: ' . $item;
+$dropdown->onChange(function ($itemId) {
+    return 'New seleced item id: ' . $itemId;
 });
 
 $submenu = $menu->addMenu('Sub-menu');

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -18,18 +18,18 @@ class Dropdown extends Lister
     public $cb;
 
     /**
-     * Supply an optional parameter to the drop-down.
+     * As per Fomantic-ui dropdown options.
      *
-     * @var array will be converted to json passed into dropdown()
+     * @var array
      */
-    public $js;
+    public $dropdownOptions = [];
 
     protected function init(): void
     {
         parent::init();
 
         if (!$this->cb) {
-            $this->cb = JsCallback::addTo($this, ['urlTrigger' => 'item']);
+            $this->cb = JsCallback::addTo($this);
         }
     }
 
@@ -37,35 +37,31 @@ class Dropdown extends Lister
      * Handle callback when user select a new item value in dropdown.
      * Callback is fire only when selecting a different item value then the current item value.
      * ex:
-     *      $dropdown = Dropdown::addTo($menu, ['menu', 'js' => ['on' => 'hover']]);
+     *      $dropdown = Dropdown::addTo($menu, ['menu', 'dropdownOptions' => ['on' => 'hover']]);
      *      $dropdown->setModel($menuItems);
      *      $dropdown->onChange(function($item) {
-     *          return 'New seleced item: '.$item;
+     *          return 'New selected item: '.$item;
      *      });.
      *
      * @param \Closure $fx handler where new selected Item value is passed too
      */
-    public function onChange(\Closure $fx)
+    public function onChange(\Closure $fx, string $argumentName = 'item')
     {
         // setting dropdown option for using callback url.
-        $this->js['onChange'] = new JsFunction(['name', 'value', 't'], [
+        $this->dropdownOptions['onChange'] = new JsFunction(['value', 'name', 't'], [
             new JsExpression(
-                "if($(this).data('currentValue') != value){\$(this).atkAjaxec({uri:[uri], uri_options:{item:value}});$(this).data('currentValue', value)}",
-                ['uri' => $this->cb->getJsUrl()]
+                "if($(this).data('currentValue') != value){\$(this).atkAjaxec({uri:[uri], uri_options:{[arg_name]:value}});$(this).data('currentValue', value)}",
+                ['uri' => $this->cb->getJsUrl(), 'arg_name' => $argumentName]
             ), ]);
 
-        $this->cb->set(function ($j, $item) use ($fx) {
-            return $fx($item);
-        }, ['item' => 'value']);
+        $this->cb->set(function ($j, $value) use ($fx) {
+            return $fx($value);
+        }, [$argumentName => 'value']);
     }
 
     protected function renderView(): void
     {
-        if (isset($this->js)) {
-            $this->js(true)->dropdown($this->js);
-        } else {
-            $this->js(true)->dropdown();
-        }
+        $this->js(true)->dropdown($this->dropdownOptions);
 
         parent::renderView();
     }

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -45,18 +45,18 @@ class Dropdown extends Lister
      *
      * @param \Closure $fx handler where new selected Item value is passed too
      */
-    public function onChange(\Closure $fx, string $argumentName = 'item')
+    public function onChange(\Closure $fx)
     {
         // setting dropdown option for using callback url.
         $this->dropdownOptions['onChange'] = new JsFunction(['value', 'name', 't'], [
             new JsExpression(
-                "if($(this).data('currentValue') != value){\$(this).atkAjaxec({uri:[uri], uri_options:{[arg_name]:value}});$(this).data('currentValue', value)}",
-                ['uri' => $this->cb->getJsUrl(), 'arg_name' => $argumentName]
+                "if($(this).data('currentValue') != value){\$(this).atkAjaxec({uri:[uri], uri_options:{item:value}});$(this).data('currentValue', value)}",
+                ['uri' => $this->cb->getJsUrl()]
             ), ]);
 
         $this->cb->set(function ($j, $value) use ($fx) {
             return $fx($value);
-        }, [$argumentName => 'value']);
+        }, ['item' => 'value']);
     }
 
     protected function renderView(): void

--- a/template/semantic-ui/dropdown.html
+++ b/template/semantic-ui/dropdown.html
@@ -3,7 +3,7 @@
 <div class="menu">
   {rows}
   {row}
-  <div class="item">{$name}</div>
+  <div class="item" data-value="{$id}">{$name}</div>
   {/}
   {/}
 </div></div>

--- a/template/semantic-ui/dropdown.pug
+++ b/template/semantic-ui/dropdown.pug
@@ -4,7 +4,7 @@
     .menu
         | {rows}
         | {row}
-        .item
+        .item(data-value='{$id}')
             | {$name}
         |
         | {/}


### PR DESCRIPTION
- Now use model id instead of model name for onChange event;
```
$dropdown = \atk4\ui\Dropdown::addTo($menu, ['With Callback', 'dropdownOptions' => ['on' => 'hover']]);
$dropdown->setSource(['a', 'b', 'c']);
$dropdown->onChange(function ($itemId) {
    return 'New seleced item id: ' . $itemId;
});
```   
- Allow to set argument name to send with the request;

Small BC break
 - $js property was rename to $dropdownOptions

