### PR TITLE
[fix] - Crud menu icon

### DIFF
--- a/src/Crud.php
+++ b/src/Crud.php
@@ -137,7 +137,12 @@ class Crud extends Grid
             foreach ($this->_getModelActions(Model\UserAction::APPLIES_TO_NO_RECORDS) as $k => $action) {
                 if ($action->enabled) {
                     $action->ui['executor'] = $this->initActionExecutor($action);
-                    $this->menuItems[$k]['item'] = $this->menu->addItem([$action->getCaption(), 'icon' => 'plus']);
+                    $this->menuItems[$k]['item'] = $this->menu->addItem(
+                        array_merge(
+                            [$action->getCaption()],
+                            $action->modifier === Model\UserAction::MODIFIER_CREATE ? ['icon' => 'plus'] : []
+                        )
+                    );
                     $this->menuItems[$k]['action'] = $action;
                 }
             }


### PR DESCRIPTION
In the Crud menu, passing an UserAction action would automatically add a plus icon to the menu button.
This fix will only add a plus icon when action modifier === CREATE.