### PR TITLE
Add word "dangerously" to template setters method names and rename some render() and load*() methods

### DIFF
--- a/demos/collection/table2.php
+++ b/demos/collection/table2.php
@@ -25,13 +25,13 @@ $table->setModel($model, ['action']);
 $table->addColumn('amount', [Table\Column\Money::class]);
 
 // Table template can be tweaked directly
-$table->template->appendHtml('SubHead', '<tr class="center aligned"><th colspan=2>This is sub-header, goes inside "thead" tag</th></tr>');
-$table->template->appendHtml('Body', '<tr class="center aligned"><td colspan=2>This is part of body, goes before other rows</td></tr>');
+$table->template->dangerouslyAppendHtml('SubHead', '<tr class="center aligned"><th colspan=2>This is sub-header, goes inside "thead" tag</th></tr>');
+$table->template->dangerouslyAppendHtml('Body', '<tr class="center aligned"><td colspan=2>This is part of body, goes before other rows</td></tr>');
 
 // Hook can be used to display data before row. You can also inject and format extra rows.
 $table->onHook(\atk4\ui\Lister::HOOK_BEFORE_ROW, function (Table $table) {
     if ($table->current_row->getId() === 2) {
-        $table->template->appendHtml('Body', '<tr class="center aligned"><td colspan=2>This goes above row with ID=2 (' . $table->current_row->get('action') . ')</th></tr>');
+        $table->template->dangerouslyAppendHtml('Body', '<tr class="center aligned"><td colspan=2>This goes above row with ID=2 (' . $table->current_row->get('action') . ')</th></tr>');
     } elseif ($table->current_row->get('action') === 'Tax') {
         // renders current row
         $table->renderRow();
@@ -43,7 +43,7 @@ $table->onHook(\atk4\ui\Lister::HOOK_BEFORE_ROW, function (Table $table) {
     }
 });
 
-$table->template->appendHtml('Foot', '<tr class="center aligned"><td colspan=2>This will appear above totals</th></tr>');
+$table->template->dangerouslyAppendHtml('Foot', '<tr class="center aligned"><td colspan=2>This will appear above totals</th></tr>');
 $table->addTotals(['action' => 'Totals:', 'amount' => ['sum']]);
 
 \atk4\ui\Header::addTo($app, ['Columns with multiple formats', 'subHeader' => 'Single column can use logic to swap out formatters', 'icon' => 'table']);

--- a/demos/javascript/vue-component.php
+++ b/demos/javascript/vue-component.php
@@ -51,7 +51,7 @@ $lister->onHook(\atk4\ui\Lister::HOOK_BEFORE_ROW, function (\atk4\ui\Lister $lis
     ++$lister->ipp;
     $lister->current_row->set('iso', mb_strtolower($lister->current_row->get('iso')));
     if ($lister->ipp === $lister->model->limit[0]) {
-        $lister->t_row->setHtml('end', '<div class="ui circular basic label"> ...</div>');
+        $lister->t_row->dangerouslySetHtml('end', '<div class="ui circular basic label"> ...</div>');
     }
 });
 
@@ -120,7 +120,7 @@ $clock_script = "
 
 // Creating the clock view and injecting js.
 $clock = \atk4\ui\View::addTo($app, ['template' => $clock_template]);
-$clock->template->trySetHtml('script', $clock_script);
+$clock->template->tryDangerouslySetHtml('script', $clock_script);
 
 // passing some style to my-clock component.
 $clock_style = [

--- a/docs/form-control.rst
+++ b/docs/form-control.rst
@@ -367,7 +367,7 @@ If you'd like to even further adjust How each item is displayed (e.g. complex HT
             $this->_tItem->set('someOtherField', $res['someOtherField]);
             $this->_tItem->set('someOtherField2', $res['someOtherField2]);
             // add item to template
-            $this->template->appendHtml('Item', $this->_tItem->render());
+            $this->template->dangerouslyAppendHtml('Item', $this->_tItem->render());
        }
    }
 

--- a/docs/template.rst
+++ b/docs/template.rst
@@ -32,7 +32,7 @@ The following code will initialize template inside a PHP code::
 
     $t = new Template('Hello, {mytag}world{/}');
 
-Once template is initialized you can `render()` it any-time to get string
+Once template is initialized you can `renderToHtml()` it any-time to get string
 "Hello, world". You can also change tag value::
 
     $t->set('mytag', 'Agile UI');
@@ -41,7 +41,7 @@ Once template is initialized you can `render()` it any-time to get string
 
     $t['mytag'] = 'Agile UI';
 
-    echo $t->render();  // "Hello, Agile UI".
+    echo $t->renderToHtml();  // "Hello, Agile UI".
 
 Tags may also be self-closing::
 
@@ -76,10 +76,10 @@ There are some operations you can do with a region, such as::
     $main_template->del('Content');
 
     $content->set(['user'=>'Joe', 'amount'=>100]);
-    $main_template->append('Content', $content->render());
+    $main_template->append('Content', $content->renderToHtml());
 
     $content->set(['user'=>'Billy', 'amount'=>50]);
-    $main_template->append('Content', $content->render());
+    $main_template->append('Content', $content->renderToHtml());
 
 Usage in Agile UI
 -----------------
@@ -94,7 +94,7 @@ engine directly, but you would be able to use it through views::
     $lister = new Lister($v, 'Content');
     $lister->setModel($userlist);
 
-    echo $v->render();
+    echo $v->renderToHtml();
 
 The code above will work like this:
 
@@ -199,7 +199,7 @@ if you require so. A typical workflow would be:
    :php:meth:`GiTemplate::loadFromString`.
 
 2. Set tag and region values with :php:meth:`GiTemplate::set`.
-3. Render template with :php:meth:`GiTemplate::render`.
+3. Render template with :php:meth:`GiTemplate::renderToHtml`.
 
 
 Template use together with Views
@@ -342,7 +342,7 @@ Example::
     $template->set('name', 'John');
     $template->dangerouslyAppendHtml('name', '&nbsp;<i class="icon-heart"></i>');
 
-    echo $template->render();
+    echo $template->renderToHtml();
 
 
 Using ArrayAccess with Templates
@@ -360,14 +360,14 @@ You may use template object as array for simplified syntax::
 Rendering template
 ------------------
 
-.. php:method:: render
+.. php:method:: renderToHtml
 
     Converts template into one string by removing tag markers.
 
 Ultimately we want to convert template into something useful. Rendering
 will return contents of the template without tags::
 
-    $result=$template->render();
+    $result=$template->renderToHtml();
 
     \atk4\ui\Text::addTo($this)->set($result);
     // Will output "Hello, World"
@@ -413,11 +413,11 @@ You can use the following code to manipulate the template above::
     $recipient ->set($recipient_data);
 
     // render sub-templates, insert into master template
-    $template->set('Sender',    $sender   ->render());
-    $template->set('Recipient', $recipient->render());
+    $template->set('Sender',    $sender   ->renderToHtml());
+    $template->set('Recipient', $recipient->renderToHtml());
 
     // get final result
-    $result=$template->render();
+    $result=$template->renderToHtml();
 
 Same thing using Agile Toolkit Views::
 
@@ -436,7 +436,7 @@ from regions of $envelope and then substituted back after render.
 In this example I've usd a basic :php:class:`View` class, however I could
 have used my own View object with some more sophisticated presentation logic.
 The only affect on the example would be name of the class, the rest of
-presentation logic would be abstracted inside view's ``render()`` method.
+presentation logic would be abstracted inside view's ``renderToHtml()`` method.
 
 Other operations with tags
 --------------------------
@@ -494,7 +494,7 @@ your template::
     $template->eachTag('include', function($content, $tag) use($template) {
         $t = $template->newInstance();
         $t->loadFromFile($content);
-        $template->set($tag, $t->render());
+        $template->set($tag, $t->renderToHtml());
     });
 
 See also: :ref:`templates and views`
@@ -582,7 +582,7 @@ How views render themselves
 ---------------------------
 
 Agile Toolkit perform object initialization first. When all the objects
-are initialized global rendering takes place. Each object's ``render()``
+are initialized global rendering takes place. Each object's ``renderToHtml()``
 method is executed in order. The job of each view is to create output
 based on it's template and then insert it into the region of owner's
 template. It's actually quite similar to our Sender/Recipient example
@@ -720,7 +720,7 @@ Property tags would contain::
 As a result each tag will be stored under it's actual name and the name with
 unique "#1" appended (in case there are multiple instances of same tag).
 This allow ``$smlite->get()`` to quickly retrieve contents of
-appropriate tag and it will also allow ``render()`` to reconstruct the
+appropriate tag and it will also allow ``renderToHtml()`` to reconstruct the
 output efficiently.
 
 

--- a/docs/template.rst
+++ b/docs/template.rst
@@ -317,7 +317,7 @@ Changing template contents
     Escapes and inserts value inside a tag. If passed a hash, then each
     key is used as a tag, and corresponding value is inserted.
 
-.. php:method:: setHtml(tag, value)
+.. php:method:: dangerouslySetHtml(tag, value)
 
     Identical but will not escape. Will also accept hash similar to set()
 
@@ -329,11 +329,11 @@ Changing template contents
 
     Attempts to append value to existing but will do nothing if tag does not exist.
 
-.. php:method:: appendHtml(tag, value)
+.. php:method:: dangerouslyAppendHtml(tag, value)
 
     Similar to append, but will not escape.
 
-.. php:method:: tryAppendHtml(tag, value)
+.. php:method:: tryDangerouslyAppendHtml(tag, value)
 
     Attempts to append non-escaped value, but will do nothing if tag does not exist.
 
@@ -344,7 +344,7 @@ Example::
     $template->loadTemplateFromString('Hello, {name}world{/}');
 
     $template->set('name', 'John');
-    $template->appendHtml('name', '&nbsp;<i class="icon-heart"></i>');
+    $template->dangerouslyAppendHtml('name', '&nbsp;<i class="icon-heart"></i>');
 
     echo $template->render();
 
@@ -575,7 +575,7 @@ access it from inside the object or from outside through "template"
 property::
 
     $grid=\atk4\ui\Grid::addTo($this, [], [null],null,array('grid_with_hint'));
-    $grid->template->trySet('my_hint','Changing value of a grid hint here!');
+    $grid->template->trySet('my_hint', 'Changing value of a grid hint here!');
 
 In this example we have instructed to use a different template for grid,
 which would contain a new tag "my\_hint" somewhere. If you try to change

--- a/docs/template.rst
+++ b/docs/template.rst
@@ -75,11 +75,11 @@ There are some operations you can do with a region, such as::
 
     $main_template->del('Content');
 
-    $content->set(['user'=>'Joe', 'amount'=>100]);
-    $main_template->append('Content', $content->renderToHtml());
+    $content->set(['user' => 'Joe', 'amount' => 100]);
+    $main_template->dangerouslyAppendHtml('Content', $content->renderToHtml());
 
-    $content->set(['user'=>'Billy', 'amount'=>50]);
-    $main_template->append('Content', $content->renderToHtml());
+    $content->set(['user' => 'Billy', 'amount' => 50]);
+    $main_template->dangerouslyAppendHtml('Content', $content->renderToHtml());
 
 Usage in Agile UI
 -----------------
@@ -367,7 +367,7 @@ Rendering template
 Ultimately we want to convert template into something useful. Rendering
 will return contents of the template without tags::
 
-    $result=$template->renderToHtml();
+    $result = $template->renderToHtml();
 
     \atk4\ui\Text::addTo($this)->set($result);
     // Will output "Hello, World"
@@ -413,15 +413,15 @@ You can use the following code to manipulate the template above::
     $recipient ->set($recipient_data);
 
     // render sub-templates, insert into master template
-    $template->set('Sender',    $sender   ->renderToHtml());
-    $template->set('Recipient', $recipient->renderToHtml());
+    $template->dangerouslySetHtml('Sender',    $sender   ->renderToHtml());
+    $template->dangerouslySetHtml('Recipient', $recipient->renderToHtml());
 
     // get final result
-    $result=$template->renderToHtml();
+    $result = $template->renderToHtml();
 
 Same thing using Agile Toolkit Views::
 
-    $envelope = \atk4\ui\View::addTo($this, [], [null],null, ['envelope']);
+    $envelope = \atk4\ui\View::addTo($this, [], [null], null, ['envelope']);
 
     $sender    = \atk4\ui\View::addTo($envelope, [], [null], 'Sender',    'Sender');
     $recipient = \atk4\ui\View::addTo($envelope, [], [null], 'Recipient', 'Recipient');
@@ -465,8 +465,8 @@ Agile Toolkit template engine allows you to use same tag several times::
     Roses are {color}red{/}
     Violets are {color}blue{/}
 
-If you execute ``set('color','green')`` then contents of both tags will
-be affected. Similarly if you call ``append('color','-ish')`` then the
+If you execute ``set('color', 'green')`` then contents of both tags will
+be affected. Similarly if you call ``append('color', '-ish')`` then the
 text will be appended to both tags.
 
 You can also use ``eachTag()`` to iterate through those tags.
@@ -494,7 +494,7 @@ your template::
     $template->eachTag('include', function($content, $tag) use($template) {
         $t = $template->newInstance();
         $t->loadFromFile($content);
-        $template->set($tag, $t->renderToHtml());
+        $template->dangerouslySetHtml($tag, $t->renderToHtml());
     });
 
 See also: :ref:`templates and views`
@@ -514,7 +514,7 @@ Consider this example::
 
 This will only show text "e-mail" and email address if email tag value is
 set to not empty value. Same for "phone" tag.
-So if you execute ``set('email',null)`` and ``set('phone',123)`` then this
+So if you execute ``set('email', null)`` and ``set('phone', 123)`` then this
 template will automatically render as::
 
     My  phone 123.
@@ -570,7 +570,7 @@ Template is available by the time ``init()`` is called and you can
 access it from inside the object or from outside through "template"
 property::
 
-    $grid=\atk4\ui\Grid::addTo($this, [], [null],null,array('grid_with_hint'));
+    $grid = \atk4\ui\Grid::addTo($this, [], [null], null, array('grid_with_hint'));
     $grid->template->trySet('my_hint', 'Changing value of a grid hint here!');
 
 In this example we have instructed to use a different template for grid,
@@ -596,11 +596,11 @@ implemented using generic views.
 
 ::
 
-    $envelope=\atk4\ui\View::addTo($this, [], [null],null,array('envelope'));
+    $envelope = \atk4\ui\View::addTo($this, [], [null], null, array('envelope'));
 
     // 3rd argument is output region, 4th is template location
-    $sender=\atk4\ui\View::addTo($envelope, [], [null],'Sender','Sender');
-    $receiver=\atk4\ui\View::addTo($envelope, [], [null],'Receiver','Receiver');
+    $sender = \atk4\ui\View::addTo($envelope, [], [null], 'Sender', 'Sender');
+    $receiver = \atk4\ui\View::addTo($envelope, [], [null], 'Receiver', 'Receiver');
 
     $sender->template->trySet($sender_data);
     $receiver->template->trySet($receiver_data);
@@ -713,8 +713,8 @@ under ``$template->template`::
 Property tags would contain::
 
     array (
-      'subject'=> array( &array ),
-      'subject#0'=> array( &array )
+      'subject#0' => array( &array ),
+      'subject#1' => array( &array )
     )
 
 As a result each tag will be stored under it's actual name and the name with

--- a/docs/template.rst
+++ b/docs/template.rst
@@ -134,16 +134,16 @@ constructor:
 
 Alternatively, if you wish to load template from a file:
 
-.. php:method:: load($file)
+.. php:method:: loadFromFile($filename)
 
     Read file and load contents as a template.
 
-.. php:method:: tryLoad($file)
+.. php:method:: tryLoadFromFile($filename)
 
     Try loading the template. Returns false if template couldn't be loaded. This can be used
     if you attempt to load template from various locations.
 
-.. php:method:: loadTemplateFromString($string)
+.. php:method:: loadFromString($string)
 
     Same as using constructor.
 
@@ -196,7 +196,7 @@ Template engine in Agile Toolkit can be used independently, without views
 if you require so. A typical workflow would be:
 
 1. Load template using :php:meth:`GiTemplate::loadTemplate` or
-   :php:meth:`GiTemplate::loadTemplateFromString`.
+   :php:meth:`GiTemplate::loadFromString`.
 
 2. Set tag and region values with :php:meth:`GiTemplate::set`.
 3. Render template with :php:meth:`GiTemplate::render`.
@@ -256,17 +256,13 @@ how it's done is important to completely grasp Agile Toolkit underpinnings.
 Loading template
 ----------------
 
-.. php:method:: loadTemplateFromString(string)
+.. php:method:: loadFromString(string)
 
     Initialize current template from the supplied string
 
-.. php:method:: loadTemplate(filename)
+.. php:method:: loadFromFile(filename)
 
     Locate (using :php:class:`PathFinder`) and read template from file
-
-.. php:method:: reload()
-
-    Will attempt to re-load template from it's original source.
 
 .. php:method:: __clone()
 
@@ -296,11 +292,11 @@ following commands::
 
     $template = GiTemplate::addTo($this);
 
-    $template->loadTemplateFromString('Hello, {name}world{/}');
+    $template->loadFromString('Hello, {name}world{/}');
 
 To load template from file::
 
-    $template->loadTemplate('mytemplate');
+    $template->loadFromFile('mytemplate');
 
 And place the following inside ``template/mytemplate.html``::
 
@@ -341,7 +337,7 @@ Example::
 
     $template = GiTemplate::addTo($this);
 
-    $template->loadTemplateFromString('Hello, {name}world{/}');
+    $template->loadFromString('Hello, {name}world{/}');
 
     $template->set('name', 'John');
     $template->dangerouslyAppendHtml('name', '&nbsp;<i class="icon-heart"></i>');
@@ -406,7 +402,7 @@ Let's assume you have the following template in ``template/envelope.html``::
 You can use the following code to manipulate the template above::
 
     $template = GiTemplate::addTo($this);
-    $template->loadTemplate('envelope');        // templates/envelope.html
+    $template->loadFromFile('envelope');        // templates/envelope.html
 
     // Split into multiple objects for processing
     $sender    = $template->cloneRegion('Sender');
@@ -497,7 +493,7 @@ your template::
 
     $template->eachTag('include', function($content, $tag) use($template) {
         $t = $template->newInstance();
-        $t->loadTemplate($content);
+        $t->loadFromFile($content);
         $template->set($tag, $t->render());
     });
 
@@ -540,7 +536,7 @@ Default template for a view
 By default view object will execute :php:meth:`defaultTemplate()` method which
 returns name of the template. This function must return array with
 one or two elements. First element is the name of the template which
-will be passed to ``loadTemplate()``. Second argument is optional and is
+will be passed to ``loadFromFile()``. Second argument is optional and is
 name of the region, which will be cloned. This allows you to have
 multiple views load data from same template but use different region.
 

--- a/src/App.php
+++ b/src/App.php
@@ -399,7 +399,7 @@ class App
         if ($output instanceof View) {
             $output = $output->render();
         } elseif ($output instanceof HtmlTemplate) {
-            $output = $output->render();
+            $output = $output->renderToHtml();
         }
 
         $this->terminate(
@@ -527,7 +527,7 @@ class App
                 throw new Exception('Callback requested, but never reached. You may be missing some arguments in request URL.');
             }
 
-            $output = $this->html->template->render();
+            $output = $this->html->template->renderToHtml();
         } catch (ExitApplicationException $e) {
             $output = '';
             $isExitException = true;

--- a/src/App.php
+++ b/src/App.php
@@ -265,7 +265,7 @@ class App
         $this->html = null;
         $this->initLayout([Layout\Centered::class]);
 
-        $this->layout->template->setHtml('Content', $this->renderExceptionHtml($exception));
+        $this->layout->template->dangerouslySetHtml('Content', $this->renderExceptionHtml($exception));
 
         // remove header
         $this->layout->template->tryDel('Header');
@@ -465,7 +465,10 @@ class App
         $this->requireCss($this->cdn['atk'] . '/agileui.css');
 
         // Set js bundle dynamic loading path.
-        $this->html->template->trySet('InitJsBundle', (new JsExpression('window.__atkBundlePublicPath = [];', [$this->cdn['atk']]))->jsRender(), false);
+        $this->html->template->tryDangerouslySetHtml(
+            'InitJsBundle',
+            (new JsExpression('window.__atkBundlePublicPath = [];', [$this->cdn['atk']]))->jsRender()
+        );
     }
 
     /**
@@ -479,7 +482,7 @@ class App
         if (!$this->html) {
             throw new Exception('App does not know how to add style');
         }
-        $this->html->template->appendHtml('HEAD', $this->getTag('style', $style));
+        $this->html->template->dangerouslyAppendHtml('HEAD', $this->getTag('style', $style));
     }
 
     /**
@@ -516,7 +519,7 @@ class App
 
             $this->html->template->set('title', $this->title);
             $this->html->renderAll();
-            $this->html->template->appendHtml('HEAD', $this->html->getJs());
+            $this->html->template->dangerouslyAppendHtml('HEAD', $this->html->getJs());
             $this->is_rendering = false;
             $this->hook(self::HOOK_BEFORE_OUTPUT);
 
@@ -715,7 +718,7 @@ class App
      */
     public function requireJs($url, $isAsync = false, $isDefer = false)
     {
-        $this->html->template->appendHtml('HEAD', $this->getTag('script', ['src' => $url, 'defer' => $isDefer, 'async' => $isAsync], '') . "\n");
+        $this->html->template->dangerouslyAppendHtml('HEAD', $this->getTag('script', ['src' => $url, 'defer' => $isDefer, 'async' => $isAsync], '') . "\n");
 
         return $this;
     }
@@ -729,7 +732,7 @@ class App
      */
     public function requireCss($url)
     {
-        $this->html->template->appendHtml('HEAD', $this->getTag('link/', ['rel' => 'stylesheet', 'type' => 'text/css', 'href' => $url]) . "\n");
+        $this->html->template->dangerouslyAppendHtml('HEAD', $this->getTag('link/', ['rel' => 'stylesheet', 'type' => 'text/css', 'href' => $url]) . "\n");
 
         return $this;
     }
@@ -968,7 +971,7 @@ class App
      *
      *   $app = new \atk4\ui\App();
      *   $app->initLayout([\atk4\ui\Layout\Centered::class]);
-     *   $app->layout->template->setHtml('Content', $e->getHtml());
+     *   $app->layout->template->dangerouslySetHtml('Content', $e->getHtml());
      *   $app->run();
      *   $app->callExit(true);
      */

--- a/src/App.php
+++ b/src/App.php
@@ -557,28 +557,28 @@ class App
     /**
      * Load template by template file name.
      *
-     * @param string $name
+     * @param string $filename
      *
      * @return HtmlTemplate
      */
-    public function loadTemplate($name)
+    public function loadTemplate($filename)
     {
         $template = new $this->templateClass();
         $template->setApp($this);
 
-        if (in_array($name[0], ['.', '/', '\\'], true) || strpos($name, ':\\') !== false) {
-            return $template->load($name);
+        if (in_array($filename[0], ['.', '/', '\\'], true) || strpos($filename, ':\\') !== false) {
+            return $template->loadFromFile($filename);
         }
 
         $dir = is_array($this->template_dir) ? $this->template_dir : [$this->template_dir];
         foreach ($dir as $td) {
-            if ($t = $template->tryLoad($td . '/' . $name)) {
+            if ($t = $template->tryLoadFromFile($td . '/' . $filename)) {
                 return $t;
             }
         }
 
         throw (new Exception('Can not find template file'))
-            ->addMoreInfo('name', $name)
+            ->addMoreInfo('filename', $filename)
             ->addMoreInfo('template_dir', $this->template_dir);
     }
 

--- a/src/Form.php
+++ b/src/Form.php
@@ -374,7 +374,7 @@ class Form extends View
                 $response->del('p');
             }
 
-            $response = $this->js()->html($response->render());
+            $response = $this->js()->html($response->renderToHtml());
         } else {
             $response = new Message([$success, 'type' => 'success', 'icon' => 'check']);
             $response->setApp($this->getApp);

--- a/src/Form/Control/Dropdown.php
+++ b/src/Form/Control/Dropdown.php
@@ -243,7 +243,7 @@ class Dropdown extends Input
         if ($this->field !== null && !$this->field->required && !$this->isMultiple) {
             $this->_tItem->set('value', '');
             $this->_tItem->set('title', $this->empty || is_numeric($this->empty) ? (string) $this->empty : '');
-            $this->template->dangerouslyAppendHtml('Item', $this->_tItem->render());
+            $this->template->dangerouslyAppendHtml('Item', $this->_tItem->renderToHtml());
         }
 
         // model set? use this, else values property
@@ -317,7 +317,7 @@ class Dropdown extends Input
             $this->_tItem->set('value', (string) $key);
             $this->_tItem->set('title', $title || is_numeric($title) ? (string) $title : '');
             // add item to template
-            $this->template->dangerouslyAppendHtml('Item', $this->_tItem->render());
+            $this->template->dangerouslyAppendHtml('Item', $this->_tItem->renderToHtml());
         }
     }
 
@@ -329,7 +329,7 @@ class Dropdown extends Input
             if (is_array($val)) {
                 if (array_key_exists('icon', $val)) {
                     $this->_tIcon->set('icon', $val['icon']);
-                    $this->_tItem->dangerouslySetHtml('Icon', $this->_tIcon->render());
+                    $this->_tItem->dangerouslySetHtml('Icon', $this->_tIcon->renderToHtml());
                 } else {
                     $this->_tItem->del('Icon');
                 }
@@ -339,7 +339,7 @@ class Dropdown extends Input
             }
 
             // add item to template
-            $this->template->dangerouslyAppendHtml('Item', $this->_tItem->render());
+            $this->template->dangerouslyAppendHtml('Item', $this->_tItem->renderToHtml());
         }
     }
 
@@ -360,10 +360,10 @@ class Dropdown extends Input
             // compatibility with how $values property works on icons: 'icon'
             // is defined in there
             $this->_tIcon->set('icon', 'icon ' . $res['icon']);
-            $this->_tItem->dangerouslyAppendHtml('Icon', $this->_tIcon->render());
+            $this->_tItem->dangerouslyAppendHtml('Icon', $this->_tIcon->renderToHtml());
         }
 
         // add item to template
-        $this->template->dangerouslyAppendHtml('Item', $this->_tItem->render());
+        $this->template->dangerouslyAppendHtml('Item', $this->_tItem->renderToHtml());
     }
 }

--- a/src/Form/Control/Dropdown.php
+++ b/src/Form/Control/Dropdown.php
@@ -243,7 +243,7 @@ class Dropdown extends Input
         if ($this->field !== null && !$this->field->required && !$this->isMultiple) {
             $this->_tItem->set('value', '');
             $this->_tItem->set('title', $this->empty || is_numeric($this->empty) ? (string) $this->empty : '');
-            $this->template->appendHtml('Item', $this->_tItem->render());
+            $this->template->dangerouslyAppendHtml('Item', $this->_tItem->render());
         }
 
         // model set? use this, else values property
@@ -317,7 +317,7 @@ class Dropdown extends Input
             $this->_tItem->set('value', (string) $key);
             $this->_tItem->set('title', $title || is_numeric($title) ? (string) $title : '');
             // add item to template
-            $this->template->appendHtml('Item', $this->_tItem->render());
+            $this->template->dangerouslyAppendHtml('Item', $this->_tItem->render());
         }
     }
 
@@ -329,7 +329,7 @@ class Dropdown extends Input
             if (is_array($val)) {
                 if (array_key_exists('icon', $val)) {
                     $this->_tIcon->set('icon', $val['icon']);
-                    $this->_tItem->setHtml('Icon', $this->_tIcon->render());
+                    $this->_tItem->dangerouslySetHtml('Icon', $this->_tIcon->render());
                 } else {
                     $this->_tItem->del('Icon');
                 }
@@ -339,7 +339,7 @@ class Dropdown extends Input
             }
 
             // add item to template
-            $this->template->appendHtml('Item', $this->_tItem->render());
+            $this->template->dangerouslyAppendHtml('Item', $this->_tItem->render());
         }
     }
 
@@ -360,10 +360,10 @@ class Dropdown extends Input
             // compatibility with how $values property works on icons: 'icon'
             // is defined in there
             $this->_tIcon->set('icon', 'icon ' . $res['icon']);
-            $this->_tItem->appendHtml('Icon', $this->_tIcon->render());
+            $this->_tItem->dangerouslyAppendHtml('Icon', $this->_tIcon->render());
         }
 
         // add item to template
-        $this->template->appendHtml('Item', $this->_tItem->render());
+        $this->template->dangerouslyAppendHtml('Item', $this->_tItem->render());
     }
 }

--- a/src/Form/Control/Input.php
+++ b/src/Form/Control/Input.php
@@ -231,7 +231,7 @@ class Input extends Form\Control
         }
 
         // set template
-        $this->template->setHtml('Input', $this->getInput());
+        $this->template->dangerouslySetHtml('Input', $this->getInput());
         $this->content = null;
 
         parent::renderView();

--- a/src/Form/Control/Multiline.php
+++ b/src/Form/Control/Multiline.php
@@ -695,7 +695,7 @@ class Multiline extends Form\Control
             }
         });
 
-        $this->multiLine->template->trySetHtml('Input', $this->getInput());
+        $this->multiLine->template->tryDangerouslySetHtml('Input', $this->getInput());
         parent::renderView();
 
         $this->multiLine->vue(

--- a/src/Form/Control/TreeItemSelector.php
+++ b/src/Form/Control/TreeItemSelector.php
@@ -146,7 +146,7 @@ class TreeItemSelector extends Form\Control
     {
         parent::renderView();
 
-        $this->itemSelector->template->trySetHtml('Input', $this->getInput());
+        $this->itemSelector->template->tryDangerouslySetHtml('Input', $this->getInput());
 
         $this->itemSelector->vue(
             'atk-tree-item-selector',

--- a/src/Form/Layout.php
+++ b/src/Form/Layout.php
@@ -168,7 +168,7 @@ class Layout extends AbstractLayout
                 }
                 $template->dangerouslySetHtml('Content', $element->getHtml());
 
-                $this->template->dangerouslyAppendHtml('Content', $template->render());
+                $this->template->dangerouslyAppendHtml('Content', $template->renderToHtml());
 
                 continue;
             }
@@ -226,9 +226,9 @@ class Layout extends AbstractLayout
             }
 
             if ($this->template->hasTag($element->short_name)) {
-                $this->template->tryDangerouslySetHtml($element->short_name, $template->render());
+                $this->template->tryDangerouslySetHtml($element->short_name, $template->renderToHtml());
             } else {
-                $this->template->dangerouslyAppendHtml('Content', $template->render());
+                $this->template->dangerouslyAppendHtml('Content', $template->renderToHtml());
             }
         }
 

--- a/src/Form/Layout.php
+++ b/src/Form/Layout.php
@@ -146,7 +146,7 @@ class Layout extends AbstractLayout
         foreach ($this->elements as $element) {
             // Buttons go under Button section
             if ($element instanceof \atk4\ui\Button) {
-                $this->template->appendHtml('Buttons', $element->getHtml());
+                $this->template->dangerouslyAppendHtml('Buttons', $element->getHtml());
 
                 continue;
             }
@@ -166,16 +166,16 @@ class Layout extends AbstractLayout
                 if ($element->inline) {
                     $template->set('class', 'inline');
                 }
-                $template->setHtml('Content', $element->getHtml());
+                $template->dangerouslySetHtml('Content', $element->getHtml());
 
-                $this->template->appendHtml('Content', $template->render());
+                $this->template->dangerouslyAppendHtml('Content', $template->render());
 
                 continue;
             }
 
             // Anything but controls or explicitly defined controls get inserted directly
             if (!$element instanceof Control || !$element->layoutWrap) {
-                $this->template->appendHtml('Content', $element->getHtml());
+                $this->template->dangerouslyAppendHtml('Content', $element->getHtml());
 
                 continue;
             }
@@ -199,7 +199,7 @@ class Layout extends AbstractLayout
             }
 
             // Controls get extra pampering
-            $template->setHtml('Input', $element->getHtml());
+            $template->dangerouslySetHtml('Input', $element->getHtml());
             $template->trySet('label', $label);
             $template->trySet('label_for', $element->id . '_input');
             $template->set('control_class', $element->getControlClass());
@@ -220,15 +220,15 @@ class Layout extends AbstractLayout
                 } else {
                     $hint->set($element->hint);
                 }
-                $template->setHtml('Hint', $hint->getHtml());
+                $template->dangerouslySetHtml('Hint', $hint->getHtml());
             } elseif ($template->hasTag('Hint')) {
                 $template->del('Hint');
             }
 
             if ($this->template->hasTag($element->short_name)) {
-                $this->template->trySetHtml($element->short_name, $template->render());
+                $this->template->tryDangerouslySetHtml($element->short_name, $template->render());
             } else {
-                $this->template->appendHtml('Content', $template->render());
+                $this->template->dangerouslyAppendHtml('Content', $template->render());
             }
         }
 

--- a/src/GridLayout.php
+++ b/src/GridLayout.php
@@ -83,13 +83,13 @@ class GridLayout extends View
             for ($col = 1; $col <= $this->columns; ++$col) {
                 $this->t_col->set('Content', '{$r' . $row . 'c' . $col . '}');
 
-                $this->t_row->dangerouslyAppendHtml('column', $this->t_col->render());
+                $this->t_row->dangerouslyAppendHtml('column', $this->t_col->renderToHtml());
             }
 
-            $this->t_wrap->dangerouslyAppendHtml('rows', $this->t_row->render());
+            $this->t_wrap->dangerouslyAppendHtml('rows', $this->t_row->renderToHtml());
         }
         $this->t_wrap->dangerouslyAppendHtml('rows', '{/rows}');
-        $tmp = new HtmlTemplate($this->t_wrap->render());
+        $tmp = new HtmlTemplate($this->t_wrap->renderToHtml());
 
         // TODO replace later, the only use of direct template property access
         $t = $this;

--- a/src/GridLayout.php
+++ b/src/GridLayout.php
@@ -75,7 +75,7 @@ class GridLayout extends View
     protected function buildTemplate()
     {
         $this->t_wrap->del('rows');
-        $this->t_wrap->appendHtml('rows', '{rows}');
+        $this->t_wrap->dangerouslyAppendHtml('rows', '{rows}');
 
         for ($row = 1; $row <= $this->rows; ++$row) {
             $this->t_row->del('column');
@@ -83,12 +83,12 @@ class GridLayout extends View
             for ($col = 1; $col <= $this->columns; ++$col) {
                 $this->t_col->set('Content', '{$r' . $row . 'c' . $col . '}');
 
-                $this->t_row->appendHtml('column', $this->t_col->render());
+                $this->t_row->dangerouslyAppendHtml('column', $this->t_col->render());
             }
 
-            $this->t_wrap->appendHtml('rows', $this->t_row->render());
+            $this->t_wrap->dangerouslyAppendHtml('rows', $this->t_row->render());
         }
-        $this->t_wrap->appendHtml('rows', '{/rows}');
+        $this->t_wrap->dangerouslyAppendHtml('rows', '{/rows}');
         $tmp = new HtmlTemplate($this->t_wrap->render());
 
         // TODO replace later, the only use of direct template property access

--- a/src/HtmlTemplate.php
+++ b/src/HtmlTemplate.php
@@ -575,7 +575,7 @@ class HtmlTemplate implements \ArrayAccess
         }
 
         foreach ($this->getTagRefs($tag) as $ref => &$vRef) {
-            $vRef = [(string) $fx($this->renderRegion($vRef), $tag . '#' . $ref)];
+            $vRef = [(string) $fx($this->renderRegionToHtml($vRef), $tag . '#' . $ref)];
         }
 
         return $this;
@@ -760,20 +760,20 @@ class HtmlTemplate implements \ArrayAccess
      * Render either a whole template or a specified region. Returns
      * current contents of a template.
      */
-    public function render(string $region = null): string
+    public function renderToHtml(string $region = null): string
     {
-        return $this->renderRegion($region !== null ? $this->get($region) : $this->template);
+        return $this->renderRegionToHtml($region !== null ? $this->get($region) : $this->template);
     }
 
     /**
      * Walk through the template array collecting the values
      * and returning them as a string.
      */
-    protected function renderRegion(array $template): string
+    protected function renderRegionToHtml(array $template): string
     {
         $res = [];
         foreach ($template as $val) {
-            $res[] = is_array($val) ? $this->renderRegion($val) : $val;
+            $res[] = is_array($val) ? $this->renderRegionToHtml($val) : $val;
         }
 
         return implode('', $res);

--- a/src/HtmlTemplate.php
+++ b/src/HtmlTemplate.php
@@ -56,7 +56,7 @@ class HtmlTemplate implements \ArrayAccess
 
     public function __construct(string $template = '')
     {
-        $this->loadTemplateFromString($template);
+        $this->loadFromString($template);
     }
 
     private function exceptionAddMoreInfo(Exception $e): Exception
@@ -497,7 +497,7 @@ class HtmlTemplate implements \ArrayAccess
         }
 
         if ($tag === self::TOP_TAG) {
-            $this->loadTemplateFromString('');
+            $this->loadFromString('');
         } else {
             $template = $this->getTagRefs($tag);
             foreach ($template as &$ref) {
@@ -613,14 +613,14 @@ class HtmlTemplate implements \ArrayAccess
      *
      * @return $this
      */
-    public function load(string $filename)
+    public function loadFromFile(string $filename)
     {
-        if ($this->tryLoad($filename) !== false) {
+        if ($this->tryLoadFromFile($filename) !== false) {
             return $this;
         }
 
         throw (new Exception('Unable to read template from file'))
-            ->addMoreInfo('file', $filename);
+            ->addMoreInfo('filename', $filename);
     }
 
     /**
@@ -628,7 +628,7 @@ class HtmlTemplate implements \ArrayAccess
      *
      * @return $this|false
      */
-    public function tryLoad(string $filename)
+    public function tryLoadFromFile(string $filename)
     {
         $filename = realpath($filename);
         if (!isset(self::$_filesCache[$filename])) {
@@ -640,7 +640,7 @@ class HtmlTemplate implements \ArrayAccess
         }
 
         $str = preg_replace('~(?:\r\n?|\n)$~s', '', self::$_filesCache[$filename]); // always trim end NL
-        $this->loadTemplateFromString($str);
+        $this->loadFromString($str);
         $this->source = 'loaded from file: ' . $filename;
 
         return $this;
@@ -651,7 +651,7 @@ class HtmlTemplate implements \ArrayAccess
      *
      * @return $this
      */
-    public function loadTemplateFromString(string $str)
+    public function loadFromString(string $str)
     {
         $this->source = 'string: ' . $str;
         $this->template = [];

--- a/src/HtmlTemplate.php
+++ b/src/HtmlTemplate.php
@@ -466,6 +466,46 @@ class HtmlTemplate implements \ArrayAccess
     }
 
     /**
+     * @deprecated use "loadFromFile" method instead - will be removed in v2.5
+     */
+    public function load(string $filename)
+    {
+        'trigger_error'('Method is deprecated. Use loadFromFile instead', E_USER_DEPRECATED);
+
+        return $this->loadFromFile($filename);
+    }
+
+    /**
+     * @deprecated use "tryLoadFromFile" method instead - will be removed in v2.5
+     */
+    public function tryLoad(string $filename)
+    {
+        'trigger_error'('Method is deprecated. Use tryLoadFromFile instead', E_USER_DEPRECATED);
+
+        return $this->tryLoadFromFile($filename);
+    }
+
+    /**
+     * @deprecated use "loadFromString" method instead - will be removed in v2.5
+     */
+    public function loadTemplateFromString(string $template = '')
+    {
+        'trigger_error'('Method is deprecated. Use loadFromString instead', E_USER_DEPRECATED);
+
+        return $this->loadFromString($template);
+    }
+
+    /**
+     * @deprecated use "renderToHtml" method instead - will be removed in v2.5
+     */
+    public function render(string $region = null)
+    {
+        'trigger_error'('Method is deprecated. Use renderToHtml instead', E_USER_DEPRECATED);
+
+        return $this->renderToHtml($region);
+    }
+
+    /**
      * Get value of the tag. Note that this may contain an array
      * if tag contains a structure.
      */

--- a/src/HtmlTemplate.php
+++ b/src/HtmlTemplate.php
@@ -293,7 +293,7 @@ class HtmlTemplate implements \ArrayAccess
      */
     public function set($tag, $value = null)
     {
-        if (func_num_args() > 2) { // remove in v2.6
+        if (func_num_args() > 2) { // remove in v2.5
             throw new \Error('3rd param $encode is no longer supported, use dangerouslySetHtml method instead');
         }
 
@@ -313,7 +313,7 @@ class HtmlTemplate implements \ArrayAccess
      */
     public function trySet($tag, $value = null)
     {
-        if (func_num_args() > 2) { // remove in v2.6
+        if (func_num_args() > 2) { // remove in v2.5
             throw new \Error('3rd param $encode is no longer supported, use tryDangerouslySetHtml method instead');
         }
 
@@ -364,7 +364,7 @@ class HtmlTemplate implements \ArrayAccess
      */
     public function append($tag, $value)
     {
-        if (func_num_args() > 2) { // remove in v2.6
+        if (func_num_args() > 2) { // remove in v2.5
             throw new \Error('3rd param $encode is no longer supported, use dangerouslyAppendHtml method instead');
         }
 
@@ -384,7 +384,7 @@ class HtmlTemplate implements \ArrayAccess
      */
     public function tryAppend($tag, $value)
     {
-        if (func_num_args() > 2) { // remove in v2.6
+        if (func_num_args() > 2) { // remove in v2.5
             throw new \Error('3rd param $encode is no longer supported, use tryDangerouslyAppendHtml method instead');
         }
 
@@ -426,7 +426,7 @@ class HtmlTemplate implements \ArrayAccess
     }
 
     /**
-     * @deprecated use "dangerouslySetHtml" method instead - will be removed in v2.6
+     * @deprecated use "dangerouslySetHtml" method instead - will be removed in v2.5
      */
     public function setHtml($tag, $value = null)
     {
@@ -436,7 +436,7 @@ class HtmlTemplate implements \ArrayAccess
     }
 
     /**
-     * @deprecated use "tryDangerouslySetHtml" method instead - will be removed in v2.6
+     * @deprecated use "tryDangerouslySetHtml" method instead - will be removed in v2.5
      */
     public function trySetHtml($tag, $value = null)
     {
@@ -446,7 +446,7 @@ class HtmlTemplate implements \ArrayAccess
     }
 
     /**
-     * @deprecated use "dangerouslyAppendHtml" method instead - will be removed in v2.6
+     * @deprecated use "dangerouslyAppendHtml" method instead - will be removed in v2.5
      */
     public function appendHtml($tag, $value)
     {
@@ -456,7 +456,7 @@ class HtmlTemplate implements \ArrayAccess
     }
 
     /**
-     * @deprecated use "tryDangerouslyAppendHtml" method instead - will be removed in v2.6
+     * @deprecated use "tryDangerouslyAppendHtml" method instead - will be removed in v2.5
      */
     public function tryAppendHtml($tag, $value)
     {

--- a/src/HtmlTemplate.php
+++ b/src/HtmlTemplate.php
@@ -288,13 +288,16 @@ class HtmlTemplate implements \ArrayAccess
      *
      * @param string|array|Model $tag
      * @param string             $value
-     * @param bool               $encode Should we HTML encode content
      *
      * @return $this
      */
-    public function set($tag, $value = null, $encode = true)
+    public function set($tag, $value = null)
     {
-        $this->_setOrAppend($tag, $value, $encode, false, true);
+        if (func_num_args() > 2) { // remove in v2.6
+            throw new \Error('3rd param $encode is no longer supported, use dangerouslySetHtml method instead');
+        }
+
+        $this->_setOrAppend($tag, $value, true, false, true);
 
         return $this;
     }
@@ -308,9 +311,13 @@ class HtmlTemplate implements \ArrayAccess
      *
      * @return $this
      */
-    public function trySet($tag, $value = null, bool $encode = true)
+    public function trySet($tag, $value = null)
     {
-        $this->_setOrAppend($tag, $value, $encode, false, false);
+        if (func_num_args() > 2) { // remove in v2.6
+            throw new \Error('3rd param $encode is no longer supported, use tryDangerouslySetHtml method instead');
+        }
+
+        $this->_setOrAppend($tag, $value, true, false, false);
 
         return $this;
     }
@@ -324,7 +331,7 @@ class HtmlTemplate implements \ArrayAccess
      *
      * @return $this
      */
-    public function setHtml($tag, $value = null)
+    public function dangerouslySetHtml($tag, $value = null)
     {
         $this->_setOrAppend($tag, $value, false, false, true);
 
@@ -332,7 +339,7 @@ class HtmlTemplate implements \ArrayAccess
     }
 
     /**
-     * See setHtml() but won't generate exception for non-existing
+     * See dangerouslySetHtml() but won't generate exception for non-existing
      * $tag.
      *
      * @param string|array|Model $tag
@@ -340,7 +347,7 @@ class HtmlTemplate implements \ArrayAccess
      *
      * @return $this
      */
-    public function trySetHtml($tag, $value = null)
+    public function tryDangerouslySetHtml($tag, $value = null)
     {
         $this->_setOrAppend($tag, $value, false, false, false);
 
@@ -355,9 +362,13 @@ class HtmlTemplate implements \ArrayAccess
      *
      * @return $this
      */
-    public function append($tag, $value, bool $encode = true)
+    public function append($tag, $value)
     {
-        $this->_setOrAppend($tag, $value, $encode, true, true);
+        if (func_num_args() > 2) { // remove in v2.6
+            throw new \Error('3rd param $encode is no longer supported, use dangerouslyAppendHtml method instead');
+        }
+
+        $this->_setOrAppend($tag, $value, true, true, true);
 
         return $this;
     }
@@ -371,9 +382,13 @@ class HtmlTemplate implements \ArrayAccess
      *
      * @return $this
      */
-    public function tryAppend($tag, $value, bool $encode = true)
+    public function tryAppend($tag, $value)
     {
-        $this->_setOrAppend($tag, $value, $encode, true, false);
+        if (func_num_args() > 2) { // remove in v2.6
+            throw new \Error('3rd param $encode is no longer supported, use tryDangerouslyAppendHtml method instead');
+        }
+
+        $this->_setOrAppend($tag, $value, true, true, false);
 
         return $this;
     }
@@ -387,7 +402,7 @@ class HtmlTemplate implements \ArrayAccess
      *
      * @return $this
      */
-    public function appendHtml($tag, $value)
+    public function dangerouslyAppendHtml($tag, $value)
     {
         $this->_setOrAppend($tag, $value, false, true, true);
 
@@ -395,7 +410,7 @@ class HtmlTemplate implements \ArrayAccess
     }
 
     /**
-     * Same as append(), but won't generate exception for non-existing
+     * Same as dangerouslyAppendHtml(), but won't generate exception for non-existing
      * $tag.
      *
      * @param string|array|Model $tag
@@ -403,11 +418,51 @@ class HtmlTemplate implements \ArrayAccess
      *
      * @return $this
      */
-    public function tryAppendHtml($tag, $value)
+    public function tryDangerouslyAppendHtml($tag, $value)
     {
         $this->_setOrAppend($tag, $value, false, true, false);
 
         return $this;
+    }
+
+    /**
+     * @deprecated use "dangerouslySetHtml" method instead - will be removed in v2.6
+     */
+    public function setHtml($tag, $value = null)
+    {
+        'trigger_error'('Method is deprecated. Use dangerouslySetHtml instead', E_USER_DEPRECATED);
+
+        return $this->dangerouslySetHtml($tag, $value);
+    }
+
+    /**
+     * @deprecated use "tryDangerouslySetHtml" method instead - will be removed in v2.6
+     */
+    public function trySetHtml($tag, $value = null)
+    {
+        'trigger_error'('Method is deprecated. Use tryDangerouslySetHtml instead', E_USER_DEPRECATED);
+
+        return $this->tryDangerouslySetHtml($tag, $value);
+    }
+
+    /**
+     * @deprecated use "dangerouslyAppendHtml" method instead - will be removed in v2.6
+     */
+    public function appendHtml($tag, $value)
+    {
+        'trigger_error'('Method is deprecated. Use dangerouslyAppendHtml instead', E_USER_DEPRECATED);
+
+        return $this->dangerouslyAppendHtml($tag, $value);
+    }
+
+    /**
+     * @deprecated use "tryDangerouslyAppendHtml" method instead - will be removed in v2.6
+     */
+    public function tryAppendHtml($tag, $value)
+    {
+        'trigger_error'('Method is deprecated. Use tryDangerouslyAppendHtml instead', E_USER_DEPRECATED);
+
+        return $this->tryDangerouslyAppendHtml($tag, $value);
     }
 
     /**

--- a/src/Layout/Centered.php
+++ b/src/Layout/Centered.php
@@ -46,7 +46,7 @@ class Centered extends \atk4\ui\Layout
     protected function renderView(): void
     {
         if ($this->image) {
-            $this->template->trySetHtml('HeaderImage', '<img class="ui image" src="' . $this->image . '" alt="' . $this->image_alt . '" />');
+            $this->template->tryDangerouslySetHtml('HeaderImage', '<img class="ui image" src="' . $this->image . '" alt="' . $this->image_alt . '" />');
         }
         parent::renderView();
     }

--- a/src/Lister.php
+++ b/src/Lister.php
@@ -169,9 +169,9 @@ class Lister extends View
             if (!$this->jsPaginator || !$this->jsPaginator->getPage()) {
                 $empty = isset($this->t_empty) ? $this->t_empty->render() : '';
                 if ($this->template->hasTag('rows')) {
-                    $this->template->appendHtml('rows', $empty);
+                    $this->template->dangerouslyAppendHtml('rows', $empty);
                 } else {
-                    $this->template->appendHtml('_top', $empty);
+                    $this->template->dangerouslyAppendHtml('_top', $empty);
                 }
             }
         }
@@ -198,9 +198,9 @@ class Lister extends View
 
         $html = $this->t_row->render();
         if ($this->template->hasTag('rows')) {
-            $this->template->appendHtml('rows', $html);
+            $this->template->dangerouslyAppendHtml('rows', $html);
         } else {
-            $this->template->appendHtml('_top', $html);
+            $this->template->dangerouslyAppendHtml('_top', $html);
         }
     }
 }

--- a/src/Lister.php
+++ b/src/Lister.php
@@ -167,7 +167,7 @@ class Lister extends View
         // empty message
         if (!$this->_rendered_rows_count) {
             if (!$this->jsPaginator || !$this->jsPaginator->getPage()) {
-                $empty = isset($this->t_empty) ? $this->t_empty->render() : '';
+                $empty = isset($this->t_empty) ? $this->t_empty->renderToHtml() : '';
                 if ($this->template->hasTag('rows')) {
                     $this->template->dangerouslyAppendHtml('rows', $empty);
                 } else {
@@ -196,7 +196,7 @@ class Lister extends View
         $this->t_row->trySet('_href', $this->url(['id' => $this->current_row->getId()]));
         $this->t_row->trySet('_id', $this->current_row->getId());
 
-        $html = $this->t_row->render();
+        $html = $this->t_row->renderToHtml();
         if ($this->template->hasTag('rows')) {
             $this->template->dangerouslyAppendHtml('rows', $html);
         } else {

--- a/src/Paginator.php
+++ b/src/Paginator.php
@@ -196,7 +196,7 @@ class Paginator extends View
             $t->trySet('active', $page === $this->page ? 'active' : '');
         }
 
-        $this->template->appendHtml('rows', $t->render());
+        $this->template->dangerouslyAppendHtml('rows', $t->render());
     }
 
     protected function renderView(): void

--- a/src/Paginator.php
+++ b/src/Paginator.php
@@ -196,7 +196,7 @@ class Paginator extends View
             $t->trySet('active', $page === $this->page ? 'active' : '');
         }
 
-        $this->template->dangerouslyAppendHtml('rows', $t->render());
+        $this->template->dangerouslyAppendHtml('rows', $t->renderToHtml());
     }
 
     protected function renderView(): void

--- a/src/Table.php
+++ b/src/Table.php
@@ -482,12 +482,12 @@ class Table extends Lister
 
         // Generate Header Row
         if ($this->header) {
-            $this->t_head->setHtml('cells', $this->getHeaderRowHtml());
-            $this->template->setHtml('Head', $this->t_head->render());
+            $this->t_head->dangerouslySetHtml('cells', $this->getHeaderRowHtml());
+            $this->template->dangerouslySetHtml('Head', $this->t_head->render());
         }
 
         // Generate template for data row
-        $this->t_row_master->setHtml('cells', $this->getDataRowHtml());
+        $this->t_row_master->dangerouslySetHtml('cells', $this->getDataRowHtml());
         $this->t_row_master['_id'] = '{$_id}';
         $this->t_row = new HtmlTemplate($this->t_row_master->render());
         $this->t_row->setApp($this->getApp());
@@ -525,11 +525,11 @@ class Table extends Lister
         // Add totals rows or empty message
         if (!$this->_rendered_rows_count) {
             if (!$this->jsPaginator || !$this->jsPaginator->getPage()) {
-                $this->template->appendHtml('Body', $this->t_empty->render());
+                $this->template->dangerouslyAppendHtml('Body', $this->t_empty->render());
             }
         } elseif ($this->totals_plan) {
-            $this->t_totals->setHtml('cells', $this->getTotalsRowHtml());
-            $this->template->appendHtml('Foot', $this->t_totals->render());
+            $this->t_totals->dangerouslySetHtml('cells', $this->getTotalsRowHtml());
+            $this->template->dangerouslyAppendHtml('Foot', $this->t_totals->render());
         }
 
         // stop JsPaginator if there are no more records to fetch
@@ -572,12 +572,12 @@ class Table extends Lister
             }
 
             // Render row and add to body
-            $this->t_row->setHtml($html_tags);
+            $this->t_row->dangerouslySetHtml($html_tags);
             $this->t_row->set('_id', $this->model->getId());
-            $this->template->appendHtml('Body', $this->t_row->render());
+            $this->template->dangerouslyAppendHtml('Body', $this->t_row->render());
             $this->t_row->del(array_keys($html_tags));
         } else {
-            $this->template->appendHtml('Body', $this->t_row->render());
+            $this->template->dangerouslyAppendHtml('Body', $this->t_row->render());
         }
     }
 

--- a/src/Table.php
+++ b/src/Table.php
@@ -483,13 +483,13 @@ class Table extends Lister
         // Generate Header Row
         if ($this->header) {
             $this->t_head->dangerouslySetHtml('cells', $this->getHeaderRowHtml());
-            $this->template->dangerouslySetHtml('Head', $this->t_head->render());
+            $this->template->dangerouslySetHtml('Head', $this->t_head->renderToHtml());
         }
 
         // Generate template for data row
         $this->t_row_master->dangerouslySetHtml('cells', $this->getDataRowHtml());
         $this->t_row_master['_id'] = '{$_id}';
-        $this->t_row = new HtmlTemplate($this->t_row_master->render());
+        $this->t_row = new HtmlTemplate($this->t_row_master->renderToHtml());
         $this->t_row->setApp($this->getApp());
 
         // Iterate data rows
@@ -525,11 +525,11 @@ class Table extends Lister
         // Add totals rows or empty message
         if (!$this->_rendered_rows_count) {
             if (!$this->jsPaginator || !$this->jsPaginator->getPage()) {
-                $this->template->dangerouslyAppendHtml('Body', $this->t_empty->render());
+                $this->template->dangerouslyAppendHtml('Body', $this->t_empty->renderToHtml());
             }
         } elseif ($this->totals_plan) {
             $this->t_totals->dangerouslySetHtml('cells', $this->getTotalsRowHtml());
-            $this->template->dangerouslyAppendHtml('Foot', $this->t_totals->render());
+            $this->template->dangerouslyAppendHtml('Foot', $this->t_totals->renderToHtml());
         }
 
         // stop JsPaginator if there are no more records to fetch
@@ -574,10 +574,10 @@ class Table extends Lister
             // Render row and add to body
             $this->t_row->dangerouslySetHtml($html_tags);
             $this->t_row->set('_id', $this->model->getId());
-            $this->template->dangerouslyAppendHtml('Body', $this->t_row->render());
+            $this->template->dangerouslyAppendHtml('Body', $this->t_row->renderToHtml());
             $this->t_row->del(array_keys($html_tags));
         } else {
-            $this->template->dangerouslyAppendHtml('Body', $this->t_row->render());
+            $this->template->dangerouslyAppendHtml('Body', $this->t_row->renderToHtml());
         }
     }
 

--- a/src/Table/Column/Link.php
+++ b/src/Table/Column/Link.php
@@ -154,7 +154,7 @@ class Link extends Table\Column
         if ($this->url) {
             $rowValues = $this->getApp()->ui_persistence ? $this->getApp()->ui_persistence->typecastSaveRow($row, $row->get()) : $row->get();
 
-            return ['c_' . $this->short_name => $this->url->set($rowValues)->render()];
+            return ['c_' . $this->short_name => $this->url->set($rowValues)->renderToHtml()];
         }
 
         $p = $this->page ?: [];

--- a/src/Table/Column/Multiformat.php
+++ b/src/Table/Column/Multiformat.php
@@ -86,7 +86,7 @@ class Multiformat extends Table\Column
         $template->set($row);
         $template->dangerouslySetHtml($html_tags);
 
-        $val = $template->render();
+        $val = $template->renderToHtml();
 
         return ['c_' . $this->short_name => $val];
     }

--- a/src/Table/Column/Multiformat.php
+++ b/src/Table/Column/Multiformat.php
@@ -84,7 +84,7 @@ class Multiformat extends Table\Column
         $template = new HtmlTemplate($cell);
         $template->setApp($this->getApp());
         $template->set($row);
-        $template->setHtml($html_tags);
+        $template->dangerouslySetHtml($html_tags);
 
         $val = $template->render();
 

--- a/src/UserAction/ModalExecutor.php
+++ b/src/UserAction/ModalExecutor.php
@@ -385,7 +385,7 @@ class ModalExecutor extends Modal implements JsExecutorInterface
                 break;
             case 'html':
                 $preview = View::addTo($modal, ['ui' => 'basic segment']);
-                $preview->template->setHtml('Content', $text);
+                $preview->template->dangerouslySetHtml('Content', $text);
 
                 break;
         }

--- a/src/UserAction/PreviewExecutor.php
+++ b/src/UserAction/PreviewExecutor.php
@@ -39,7 +39,7 @@ class PreviewExecutor extends BasicExecutor
                 break;
             case 'html':
                 $this->preview = View::addTo($this, ['ui' => 'segment']);
-                $this->preview->template->setHtml('Content', $text);
+                $this->preview->template->dangerouslySetHtml('Content', $text);
 
                 break;
         }

--- a/src/View.php
+++ b/src/View.php
@@ -660,7 +660,7 @@ class View extends AbstractView implements JsExpressionable
      */
     protected function renderTemplateToHtml(string $region = null): string
     {
-        return $this->template->render($region);
+        return $this->template->renderToHtml($region);
     }
 
     /**

--- a/src/View.php
+++ b/src/View.php
@@ -610,7 +610,7 @@ class View extends AbstractView implements JsExpressionable
             foreach ($this->attr as $attr => $val) {
                 $tmp[] = $attr . '="' . $this->getApp()->encodeAttribute($val) . '"';
             }
-            $this->template->setHtml('attributes', implode(' ', $tmp));
+            $this->template->dangerouslySetHtml('attributes', implode(' ', $tmp));
         }
     }
 
@@ -625,7 +625,7 @@ class View extends AbstractView implements JsExpressionable
                 continue;
             }
 
-            $this->template->appendHtml($view->region, $view->getHtml());
+            $this->template->dangerouslyAppendHtml($view->region, $view->getHtml());
 
             if ($view->_js_actions) {
                 $this->_js_actions = array_merge_recursive($this->_js_actions, $view->_js_actions);

--- a/src/VirtualPage.php
+++ b/src/VirtualPage.php
@@ -115,8 +115,8 @@ class VirtualPage extends View
                 // special treatment for popup
                 if ($mode === 'popup') {
                     $this->getApp()->html->template->set('title', $this->getApp()->title);
-                    $this->getApp()->html->template->setHtml('Content', parent::getHtml());
-                    $this->getApp()->html->template->appendHtml('HEAD', $this->getJs());
+                    $this->getApp()->html->template->dangerouslySetHtml('Content', parent::getHtml());
+                    $this->getApp()->html->template->dangerouslyAppendHtml('HEAD', $this->getJs());
 
                     $this->getApp()->terminateHtml($this->getApp()->html->template);
                 }
@@ -152,13 +152,13 @@ class VirtualPage extends View
                 }
             }
 
-            $this->getApp()->layout->template->setHtml('Content', parent::getHtml());
+            $this->getApp()->layout->template->dangerouslySetHtml('Content', parent::getHtml());
             $this->getApp()->layout->_js_actions = array_merge($this->getApp()->layout->_js_actions, $this->_js_actions);
 
-            $this->getApp()->html->template->setHtml('Content', $this->getApp()->layout->template->render());
-            $this->getApp()->html->template->setHtml('Modals', $modalHtml);
+            $this->getApp()->html->template->dangerouslySetHtml('Content', $this->getApp()->layout->template->render());
+            $this->getApp()->html->template->dangerouslySetHtml('Modals', $modalHtml);
 
-            $this->getApp()->html->template->appendHtml('HEAD', $this->getApp()->layout->getJs());
+            $this->getApp()->html->template->dangerouslyAppendHtml('HEAD', $this->getApp()->layout->getJs());
 
             $this->getApp()->terminateHtml($this->getApp()->html->template);
         });

--- a/src/VirtualPage.php
+++ b/src/VirtualPage.php
@@ -155,7 +155,7 @@ class VirtualPage extends View
             $this->getApp()->layout->template->dangerouslySetHtml('Content', parent::getHtml());
             $this->getApp()->layout->_js_actions = array_merge($this->getApp()->layout->_js_actions, $this->_js_actions);
 
-            $this->getApp()->html->template->dangerouslySetHtml('Content', $this->getApp()->layout->template->render());
+            $this->getApp()->html->template->dangerouslySetHtml('Content', $this->getApp()->layout->template->renderToHtml());
             $this->getApp()->html->template->dangerouslySetHtml('Modals', $modalHtml);
 
             $this->getApp()->html->template->dangerouslyAppendHtml('HEAD', $this->getApp()->layout->getJs());

--- a/tests/HtmlTemplateTest.php
+++ b/tests/HtmlTemplateTest.php
@@ -18,7 +18,7 @@ class HtmlTemplateTest extends AtkPhpunit\TestCase
         $t = new HtmlTemplate('hello, {foo}world{/}');
         $t['foo'] = 'bar';
 
-        $this->assertSame('hello, bar', $t->render());
+        $this->assertSame('hello, bar', $t->renderToHtml());
     }
 
     /**
@@ -149,10 +149,10 @@ class HtmlTemplateTest extends AtkPhpunit\TestCase
         // del tests
         $t->set('foo', 'Hello');
         $t->del('foo');
-        $this->assertSame(' guys', $t->render());
+        $this->assertSame(' guys', $t->renderToHtml());
         $t->set('foo', 'Hello');
         $t->tryDel('qwe'); // non existent tag, ignores
-        $this->assertSame('Hello guys', $t->render());
+        $this->assertSame('Hello guys', $t->renderToHtml());
 
         // set and append tests
         $t->set('foo', 'Hello');
@@ -168,7 +168,7 @@ class HtmlTemplateTest extends AtkPhpunit\TestCase
         $t->tryDangerouslyAppendHtml('foo', ' and <b>smart</b>'); // appends html
         $t->tryDangerouslyAppendHtml('qwe', '<b>ignore</b> this'); // ignores
 
-        $this->assertSame('<b>Hi</b> and <b>welcome</b> my dear and <b>smart</b> guys', $t->render());
+        $this->assertSame('<b>Hi</b> and <b>welcome</b> my dear and <b>smart</b> guys', $t->renderToHtml());
     }
 
     /**
@@ -202,14 +202,14 @@ class HtmlTemplateTest extends AtkPhpunit\TestCase
                 return strtoupper($value);
             });
         }
-        $this->assertSame('HELLO, cruel WORLD. WELCOME', $t->render());
+        $this->assertSame('HELLO, cruel WORLD. WELCOME', $t->renderToHtml());
 
         // tag contains all template (for example in Lister)
         $t = new HtmlTemplate('{foo}hello{/}');
         $t->eachTag('foo', function ($value, $tag) {
             return strtoupper($value);
         });
-        $this->assertSame('HELLO', $t->render());
+        $this->assertSame('HELLO', $t->renderToHtml());
     }
 
     /**
@@ -221,11 +221,11 @@ class HtmlTemplateTest extends AtkPhpunit\TestCase
 
         // clone only {foo} region
         $t1 = $t->cloneRegion('foo');
-        $this->assertSame('hello', $t1->render());
+        $this->assertSame('hello', $t1->renderToHtml());
 
         // clone all template
         $t1 = $t->cloneRegion('_top');
-        $this->assertSame('hello guys', $t1->render());
+        $this->assertSame('hello guys', $t1->renderToHtml());
     }
 
     /**
@@ -244,7 +244,7 @@ class HtmlTemplateTest extends AtkPhpunit\TestCase
     public function testRenderRegion()
     {
         $t = new HtmlTemplate('{foo}hello{/} guys');
-        $this->assertSame('hello', $t->render('foo'));
+        $this->assertSame('hello', $t->renderToHtml('foo'));
     }
 
     public function testDollarTags()
@@ -254,6 +254,6 @@ class HtmlTemplateTest extends AtkPhpunit\TestCase
             'foo' => 'Hello',
             'bar' => 'welcome',
         ]);
-        $this->assertSame('Hello guys and welcome here', $t->render());
+        $this->assertSame('Hello guys and welcome here', $t->renderToHtml());
     }
 }

--- a/tests/HtmlTemplateTest.php
+++ b/tests/HtmlTemplateTest.php
@@ -87,7 +87,7 @@ class HtmlTemplateTest extends AtkPhpunit\TestCase
     {
         $t = new HtmlTemplate();
         $this->expectException(Exception::class);
-        $t->load('bad_template_file');
+        $t->loadFromFile('bad_template_file');
     }
 
     /**
@@ -96,7 +96,7 @@ class HtmlTemplateTest extends AtkPhpunit\TestCase
     public function testBadTemplate2()
     {
         $t = new HtmlTemplate();
-        $this->assertFalse($t->tryLoad('bad_template_file'));
+        $this->assertFalse($t->tryLoadFromFile('bad_template_file'));
     }
 
     /**
@@ -235,7 +235,7 @@ class HtmlTemplateTest extends AtkPhpunit\TestCase
     {
         $t = new HtmlTemplate();
         $this->expectException(Exception::class);
-        $t->load('such-file-does-not-exist.txt');
+        $t->loadFromFile('such-file-does-not-exist.txt');
     }
 
     /**

--- a/tests/HtmlTemplateTest.php
+++ b/tests/HtmlTemplateTest.php
@@ -140,7 +140,7 @@ class HtmlTemplateTest extends AtkPhpunit\TestCase
     }
 
     /**
-     * Test set, append, tryAppend, tryAppendHtml, del, tryDel.
+     * Test set, append, tryAppend, tryDangerouslyAppendHtml, del, tryDel.
      */
     public function testSetAppendDel()
     {
@@ -157,16 +157,16 @@ class HtmlTemplateTest extends AtkPhpunit\TestCase
         // set and append tests
         $t->set('foo', 'Hello');
         $t->set('foo', 'Hi'); // overwrites
-        $t->setHtml('foo', '<b>Hi</b>'); // overwrites
+        $t->dangerouslySetHtml('foo', '<b>Hi</b>'); // overwrites
         $t->trySet('qwe', 'ignore this'); // ignores
-        $t->trySetHtml('qwe', '<b>ignore</b> this'); // ignores
+        $t->tryDangerouslySetHtml('qwe', '<b>ignore</b> this'); // ignores
 
         $t->append('foo', ' and'); // appends
-        $t->appendHtml('foo', ' <b>welcome</b> my'); // appends
+        $t->dangerouslyAppendHtml('foo', ' <b>welcome</b> my'); // appends
         $t->tryAppend('foo', ' dear'); // appends
         $t->tryAppend('qwe', 'ignore this'); // ignores
-        $t->tryAppendHtml('foo', ' and <b>smart</b>'); // appends html
-        $t->tryAppendHtml('qwe', '<b>ignore</b> this'); // ignores
+        $t->tryDangerouslyAppendHtml('foo', ' and <b>smart</b>'); // appends html
+        $t->tryDangerouslyAppendHtml('qwe', '<b>ignore</b> this'); // ignores
 
         $this->assertSame('<b>Hi</b> and <b>welcome</b> my dear and <b>smart</b> guys', $t->render());
     }


### PR DESCRIPTION
like React and other frameworks do - having html setter itself is not dangerous, but you really must know what are you doing

deprecated BC provided

also, these methods were renamed:

- method `HtmlTemplate::load` was renamed to `HtmlTemplate::loadFromFile`
- method `HtmlTemplate::tryLoad` was renamed to `HtmlTemplate::tryLoadFromFile`
- method `HtmlTemplate::loadTemplateFromString` was renamed to `HtmlTemplate::loadFromString`
- method `HtmlTemplate::render` was renamed to `HtmlTemplate::renderToHtml`

and defautly encoding setter methods do not longer accept dangerous 3rd `$encode` param