### PR TITLE
Fix caching, use raw.githack.com instead of jsdelivr for develop

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -18,7 +18,7 @@ jobs:
           echo "::set-env name=version::$v"
 
           git branch
-          #sed -i "s|'https://cdn.jsdelivr.net/gh/atk4/ui@develop/public.*|'https://cdn.jsdelivr.net/gh/atk4/ui@$v/public',|" src/App.php
+          #sed -i "s|'https://raw.githack.com/atk4/ui/develop/public.*|'https://cdn.jsdelivr.net/gh/atk4/ui@$v/public',|" src/App.php
           # it was develop, it can stay develop for DEVELOP branch, so we see changes to JS right away.
 
           # Set next version for develop branch
@@ -44,7 +44,7 @@ jobs:
           pr_body: |
             Compiled JS files from last release are here:
 
-              https://cdn.jsdelivr.net/gh/atk4/ui@${{ env.version }}/public/
+            https://cdn.jsdelivr.net/gh/atk4/ui@${{ env.version }}/public/
 
           pr_reviewer: "romaninsh"
           pr_assignee: "romaninsh"

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -242,7 +242,7 @@ jobs:
         run: |
           cp -r public public.orig && rm public/*.js
           (cd js && npm run build)
-          sed -i "s~'https://cdn.jsdelivr.net/gh/atk4/ui@develop/public.*~'/public',~" src/App.php
+          sed -i "s~'https://raw.githack.com/atk4/ui/develop/public.*~'/public',~" src/App.php
           diff -qr public public.orig
           rm -r public.orig
 

--- a/src/App.php
+++ b/src/App.php
@@ -38,7 +38,7 @@ class App
 
     /** @var array|false Location where to load JS/CSS files */
     public $cdn = [
-        'atk' => 'https://cdn.jsdelivr.net/gh/atk4/ui@develop/public',
+        'atk' => 'https://raw.githack.com/atk4/ui/develop/public',
         'jquery' => 'https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1',
         'serialize-object' => 'https://cdnjs.cloudflare.com/ajax/libs/jquery-serialize-object/2.5.0',
         'semantic-ui' => 'https://cdnjs.cloudflare.com/ajax/libs/fomantic-ui/2.8.6',


### PR DESCRIPTION
raw.githack.com should cache files no more than a few minutes, jsdelivr.com supports purge, but it does not update the source resource until tagged (seems almost a bug there)