### PR TITLE
Fix Template::cloneRegion

### DIFF
--- a/src/HtmlTemplate.php
+++ b/src/HtmlTemplate.php
@@ -636,7 +636,7 @@ class HtmlTemplate implements \ArrayAccess
             $template->template = $this->template;
             $template->source = $this->source;
         } else {
-            $template->template = [$tag . '#0' => $this->get($tag)];
+            $template->template = $this->get($tag);
             $template->source = 'clone of tag "' . $tag . '" from template "' . $this->source . '"';
         }
         $template->rebuildTagsIndex();

--- a/src/HtmlTemplate.php
+++ b/src/HtmlTemplate.php
@@ -636,7 +636,7 @@ class HtmlTemplate implements \ArrayAccess
             $template->template = $this->template;
             $template->source = $this->source;
         } else {
-            $template->template = [self::TOP_TAG . '#0' => $this->get($tag)];
+            $template->template = [$tag . '#0' => $this->get($tag)];
             $template->source = 'clone of tag "' . $tag . '" from template "' . $this->source . '"';
         }
         $template->rebuildTagsIndex();


### PR DESCRIPTION
this is a bug, `_top` key should not be added (and is not set before cloned)