### PR TITLE
Replace call_user_func() calls as much as possible

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -204,9 +204,7 @@ class App
 
                 throw new \ErrorException($msg, 0, $severity, $file, $line);
             });
-            if (\PHP_SAPI !== 'cli') { // for phpunit
-                http_response_code(500);
-            }
+            http_response_code(500);
         }
 
         // always run app on shutdown

--- a/src/Form/Control/Multiline.php
+++ b/src/Form/Control/Multiline.php
@@ -108,7 +108,7 @@ class Multiline extends Form\Control
     /** @var array SuiTable component props */
     public $tableProps = [];
 
-    /** @var array<string, array{component: string, componentProps: mixed}> Set Vue component to use per field type. */
+    /** @var array<string, array<string, mixed>> Set Vue component to use per field type. */
     protected $fieldMapToComponent = [
         'default' => [
             'component' => self::INPUT,
@@ -590,13 +590,14 @@ class Multiline extends Form\Control
             $component = $this->fieldMapToComponent['default'];
         }
 
-        $definition = array_map(function ($value) use ($field) {
-            $this->issetOwner(); // prevent PHP CS Fixer to make this anonymous function static, TODO https://github.com/atk4/ui/pull/1625
+        // map all callables defaults
+        foreach ($component as $k => $v) {
+            if (is_array($v) && is_callable($v)) {
+                $component[$k] = call_user_func($v, $field);
+            }
+        }
 
-            return is_array($value) && is_callable($value) ? call_user_func($value, $field) : $value;
-        }, $component);
-
-        return $definition;
+        return $component;
     }
 
     protected function getFieldItems(Field $field, ?int $limit = 10): array

--- a/src/Form/Control/Multiline.php
+++ b/src/Form/Control/Multiline.php
@@ -171,7 +171,7 @@ class Multiline extends Form\Control
      * Set during fieldDefinition and apply during renderView() after getValue().
      * Must contains callable function and function will receive $model field and value as parameter.
      *
-     * @var array
+     * @var array<string, \Closure(Field, string): void>
      */
     private $valuePropsBinding = [];
 
@@ -546,7 +546,7 @@ class Multiline extends Form\Control
 
         $props['config']['placeholder'] ??= 'Select ' . $field->getCaption();
 
-        $this->valuePropsBinding[$field->shortName] = [__CLASS__, 'setLookupOptionValue'];
+        $this->valuePropsBinding[$field->shortName] = fn ($field, $value) => $this->setLookupOptionValue($field, $value);
 
         return $props;
     }
@@ -629,8 +629,8 @@ class Multiline extends Form\Control
 
         foreach ($fieldValues as $rows) {
             foreach ($rows as $fieldName => $value) {
-                if (array_key_exists($fieldName, $this->valuePropsBinding)) {
-                    call_user_func($this->valuePropsBinding[$fieldName], $this->model->getField($fieldName), $value);
+                if (isset($this->valuePropsBinding[$fieldName])) {
+                    ($this->valuePropsBinding[$fieldName])($this->model->getField($fieldName), $value);
                 }
             }
         }
@@ -657,7 +657,7 @@ class Multiline extends Form\Control
                 'fields' => $this->fieldDefs,
                 'url' => $this->renderCallback->getJsUrl(),
                 'eventFields' => $this->eventFields,
-                'hasChangeCb' => $this->onChangeFunction ? true : false,
+                'hasChangeCb' => $this->onChangeFunction !== null,
                 'tableProps' => $this->tableProps,
                 'rowLimit' => $this->rowLimit,
                 'caption' => $this->caption,
@@ -681,7 +681,7 @@ class Multiline extends Form\Control
                 $this->getApp()->terminateJson(['success' => true, 'expressions' => $expressionValues]);
                 // no break - expression above always terminate
             case 'on-change':
-                $response = call_user_func($this->onChangeFunction, $this->typeCastLoadValues($this->getApp()->decodeJson($_POST['rows'])), $this->form);
+                $response = ($this->onChangeFunction)($this->typeCastLoadValues($this->getApp()->decodeJson($_POST['rows'])), $this->form);
                 $this->renderCallback->terminateAjax($this->renderCallback->getAjaxec($response));
                 // TODO JsCallback::terminateAjax() should return never
         }

--- a/src/Form/Control/ScopeBuilder.php
+++ b/src/Form/Control/ScopeBuilder.php
@@ -426,12 +426,16 @@ class ScopeBuilder extends Form\Control
         $options = $defaults['options'] ?? [];
         unset($defaults['options']);
 
-        // map all values for callables and merge with defaults
-        return array_merge(array_map(function ($value) use ($field, $options) {
-            $this->issetOwner(); // prevent PHP CS Fixer to make this anonymous function static, TODO https://github.com/atk4/ui/pull/1625
+        // map all callables
+        foreach ($rule as $k => $v) {
+            if (is_array($v) && is_callable($v)) {
+                $rule[$k] = call_user_func($v, $field, $options);
+            }
+        }
 
-            return is_array($value) && is_callable($value) ? call_user_func($value, $field, $options) : $value;
-        }, $rule), $defaults);
+        $rule = array_merge($rule, $defaults);
+
+        return $rule;
     }
 
     /**

--- a/src/UserAction/ExecutorFactory.php
+++ b/src/UserAction/ExecutorFactory.php
@@ -191,7 +191,9 @@ class ExecutorFactory
             }
         }
 
-        $seed = is_array($seed) && is_callable($seed) ? call_user_func($seed, $action, $type) : $seed;
+        if (is_array($seed) && is_callable($seed)) {
+            $seed = call_user_func($seed, $action, $type);
+        }
 
         return Factory::factory($seed);
     }
@@ -242,7 +244,11 @@ class ExecutorFactory
             }
         }
 
-        return is_array($caption) && is_callable($caption) ? call_user_func($caption, $action) : $caption;
+        if (is_array($caption) && is_callable($caption)) {
+            $caption = call_user_func($caption, $action);
+        }
+
+        return $caption;
     }
 
     /**


### PR DESCRIPTION
`call_user_func()` calls cannot be fully removed as long as property defaults should be supported - they are php-src constant expressions and they currently do not support Closures, not even first class callables.