### PR TITLE
Refactor ScopeBuilder date picker

### DIFF
--- a/js/Release.md
+++ b/js/Release.md
@@ -1,5 +1,11 @@
 ## Release note
 
+### version 1.16.3 (2020-09-30)
+
+- create atk-date-picker vue component.
+- Update query-builder
+    - allow date picker customization;
+
 ### version 1.16.2 (2020-09-23)
 - VueService
     - Add possibility to check if all components on page are load.

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atkjs-ui",
-  "version": "1.16.2",
+  "version": "1.16.3",
   "description": "Agile Toolkit Javascript library.",
   "main": "lib/atkjs-ui.js",
   "scripts": {

--- a/js/src/agile-toolkit-ui.js
+++ b/js/src/agile-toolkit-ui.js
@@ -8,7 +8,7 @@ import atkSemantic from 'atk-semantic-ui';
 import date from 'locutus/php/datetime/date';
 import { tableDropdown } from './helpers/table-dropdown.helper';
 import { plugin } from './plugin';
-import { atkOptions, atkEventBus, atkUtilites } from './atk-utils';
+import { atkOptions, atkEventBus, atkUtils } from './atk-utils';
 import dataService from './services/data.service';
 import panelService from './services/panel.service';
 import vueService from './services/vue.service';
@@ -19,7 +19,7 @@ const atk = { ...atkSemantic };
 atk.version = () => _ATKVERSION_;
 atk.options = atkOptions;
 atk.eventBus = atkEventBus;
-atk.utils = atkUtilites;
+atk.utils = atkUtils;
 
 atk.debounce = (fn, value) => {
     const timeOut = atk.options.get('debounceTimeout');

--- a/js/src/agile-toolkit-ui.js
+++ b/js/src/agile-toolkit-ui.js
@@ -8,7 +8,7 @@ import atkSemantic from 'atk-semantic-ui';
 import date from 'locutus/php/datetime/date';
 import { tableDropdown } from './helpers/table-dropdown.helper';
 import { plugin } from './plugin';
-import { atkOptions, atkEventBus } from './atk-utils';
+import { atkOptions, atkEventBus, atkUtilites } from './atk-utils';
 import dataService from './services/data.service';
 import panelService from './services/panel.service';
 import vueService from './services/vue.service';
@@ -19,6 +19,7 @@ const atk = { ...atkSemantic };
 atk.version = () => _ATKVERSION_;
 atk.options = atkOptions;
 atk.eventBus = atkEventBus;
+atk.utils = atkUtilites;
 
 atk.debounce = (fn, value) => {
     const timeOut = atk.options.get('debounceTimeout');

--- a/js/src/atk-utils.js
+++ b/js/src/atk-utils.js
@@ -39,7 +39,7 @@ const atkEventBus = (function () {
 
 /*
 * Utilities function that you can execute
-* from atk context. Usage: atk.exec().date().parse('string');
+* from atk context. Usage: atk.utils.date().parse('string');
 */
 const atkUtilites = (function () {
     return {

--- a/js/src/atk-utils.js
+++ b/js/src/atk-utils.js
@@ -37,4 +37,24 @@ const atkEventBus = (function () {
     };
 }());
 
-export { atkOptions, atkEventBus };
+/*
+* Utilities function that you can execute
+* from atk context. Usage: atk.exec().date().parse('string');
+*/
+const atkUtilites = (function () {
+    return {
+        date: function() {
+            return {
+                // fix date parsing for different time zone if time is not supply.
+                parse: function (dateString) {
+                    if (dateString.match(/^[0-9]{4}[/\-.][0-9]{2}[/\-.][0-9]{2}$/)) {
+                        dateString += ' 00:00:00';
+                    }
+                    return dateString;
+                }
+            }
+        }
+    }
+})();
+
+export { atkOptions, atkEventBus, atkUtilites };

--- a/js/src/atk-utils.js
+++ b/js/src/atk-utils.js
@@ -41,7 +41,7 @@ const atkEventBus = (function () {
 * Utilities function that you can execute
 * from atk context. Usage: atk.utils.date().parse('string');
 */
-const atkUtilites = (function () {
+const atkUtils = (function () {
     return {
         date: function () {
             return {
@@ -57,4 +57,4 @@ const atkUtilites = (function () {
     };
 }());
 
-export { atkOptions, atkEventBus, atkUtilites };
+export { atkOptions, atkEventBus, atkUtils };

--- a/js/src/atk-utils.js
+++ b/js/src/atk-utils.js
@@ -43,7 +43,7 @@ const atkEventBus = (function () {
 */
 const atkUtilites = (function () {
     return {
-        date: function() {
+        date: function () {
             return {
                 // fix date parsing for different time zone if time is not supply.
                 parse: function (dateString) {
@@ -51,10 +51,10 @@ const atkUtilites = (function () {
                         dateString += ' 00:00:00';
                     }
                     return dateString;
-                }
-            }
-        }
-    }
-})();
+                },
+            };
+        },
+    };
+}());
 
 export { atkOptions, atkEventBus, atkUtilites };

--- a/js/src/components/query-builder/fomantic-ui-rule.component.vue
+++ b/js/src/components/query-builder/fomantic-ui-rule.component.vue
@@ -83,13 +83,11 @@
 
 <script>
 import QueryBuilderRule from 'vue-query-builder/dist/rule/QueryBuilderRule.umd';
-import AtkDatePicker from "../share/atk-date-picker";
+import AtkDatePicker from '../share/atk-date-picker';
 
 export default {
-  components: {AtkDatePicker},
-  extends: QueryBuilderRule,
-    component: {
-    },
+    extends: QueryBuilderRule,
+    components: { 'atk-date-picker': AtkDatePicker },
     data: function () {
         return {};
     },
@@ -133,18 +131,18 @@ export default {
             }
         },
         onDateChange: function (date) {
-          this.query.value = date;
+            this.query.value = date;
         },
         getDatePickerProps: function () {
-          return {
-            'input-props' : {class: 'atk-qb-date-picker'},
-            'popover': { placement: 'bottom', visibility: 'click' },
-            ...this.getRootData().data.componentsProps.datePicker || {},
-          }
+            return {
+                'input-props': { class: 'atk-qb-date-picker' },
+                popover: { placement: 'bottom', visibility: 'click' },
+                ...this.getRootData().data.componentsProps.datePicker || {},
+            };
         },
-      getAtkDatePickerProps: function () {
-          return this.getRootData().data.componentsProps.atkDateOptions || {};
-      }
+        getAtkDatePickerProps: function () {
+            return this.getRootData().data.componentsProps.atkDateOptions || {};
+        },
     },
 };
 </script>

--- a/js/src/components/query-builder/fomantic-ui-rule.component.vue
+++ b/js/src/components/query-builder/fomantic-ui-rule.component.vue
@@ -38,12 +38,8 @@
                                 <template v-if="canDisplay('date')">
                                     <div class="ui small input atk-qb">
                                         <v-date-picker
-                                                :locale='dateLocale'
-                                                :input-props="{class: 'atk-qb-date-picker'}"
                                                 v-model="dateValue"
-                                                :masks="dateMask"
-                                                :popover="{ placement: 'bottom', visibility: 'click' }"
-                                                ref="dateRef"></v-date-picker>
+                                                v-bind="getDateProps()"></v-date-picker>
                                     </div>
                                 </template>
                                 <!-- Checkbox or Radio input -->
@@ -150,15 +146,16 @@ export default {
             }
         },
         getDateFromString: function (dateString) {
-            if (dateString) {
-                // fix date parsing for different time zone if time is not supply.
-                if (dateString.match(/^[0-9]{4}[/\-.][0-9]{2}[/\-.][0-9]{2}$/)) {
-                    dateString += ' 00:00:00';
-                }
-                return new Date(dateString);
-            }
-            return new Date();
+            return dateString ? new Date(atk.utils.date().parse(dateString)) : new Date();
         },
+        getDateProps : function () {
+          return {
+            'locale': this.dateLocale,
+            'input-props' : {class: 'atk-qb-date-picker'},
+            'masks': this.dateMask,
+            'popover': { placement: 'bottom', visibility: 'click' },
+            ...this.rule.datePickerOptions}
+        }
     },
 };
 </script>

--- a/js/src/components/query-builder/fomantic-ui-rule.component.vue
+++ b/js/src/components/query-builder/fomantic-ui-rule.component.vue
@@ -37,9 +37,11 @@
                                 <!-- Date input -->
                                 <template v-if="canDisplay('date')">
                                     <div class="ui small input atk-qb">
-                                        <v-date-picker
-                                                v-model="dateValue"
-                                                v-bind="getDateProps()"></v-date-picker>
+                                      <atk-date-picker
+                                          :datePickerProps="getDatePickerProps()"
+                                          :atkDateOptions="getAtkDatePickerProps()"
+                                          :value="query.value"
+                                          @dateChange="onDateChange"></atk-date-picker>
                                     </div>
                                 </template>
                                 <!-- Checkbox or Radio input -->
@@ -81,24 +83,17 @@
 
 <script>
 import QueryBuilderRule from 'vue-query-builder/dist/rule/QueryBuilderRule.umd';
+import AtkDatePicker from "../share/atk-date-picker";
 
 export default {
-    extends: QueryBuilderRule,
+  components: {AtkDatePicker},
+  extends: QueryBuilderRule,
     component: {
     },
     data: function () {
-        return {
-            dateMask: { input: this.rule.format ? this.rule.format : 'YYYY-MM-DD' },
-            dateLocale: this.rule.locale ? this.rule.locale : 'en-En',
-        };
+        return {};
     },
-    mounted: function () {
-        if (this.isDatePicker) {
-            this.$nextTick(() => {
-                this.dateValue = this.getDateFromString(this.query.value);
-            });
-        }
-    },
+    inject: ['getRootData'],
     computed: {
         isInput: function () {
             return this.rule.type === 'text' || this.rule.type === 'numeric';
@@ -114,14 +109,6 @@ export default {
         },
         isSelect: function () {
             return this.rule.type === 'select';
-        },
-        dateValue: {
-            get: function () {
-                return this.getDateFromString(this.query.value);
-            },
-            set: function (date) {
-                this.query.value = date ? atk.phpDate('Y-m-d', date) : '';
-            },
         },
     },
     methods: {
@@ -145,23 +132,25 @@ export default {
             default: return false;
             }
         },
-        getDateFromString: function (dateString) {
-            return dateString ? new Date(atk.utils.date().parse(dateString)) : new Date();
+        onDateChange: function (date) {
+          this.query.value = date;
         },
-        getDateProps : function () {
+        getDatePickerProps: function () {
           return {
-            'locale': this.dateLocale,
             'input-props' : {class: 'atk-qb-date-picker'},
-            'masks': this.dateMask,
             'popover': { placement: 'bottom', visibility: 'click' },
-            ...this.rule.datePickerOptions}
-        }
+            ...this.getRootData().data.componentsProps.datePicker || {},
+          }
+        },
+      getAtkDatePickerProps: function () {
+          return this.getRootData().data.componentsProps.atkDateOptions || {};
+      }
     },
 };
 </script>
 
 <style>
-    .ui.input.atk-qb > input, .ui.input.atk-qb > span > input, .ui.form .input.atk-qb {
+    .ui.input.atk-qb > input, .ui.input.atk-qb span > input, .ui.form .input.atk-qb {
         padding: 6px;
     }
     .ui.grid > .row.atk-qb {

--- a/js/src/components/share/atk-date-picker.js
+++ b/js/src/components/share/atk-date-picker.js
@@ -1,0 +1,50 @@
+/**
+ * Wrapper for v-date-picker component from V-Calendar
+ * https://vcalendar.io/
+ *
+ * Props
+ *  value: The initial date vale as a string.
+ *  datePickerProps: Any of v-date-picker components props
+ *  atkDateOptions:
+ *    useTodayDefault: Will set picker to today when value is null, false by default.
+ *    phpDateFormat: The string format for representing the date value.
+ *
+ *   Will emit a dateChange event when date is set.
+ */
+
+const template = `<v-date-picker v-model="date" v-bind="datePickerProps" @input="onChange"></v-date-picker>`;
+
+export default {
+  name: 'atk-date-picker',
+  template: template,
+  props: ['value', 'datePickerProps', 'atkDateOptions'],
+  data: function() {
+    const {useTodayDefault = false, phpDateFormat = 'Y-m-d' } = this.atkDateOptions || {};
+    return {
+      useTodayDefault: useTodayDefault,
+      phpDateFormat: phpDateFormat,
+      date: null,
+    }
+  },
+  mounted: function () {
+    if (this.useTodayDefault && this.value === null) {
+      this.date = new Date()
+    } else if (this.value) {
+      this.date = this.getDateFromString(this.value);
+    }
+
+    if (this.date) {
+      this.$emit('dateChange', atk.phpDate(this.phpDateFormat, this.date));
+    }
+  },
+  computed: {
+  },
+  methods: {
+    onChange: function (date) {
+      this.$emit('dateChange', atk.phpDate(this.phpDateFormat, date));
+    },
+    getDateFromString: function (dateString) {
+      return new Date(atk.utils.date().parse(dateString));
+    },
+  }
+}

--- a/js/src/components/share/atk-date-picker.js
+++ b/js/src/components/share/atk-date-picker.js
@@ -12,39 +12,39 @@
  *   Will emit a dateChange event when date is set.
  */
 
-const template = `<v-date-picker v-model="date" v-bind="datePickerProps" @input="onChange"></v-date-picker>`;
+const template = '<v-date-picker v-model="date" v-bind="datePickerProps" @input="onChange"></v-date-picker>';
 
 export default {
-  name: 'atk-date-picker',
-  template: template,
-  props: ['value', 'datePickerProps', 'atkDateOptions'],
-  data: function() {
-    const {useTodayDefault = false, phpDateFormat = 'Y-m-d' } = this.atkDateOptions || {};
-    return {
-      useTodayDefault: useTodayDefault,
-      phpDateFormat: phpDateFormat,
-      date: null,
-    }
-  },
-  mounted: function () {
-    if (this.useTodayDefault && this.value === null) {
-      this.date = new Date()
-    } else if (this.value) {
-      this.date = this.getDateFromString(this.value);
-    }
+    name: 'atk-date-picker',
+    template: template,
+    props: ['value', 'datePickerProps', 'atkDateOptions'],
+    data: function () {
+        const { useTodayDefault = false, phpDateFormat = 'Y-m-d' } = this.atkDateOptions || {};
+        return {
+            useTodayDefault: useTodayDefault,
+            phpDateFormat: phpDateFormat,
+            date: null,
+        };
+    },
+    mounted: function () {
+        if (this.useTodayDefault && this.value === null) {
+            this.date = new Date();
+        } else if (this.value) {
+            this.date = this.getDateFromString(this.value);
+        }
 
-    if (this.date) {
-      this.$emit('dateChange', atk.phpDate(this.phpDateFormat, this.date));
-    }
-  },
-  computed: {
-  },
-  methods: {
-    onChange: function (date) {
-      this.$emit('dateChange', atk.phpDate(this.phpDateFormat, date));
+        if (this.date) {
+            this.$emit('dateChange', atk.phpDate(this.phpDateFormat, this.date));
+        }
     },
-    getDateFromString: function (dateString) {
-      return new Date(atk.utils.date().parse(dateString));
+    computed: {
     },
-  }
-}
+    methods: {
+        onChange: function (date) {
+            this.$emit('dateChange', atk.phpDate(this.phpDateFormat, date));
+        },
+        getDateFromString: function (dateString) {
+            return new Date(atk.utils.date().parse(dateString));
+        },
+    },
+};

--- a/src/Form/Control/ScopeBuilder.php
+++ b/src/Form/Control/ScopeBuilder.php
@@ -68,7 +68,7 @@ class ScopeBuilder extends Control
      * The atk-date-picker props options:
      *    'phpDateFormat' The date format value. Default: 'Y-m-d'
      *    'useTodayDefault' Will set date value to today when date value is set to null.
-     * 
+     *
      * @var array
      */
     public $atkdDateOptions = [];
@@ -185,14 +185,6 @@ class ScopeBuilder extends Control
 
     /**
      * Definition of rule types.
-     *
-     * Note: date field used v-date-picker for date selection
-     * v-date-picker options (props) can be set via it's rule
-     * datePickerOptions property.
-     *  'datePickerOptions' => [
-     *     'first-day-of-week' => 2 // calendar start on Monday
-     *     'popover'=> [ 'placement' => 'right', 'visibility' => 'hover' ] // display at right when hovering.
-     *   ]
      *
      * @var array
      */

--- a/src/Form/Control/ScopeBuilder.php
+++ b/src/Form/Control/ScopeBuilder.php
@@ -58,6 +58,21 @@ class ScopeBuilder extends Control
      */
     public static $listDelimiters = [';', ','];
 
+    /** @var array The Vue v-date-picker component props. Leave empty for default. */
+    public $datePickerProps = [
+        'locale' => 'en-En',
+        'masks'  => ['input' => 'YYYY-MM-DD']
+    ];
+
+    /**
+     * The atk-date-picker props options:
+     *    'phpDateFormat' The date format value. Default: 'Y-m-d'
+     *    'useTodayDefault' Will set date value to today when date value is set to null.
+     * 
+     * @var array
+     */
+    public $atkdDateOptions = [];
+
     /**
      * The scopebuilder View. Assigned in init().
      *
@@ -252,8 +267,6 @@ class ScopeBuilder extends Control
                 self::OPERATOR_EMPTY,
                 self::OPERATOR_NOT_EMPTY,
             ],
-            // v-date-picker options. Leave empty for default options.
-            'datePickerOptions' => []
         ],
         'datetime' => 'date',
         'integer' => 'numeric',
@@ -438,6 +451,10 @@ class ScopeBuilder extends Control
                     'labels' => $this->labels ?? null,
                     'form' => $this->form->formElement->name,
                     'debug' => $this->options['debug'] ?? false,
+                    'componentsProps' => [
+                        'datePicker' => $this->datePickerProps,
+                        'atkDateOptions' => $this->atkdDateOptions,
+                    ]
                 ],
             ]
         );

--- a/src/Form/Control/ScopeBuilder.php
+++ b/src/Form/Control/ScopeBuilder.php
@@ -171,6 +171,14 @@ class ScopeBuilder extends Control
     /**
      * Definition of rule types.
      *
+     * Note: date field used v-date-picker for date selection
+     * v-date-picker options (props) can be set via it's rule
+     * datePickerOptions property.
+     *  'datePickerOptions' => [
+     *     'first-day-of-week' => 2 // calendar start on Monday
+     *     'popover'=> [ 'placement' => 'right', 'visibility' => 'hover' ] // display at right when hovering.
+     *   ]
+     *
      * @var array
      */
     protected static $ruleTypes = [
@@ -244,6 +252,8 @@ class ScopeBuilder extends Control
                 self::OPERATOR_EMPTY,
                 self::OPERATOR_NOT_EMPTY,
             ],
+            // v-date-picker options. Leave empty for default options.
+            'datePickerOptions' => []
         ],
         'datetime' => 'date',
         'integer' => 'numeric',

--- a/src/Form/Control/ScopeBuilder.php
+++ b/src/Form/Control/ScopeBuilder.php
@@ -61,7 +61,7 @@ class ScopeBuilder extends Control
     /** @var array The Vue v-date-picker component props. Leave empty for default. */
     public $datePickerProps = [
         'locale' => 'en-En',
-        'masks'  => ['input' => 'YYYY-MM-DD']
+        'masks' => ['input' => 'YYYY-MM-DD'],
     ];
 
     /**
@@ -71,7 +71,9 @@ class ScopeBuilder extends Control
      *
      * @var array
      */
-    public $atkdDateOptions = [];
+    public $atkdDateOptions = [
+        'useTodayDefault' => true,
+    ];
 
     /**
      * The scopebuilder View. Assigned in init().
@@ -446,7 +448,7 @@ class ScopeBuilder extends Control
                     'componentsProps' => [
                         'datePicker' => $this->datePickerProps,
                         'atkDateOptions' => $this->atkdDateOptions,
-                    ]
+                    ],
                 ],
             ]
         );


### PR DESCRIPTION
- Create atk-date-picker component wrapper for v-date-picker;

- Allow customizing date picker in the query builder via v-date-picker props.

Example: Starting calendar on a Monday by setting the first-day-of-week option and changing language

```
    public $datePickerProps = [
        'locale' => 'fr-Fr',
        'masks' => ['input' => 'YYYY-MM-DD'],
        'first-day-of-week' => 2
    ];
```

<img width="563" alt="Screen Shot 2020-09-30 at 10 59 14 AM" src="https://user-images.githubusercontent.com/2204478/94702709-0e56ea00-030c-11eb-8c2b-809aca18e4af.png">



