### PR TITLE
Make outputResponseJson() and outputResponseHtml() protected

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -1067,7 +1067,7 @@ class App
      *
      * @param string[] $headers
      */
-    private function outputResponseHtml(string $data, array $headers = []): void
+    protected function outputResponseHtml(string $data, array $headers = []): void
     {
         $this->outputResponse(
             $data,
@@ -1081,7 +1081,7 @@ class App
      * @param string|array $data
      * @param string[]     $headers
      */
-    private function outputResponseJson($data, array $headers = []): void
+    protected function outputResponseJson($data, array $headers = []): void
     {
         if (!is_string($data)) {
             $data = $this->encodeJson($data);


### PR DESCRIPTION
These methods were private before, making it unneccessarily hard for example to overwrite caughtException(). In my case, I want to return a jsToast if it was a JS request, not a full page load:
```
 //this code is in the if clause that checks if it was a JS request
$jsToast = new JsToast(['message' => $message, 'class' => 'error']);
           $this->outputResponseJson(
                [
                    'success' => true,
                    'message' => '',
                    'atkjs' => $jsToast->jsRender()
                ]
            );
```