### PR TITLE
Revert "Trigger Bundler CI using better filter"

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -1,12 +1,11 @@
 name: Bundler
 
-on:
-  create:
-    branches: 'release/*'
+on: create
 
 jobs:
   autocommit:
     name: Update to stable dependencies
+    if: startsWith(github.ref, 'refs/heads/release/')
     runs-on: ubuntu-latest
     container:
       image: atk4/image:latest


### PR DESCRIPTION
see https://github.community/t/trigger-job-on-branch-created/16878/5 , there is no branch trigger filter for create

must be merged asap to prevent bad commit and branches to be created