### PR TITLE
Cleanup JsExpression to string/JS

### DIFF
--- a/demos/_includes/FlyersForm.php
+++ b/demos/_includes/FlyersForm.php
@@ -48,7 +48,7 @@ class FlyersForm extends Form
         $ml->setModel(new Flyers(new \atk4\data\Persistence\Array_($this->flyers)));
 
         $cards = $this->addControl('cards', [Form\Control\TreeItemSelector::class, 'treeItems' => $this->cards, 'caption' => 'Flyers program:'], ['type' => 'array', 'serialize' => 'json']);
-        $cards->set(json_encode([]));
+        $cards->set($this->app->encodeJson([]));
 
         $this->onSubmit(function ($form) {
             return new \atk4\ui\JsToast('Thank you!');

--- a/demos/form-control/multiline.php
+++ b/demos/form-control/multiline.php
@@ -75,5 +75,5 @@ $multiline->jsAfterDelete = new JsFunction(['value'], [new JsExpression('console
 $form->onSubmit(function (Form $form) use ($multiline) {
     $rows = $multiline->saveRows()->getModel()->export();
 
-    return new \atk4\ui\JsToast(json_encode(array_values($rows)));
+    return new \atk4\ui\JsToast($form->app->encodeJson(array_values($rows)));
 });

--- a/demos/form-control/tree-item-selector.php
+++ b/demos/form-control/tree-item-selector.php
@@ -41,8 +41,8 @@ $form = Form::addTo($app);
 $control = $form->addControl('tree', [Form\Control\TreeItemSelector::class, 'treeItems' => $items, 'caption' => 'Multiple selection:'], ['type' => 'array', 'serialize' => 'json']);
 $control->set($app->encodeJson([201, 301, 503]));
 
-//$control->onItem(function($value) {
-//    return new \atk4\ui\JsToast(json_encode($value));
+//$control->onItem(function($value) use ($app) {
+//    return new \atk4\ui\JsToast($app->encodeJson($value));
 //});
 
 $control = $form->addControl('tree1', [Form\Control\TreeItemSelector::class, 'treeItems' => $items, 'allowMultiple' => false, 'caption' => 'Single selection:']);

--- a/demos/form/form-section.php
+++ b/demos/form/form-section.php
@@ -20,7 +20,7 @@ $model->loadAny();
 $noSave = function (Form $form) {
     return new \atk4\ui\JsToast([
         'title' => 'POSTed field values',
-        'message' => '<pre>' . json_encode($form->model->get(), JSON_PRETTY_PRINT) . '</pre>',
+        'message' => '<pre>' . $form->app->encodeJson($form->model->get()) . '</pre>',
         'class' => 'success',
         'displayTime' => 5000,
     ]);

--- a/demos/form/form3.php
+++ b/demos/form/form3.php
@@ -39,7 +39,7 @@ $form->onSubmit(function (Form $form) {
     foreach ($form->model->dirty as $field => $value) {
         // we should care only about editable fields
         if ($form->model->getField($field)->isEditable()) {
-            $errors[] = $form->error($field, 'Value was changed, ' . json_encode($value) . ' to ' . json_encode($form->model->get($field)));
+            $errors[] = $form->error($field, 'Value was changed, ' . $form->app->encodeJson($value) . ' to ' . $form->app->encodeJson($form->model->get($field)));
         }
     }
 

--- a/demos/others/sticky2.php
+++ b/demos/others/sticky2.php
@@ -41,7 +41,7 @@ $t->addDecorator('name', [\atk4\ui\Table\Column\Link::class, [], ['name']]);
 
 $frame = \atk4\ui\View::addTo($app, ['ui' => 'green segment']);
 \atk4\ui\Button::addTo($frame, ['does not inherit sticky get'])->on('click', function () use ($app) {
-    return new \atk4\ui\JsNotify('$_GET = ' . $this->app->encodeJson($_GET));
+    return new \atk4\ui\JsNotify('$_GET = ' . $app->encodeJson($_GET));
 });
 
 \atk4\ui\Header::addTo($app, ['Use of View::url()']);

--- a/demos/others/sticky2.php
+++ b/demos/others/sticky2.php
@@ -40,8 +40,8 @@ $t->setSource(['Red', 'Green', 'Blue']);
 $t->addDecorator('name', [\atk4\ui\Table\Column\Link::class, [], ['name']]);
 
 $frame = \atk4\ui\View::addTo($app, ['ui' => 'green segment']);
-\atk4\ui\Button::addTo($frame, ['does not inherit sticky get'])->on('click', function () {
-    return new \atk4\ui\JsNotify('$_GET = ' . json_encode($_GET));
+\atk4\ui\Button::addTo($frame, ['does not inherit sticky get'])->on('click', function () use ($app) {
+    return new \atk4\ui\JsNotify('$_GET = ' . $this->app->encodeJson($_GET));
 });
 
 \atk4\ui\Header::addTo($app, ['Use of View::url()']);

--- a/docs/table.rst
+++ b/docs/table.rst
@@ -462,7 +462,7 @@ column name in table with their new width in pixel.::
 
     $table->resizableColumn(function($j, $w){
         // do something with new column width
-        $columnWidths = json_decode($w);
+        $columnWidths = $this->app->decodeJson($w);
         return;
     }, [200,300,100,100,100]);
 

--- a/docs/tree-item-selector.rst
+++ b/docs/tree-item-selector.rst
@@ -91,8 +91,8 @@ Callback Usage
 It is possible to run a callback function every time an item is select on the list. The callback function will receive the selected item
 set by the user.::
 
-    $control->onItem(function($value) {
-        return new \atk4\ui\JsToast(json_encode($value));
+    $control->onItem(function($value) use ($app) {
+        return new \atk4\ui\JsToast($app->encodeJson($value));
     });
 
 Note

--- a/docs/tree-item-selector.rst
+++ b/docs/tree-item-selector.rst
@@ -91,8 +91,8 @@ Callback Usage
 It is possible to run a callback function every time an item is select on the list. The callback function will receive the selected item
 set by the user.::
 
-    $control->onItem(function($value) use ($app) {
-        return new \atk4\ui\JsToast($app->encodeJson($value));
+    $control->onItem(function($value) {
+        return new \atk4\ui\JsToast($this->app->encodeJson($value));
     });
 
 Note

--- a/src/App.php
+++ b/src/App.php
@@ -934,9 +934,10 @@ class App
 
     public function decodeJson(string $json)
     {
-        $data = json_decode($json, true, 512, JSON_BIGINT_AS_STRING);
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new Exception('JSON decode error: ' . json_last_error_msg());
+        try {
+            $data = json_decode($json, true, 512, JSON_BIGINT_AS_STRING | JSON_THROW_ON_ERROR);
+        } catch (\Exception $e) {
+            throw new Exception('JSON decode error', 0, $e);
         }
 
         return $data;
@@ -949,9 +950,10 @@ class App
             $options |= JSON_FORCE_OBJECT;
         }
 
-        $json = json_encode($data, $options, 512);
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new Exception('JSON encode error: ' . json_last_error_msg());
+        try {
+            $json = json_encode($data, $options | JSON_THROW_ON_ERROR, 512);
+        } catch (\Exception $e) {
+            throw new Exception('JSON encode error', 0, $e);
         }
 
         // IMPORTANT: always convert large integers to string, otherwise numbers can be rounded by JS

--- a/src/App.php
+++ b/src/App.php
@@ -934,11 +934,7 @@ class App
 
     public function decodeJson(string $json)
     {
-        try {
-            $data = json_decode($json, true, 512, JSON_BIGINT_AS_STRING | JSON_THROW_ON_ERROR);
-        } catch (\Exception $e) {
-            throw new Exception('JSON decode error', 0, $e);
-        }
+        $data = json_decode($json, true, 512, JSON_BIGINT_AS_STRING | JSON_THROW_ON_ERROR);
 
         return $data;
     }
@@ -950,11 +946,7 @@ class App
             $options |= JSON_FORCE_OBJECT;
         }
 
-        try {
-            $json = json_encode($data, $options | JSON_THROW_ON_ERROR, 512);
-        } catch (\Exception $e) {
-            throw new Exception('JSON encode error', 0, $e);
-        }
+        $json = json_encode($data, $options | JSON_THROW_ON_ERROR, 512);
 
         // IMPORTANT: always convert large integers to string, otherwise numbers can be rounded by JS
         // replace large JSON integers only, do not replace anything in JSON/JS strings

--- a/src/Console.php
+++ b/src/Console.php
@@ -372,7 +372,7 @@ class Console extends View implements \Psr\Log\LoggerInterface
             throw (new Exception('Incorrect value for an object'))
                 ->addMoreInfo('object', $object);
         }
-        $this->output('--[ Result: ' . json_encode($result) . ' ]------------');
+        $this->output('--[ Result: ' . $this->app->encodeJson($result) . ' ]------------');
 
         return $this;
     }

--- a/src/Form/Control/Dropdown.php
+++ b/src/Form/Control/Dropdown.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace atk4\ui\Form\Control;
 
 use atk4\ui\JsExpression;
+use atk4\ui\JsExpressionable;
 use atk4\ui\JsFunction;
 
 /**
@@ -227,10 +228,8 @@ class Dropdown extends Input
 
     /**
      * Render js for dropdown.
-     *
-     * @return mixed
      */
-    protected function jsRenderDropdown()
+    protected function jsRenderDropdown(): JsExpressionable
     {
         return $this->js(true)->dropdown($this->dropdownOptions);
     }

--- a/src/Form/Control/Multiline.php
+++ b/src/Form/Control/Multiline.php
@@ -240,7 +240,7 @@ class Multiline extends Form\Control
 
         // load the data associated with this input and validate it.
         $this->form->onHook(Form::HOOK_LOAD_POST, function ($form) {
-            $this->rowData = json_decode($_POST[$this->short_name], true);
+            $this->rowData = $this->app->decodeJson($_POST[$this->short_name]);
             if ($this->rowData) {
                 $this->rowErrors = $this->validate($this->rowData);
                 if ($this->rowErrors) {
@@ -328,7 +328,7 @@ class Multiline extends Form\Control
                     $data[] = $d_row;
                 }
             }
-            $data = json_encode($data, JSON_UNESCAPED_UNICODE);
+            $data = $this->app->encodeJson($data);
         }
 
         return $data;
@@ -731,7 +731,7 @@ class Multiline extends Form\Control
                 break;
             case 'on-change':
                 // Let regular callback render output.
-                return ($this->onChangeFunction)(json_decode($_POST['rows'], true), $this->form);
+                return ($this->onChangeFunction)($this->app->decodeJson($_POST['rows']), $this->form);
 
                 break;
         }

--- a/src/Form/Control/TreeItemSelector.php
+++ b/src/Form/Control/TreeItemSelector.php
@@ -99,7 +99,10 @@ class TreeItemSelector extends Form\Control
     public function onItem(\Closure $fx)
     {
         $this->cb = JsCallback::addTo($this)->set(function ($j, $data) use ($fx) {
-            $value = $this->allowMultiple ? json_decode($data, true) : json_decode($data, true)[0];
+            $value = $this->app->decodeJson($data);
+            if (!$this->allowMultiple) {
+                $value = $value[0];
+            }
 
             return $fx($value);
         }, ['data' => 'value']);

--- a/src/JsCallback.php
+++ b/src/JsCallback.php
@@ -68,7 +68,7 @@ class JsCallback extends Callback implements JsExpressionable
         return $out;
     }
 
-    public function jsRender()
+    public function jsRender(): string
     {
         if (!$this->app) {
             throw new Exception('Call-back must be part of a RenderTree');

--- a/src/JsChain.php
+++ b/src/JsChain.php
@@ -156,12 +156,7 @@ class JsChain extends JsExpression
             ')';
     }
 
-    /**
-     * Produce String representing this JavaScript extension.
-     *
-     * @return string
-     */
-    public function jsRender()
+    public function jsRender(): string
     {
         $ret = '';
 

--- a/src/JsConditionalForm.php
+++ b/src/JsConditionalForm.php
@@ -55,7 +55,7 @@ class JsConditionalForm implements JsExpressionable
         $this->fieldRules = $rules;
     }
 
-    public function jsRender()
+    public function jsRender(): string
     {
         $chain = (new Jquery($this->form))
             ->atkConditionalForm([

--- a/src/JsExpression.php
+++ b/src/JsExpression.php
@@ -35,10 +35,8 @@ class JsExpression implements JsExpressionable
 
     /**
      * Converts this arbitrary JavaScript expression into string.
-     *
-     * @return string
      */
-    public function jsRender()
+    public function jsRender(): string
     {
         $namelessCount = 0;
 
@@ -82,14 +80,10 @@ class JsExpression implements JsExpressionable
     }
 
     /**
-     * Provides replacement for json_encode that will respect JsExpressionable objects
+     * Provides replacement for json_encode() that will respect JsExpressionable objects
      * and call jsRender() for them instead of escaping.
-     *
-     * @param mixed $arg anything
-     *
-     * @return string valid JSON expression
      */
-    protected function _json_encode($arg)
+    protected function _json_encode($arg): string
     {
         /*
          * This function is very similar to json_encode, however it will traverse array
@@ -126,7 +120,7 @@ class JsExpression implements JsExpressionable
                 $string = '[' . implode(',', $array) . ']';
             }
         } elseif (is_string($arg)) {
-            $string = '"' . $this->_safe_js_string($arg) . '"';
+            $string = json_encode($arg, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
         } elseif (is_bool($arg)) {
             $string = json_encode($arg);
         } elseif (is_int($arg)) {
@@ -142,45 +136,5 @@ class JsExpression implements JsExpressionable
         }
 
         return $string;
-    }
-
-    /**
-     * TODO: Escapes the string, but needs a reference to where this code has been from.
-     *
-     * @internal
-     *
-     * @param string $str
-     */
-    public function _safe_js_string($str)
-    {
-        $length = strlen($str);
-        $ret = '';
-        for ($i = 0; $i < $length; ++$i) {
-            switch ($str[$i]) {
-                case "\r":
-                    $ret .= '\\r';
-
-                    break;
-                case "\n":
-                    $ret .= '\\n';
-
-                    break;
-                case '"':
-                case "'":
-                case '<':
-                case '>':
-                case '&':
-                case '\\':
-                    $ret .= '\x' . dechex(ord($str[$i]));
-
-                    break;
-                default:
-                    $ret .= $str[$i];
-
-                    break;
-            }
-        }
-
-        return $ret;
     }
 }

--- a/src/JsExpression.php
+++ b/src/JsExpression.php
@@ -120,7 +120,7 @@ class JsExpression implements JsExpressionable
                 $string = '[' . implode(',', $array) . ']';
             }
         } elseif (is_string($arg)) {
-            $string = json_encode($arg, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+            $string = json_encode($arg, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
         } elseif (is_bool($arg)) {
             $string = json_encode($arg);
         } elseif (is_int($arg)) {

--- a/src/JsExpressionable.php
+++ b/src/JsExpressionable.php
@@ -9,8 +9,5 @@ namespace atk4\ui;
  */
 interface JsExpressionable
 {
-    /**
-     * Convert JsExpression into string.
-     */
-    public function jsRender();
+    public function jsRender(): string;
 }

--- a/src/JsFunction.php
+++ b/src/JsFunction.php
@@ -53,12 +53,7 @@ class JsFunction implements JsExpressionable
         }
     }
 
-    /**
-     * Render function/expression.
-     *
-     * @return string
-     */
-    public function jsRender()
+    public function jsRender(): string
     {
         $pre = '';
 

--- a/src/JsNotify.php
+++ b/src/JsNotify.php
@@ -170,12 +170,7 @@ class JsNotify implements JsExpressionable
         return $this;
     }
 
-    /**
-     * Render the notifier.
-     *
-     * @return string
-     */
-    public function jsRender()
+    public function jsRender(): string
     {
         if ($this->attachTo) {
             $final = $this->attachTo->js();

--- a/src/JsReload.php
+++ b/src/JsReload.php
@@ -50,7 +50,7 @@ class JsReload implements JsExpressionable
         $this->includeStorage = $includeStorage;
     }
 
-    public function jsRender()
+    public function jsRender(): string
     {
         $final = (new Jquery($this->view))
             ->atkReloadView(

--- a/src/JsSse.php
+++ b/src/JsSse.php
@@ -41,7 +41,7 @@ class JsSse extends JsCallback
         }
     }
 
-    public function jsRender()
+    public function jsRender(): string
     {
         if (!$this->app) {
             throw new Exception('Call-back must be part of a RenderTree');

--- a/src/JsToast.php
+++ b/src/JsToast.php
@@ -49,7 +49,7 @@ class JsToast implements JsExpressionable
         return $this;
     }
 
-    public function jsRender()
+    public function jsRender(): string
     {
         return (new Jquery('body'))->toast($this->settings)->jsRender();
     }

--- a/src/Persistence/Ui.php
+++ b/src/Persistence/Ui.php
@@ -98,7 +98,7 @@ class Ui extends \atk4\data\Persistence
         case 'array':
         case 'object':
             // don't encode if we already use some kind of serialization
-            $value = $f->serialize ? $value : json_encode($value);
+            $value = $f->serialize ? $value : json_encode($value, JSON_THROW_ON_ERROR);
 
             break;
         }

--- a/src/Table.php
+++ b/src/Table.php
@@ -376,7 +376,7 @@ class Table extends Lister
      * ex:
      *  $table->resizableColumn(function($j, $w){
      *       // do somethings with columns width
-     *       $columns = json_decode($w);
+     *       $columns = $this->app->decodeJson($w);
      *   });
      *
      * @param \Closure $fx             a callback function with columns widths as parameter

--- a/src/UserAction/JsEventExecutor.php
+++ b/src/UserAction/JsEventExecutor.php
@@ -123,7 +123,7 @@ class JsEventExecutor implements JsExpressionable
         return $errors;
     }
 
-    public function jsRender()
+    public function jsRender(): string
     {
         $this->cb->set(function () {
             $id = $_POST['atk_event_id'] ?? null;

--- a/src/View.php
+++ b/src/View.php
@@ -873,8 +873,8 @@ class View extends AbstractView implements JsExpressionable
      */
     public function jsGetStoreData()
     {
-        $data['local'] = json_decode($_GET[$this->name . '_local_store'] ?? $_POST[$this->name . '_local_store'] ?? 'null', true);
-        $data['session'] = json_decode($_GET[$this->name . '_session_store'] ?? $_POST[$this->name . '_session_store'] ?? 'null', true);
+        $data['local'] = json_decode($_GET[$this->name . '_local_store'] ?? $_POST[$this->name . '_local_store'] ?? 'null', true, 512, JSON_THROW_ON_ERROR);
+        $data['session'] = json_decode($_GET[$this->name . '_session_store'] ?? $_POST[$this->name . '_session_store'] ?? 'null', true, 512, JSON_THROW_ON_ERROR);
 
         return $data;
     }
@@ -916,7 +916,7 @@ class View extends AbstractView implements JsExpressionable
             throw new Exception('View property name needs to be set.');
         }
 
-        return (new JsChain('atk.dataService'))->addJsonData($name, json_encode($data), $type);
+        return (new JsChain('atk.dataService'))->addJsonData($name, json_encode($data, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR), $type);
     }
 
     /**
@@ -1118,7 +1118,7 @@ class View extends AbstractView implements JsExpressionable
             throw new Exception('Render tree must be initialized before materializing JsChains.');
         }
 
-        return json_encode('#' . $this->id);
+        return json_encode('#' . $this->id, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
     }
 
     /**

--- a/src/View.php
+++ b/src/View.php
@@ -1111,10 +1111,8 @@ class View extends AbstractView implements JsExpressionable
 
     /**
      * Convert View into a value in case it happens to be inside our json_encode (as argument to JsChain).
-     *
-     * @return string
      */
-    public function jsRender()
+    public function jsRender(): string
     {
         if (!$this->_initialized) {
             throw new Exception('Render tree must be initialized before materializing JsChains.');

--- a/tests/CallbackTest.php
+++ b/tests/CallbackTest.php
@@ -26,11 +26,10 @@ class AppMock extends \atk4\ui\App
 
 class CallbackTest extends AtkPhpunit\TestCase
 {
-    /**
-     * Test constructor.
-     */
-    private $regex = '/^..DOCTYPE/';
+    /** @var string */
+    private $htmlDoctypeRegex = '~^<!DOCTYPE~';
 
+    /** @var \atk4\ui\App */
     public $app;
 
     protected function setUp(): void
@@ -94,7 +93,7 @@ class CallbackTest extends AtkPhpunit\TestCase
 
         $this->assertNull($var);
 
-        $this->expectOutputRegex($this->regex);
+        $this->expectOutputRegex($this->htmlDoctypeRegex);
         $app->run();
 
         $this->assertSame(34, $var);
@@ -122,7 +121,7 @@ class CallbackTest extends AtkPhpunit\TestCase
 
         $this->assertNull($var);
 
-        $this->expectOutputRegex($this->regex);
+        $this->expectOutputRegex($this->htmlDoctypeRegex);
         $app->run();
 
         $this->assertSame(34, $var);
@@ -143,7 +142,7 @@ class CallbackTest extends AtkPhpunit\TestCase
 
         $this->assertNull($var);
 
-        $this->expectOutputRegex($this->regex);
+        $this->expectOutputRegex($this->htmlDoctypeRegex);
         $app->run();
 
         $this->assertNull($var);

--- a/tests/DemosTest.php
+++ b/tests/DemosTest.php
@@ -212,7 +212,9 @@ class DemosTest extends AtkPhpunit\TestCase
         return 'demos/' . $path;
     }
 
-    protected $regexHtml = '~^..DOCTYPE~';
+    /** @var string */
+    protected $regexHtml = '~^<!DOCTYPE~';
+    /** @var string */
     protected $regexJson = '~
         (?(DEFINE)
            (?<number>   -? (?= [1-9]|0(?!\d) ) \d+ (\.\d+)? ([eE] [+-]? \d+)? )
@@ -225,6 +227,7 @@ class DemosTest extends AtkPhpunit\TestCase
         )
         \A (?&json) \Z
         ~six';
+    /** @var string */
     protected $regexSse = '~^(id|event|data).*$~m';
 
     public function demoFilesProvider(): array


### PR DESCRIPTION
breaking as `jsRender()` method signature is changed and needs to be adjusted if overrided

also use App JSON encode/decode as possible, but keep native json_encode/json_decode in View, so it can be (at least for now) used without an App