### PR TITLE
Remove mergeStickyArgsFromChildView from Lookup

### DIFF
--- a/src/Form/Control/Lookup.php
+++ b/src/Form/Control/Lookup.php
@@ -451,9 +451,4 @@ class Lookup extends Input
 
         return parent::set($value, $junk);
     }
-
-    protected function mergeStickyArgsFromChildView(): ?AbstractView
-    {
-        return $this->callback;
-    }
 }


### PR DESCRIPTION
this method is designed solely for Callback trully related with parent View

if really needed, it must be tested in `tests-behat/lookup.feature`