### PR TITLE
[fix] Multiline

### DIFF
--- a/demos/form-control/multiline.php
+++ b/demos/form-control/multiline.php
@@ -94,16 +94,16 @@ $inventory = new $inventoryItemClass(new Persistence\Array_(), ['dateFormat' => 
 // Populate some data.
 $total = 0;
 for ($i = 1; $i < 3; ++$i) {
-    $inventory2 = $inventory->createEntity();
-    $inventory2->set('id', $i);
-    $inventory2->set('inv_date', date($dateFormat));
-    $inventory2->set('inv_time', date($timeFormat));
-    $inventory2->set('item', 'item_' . $i);
-    $inventory2->set('country', random_int(1, 100));
-    $inventory2->set('qty', random_int(10, 100));
-    $inventory2->set('box', random_int(1, 10));
-    $total = $total + ($inventory2->get('qty') * $inventory2->get('box'));
-    $inventory2->saveAndUnload();
+    $entity = $inventory->createEntity();
+    $entity->set('id', $i);
+    $entity->set('inv_date', date($dateFormat));
+    $entity->set('inv_time', date($timeFormat));
+    $entity->set('item', 'item_' . $i);
+    $entity->set('country', random_int(1, 100));
+    $entity->set('qty', random_int(10, 100));
+    $entity->set('box', random_int(1, 10));
+    $total = $total + ($entity->get('qty') * $entity->get('box'));
+    $entity->saveAndUnload();
 }
 
 $form = Form::addTo($app);

--- a/docs/multiline.rst
+++ b/docs/multiline.rst
@@ -101,22 +101,23 @@ Lets say a User can have many email addresses, but you want to store them in a s
         }
     }
 
-Using a form with User model won't automatically add a Multiline to edit the email addresses.
+Using a form with User model won't automatically add a Multiline to edit the related email addresses.
 
-.. php:method:: setReferenceModel(Model $refModel, string $linkByFieldName, array $field = [])
+.. php:method:: setReferenceModel(string $refModelName, Model $modelEntity = null, array $fieldNames = []): Model
 
-If you want to edit them along with the user, Multiline need to be set up accordingly::
+If you want to edit them along with the user, Multiline need to be set up accordingly using the setReferenceModel method::
 
     // Add a form to Ui in order to edit User record.
     $user_form = \Atk4\Ui\Form::addTo($app);
-    $user_form->setModel($user);
+    $user_form->setModel($user->load($userId));
 
     $ml = $user_form->addControl('emails', [\Atk4\Ui\Form\Control\Multiline::class]);
-    $ml->setReferenceModel($user->ref('Emails'), 'user_id');
+    $ml->setReferenceModel('Emails');
 
     // set up saving of Email on Form submit
     $user_form->onSubmit(function($form) use ($ml) {
         $form->model->save();
+        // save emails record related to current user.
         $ml->saveRows();
 
         return new JsToast(var_export($ml->model->export(), true));

--- a/docs/type-presentation.rst
+++ b/docs/type-presentation.rst
@@ -17,7 +17,7 @@ important concept to understand is the distinction between data Presentation and
 
 Agile UI believes that presentation must be consistent throughout the system. A monetary
 field will use same format on the :php:class:`Form`, :php:class:`Table` and even inside a
-custom HTML template specified into generic :php:class:`View`. 
+custom HTML template specified into generic :php:class:`View`.
 
 When it comes to decoration, the method is very dependent on the context. A form may present
 Calendar (DatePicker) or enable control icon to indicate currency.
@@ -112,7 +112,7 @@ This is reverse scenario. Field `account_number` needs to be stored as-is but sh
 hidden when presented. To hide it from Table::
 
     $model = new User($app->db);
-    
+
     $table->setModel($model);
     $model->addDecorator('account_number', new \Atk4\Ui\Table\Column\Password());
 
@@ -132,7 +132,7 @@ yet make it available when editing, you could create your own :php:class:`Table\
         public function getHtmlTags(\Atk4\Data\Model $row, $field)
         {
             return [
-                'mask' => substr($field->get(), -4) 
+                'mask' => substr($field->get(), -4)
             ];
         }
     }
@@ -153,9 +153,9 @@ extending :php:class:`Persistence\\Ui`::
         public function _typecastSaveField(\Atk4\Data\Field $field, $value)
         {
             switch ($field->type) {
-            case 'card':
-                $parts = str_split($value, 4);
-                return join(' ', $parts);
+                case 'card':
+                    $parts = str_split($value, 4);
+                    return join(' ', $parts);
             }
             return parent::_typecastSaveField($field, $value);
         }
@@ -163,8 +163,8 @@ extending :php:class:`Persistence\\Ui`::
         public function _typecastLoadField(\Atk4\Data\Field $field, $value)
         {
             switch ($field->type) {
-            case 'card':
-                return str_replace(' ', '', $value);
+                case 'card':
+                    return str_replace(' ', '', $value);
             }
             return parent::_typecastLoadField($field, $value);
         }

--- a/src/Form/Control/Multiline.php
+++ b/src/Form/Control/Multiline.php
@@ -869,7 +869,7 @@ class Multiline extends Form\Control
             case 'integer':
             case 'float':
                 // Value is 0 or the field value.
-                $value = $model->get($fieldName) ?: 0;
+                $value = (string) $model->get($fieldName) ?: 0;
 
                 break;
             default:

--- a/src/Form/Control/Multiline.php
+++ b/src/Form/Control/Multiline.php
@@ -210,7 +210,7 @@ class Multiline extends Form\Control
 
         // load the data associated with this input and validate it.
         $this->form->onHook(Form::HOOK_LOAD_POST, function ($form, &$post) {
-            $this->rowData = $this->loadRowData();
+            $this->rowData = $this->typeCastLoadValues($this->getApp()->decodeJson($_POST[$this->short_name]));
             if ($this->rowData) {
                 $this->rowErrors = $this->validate($this->rowData);
                 if ($this->rowErrors) {
@@ -247,11 +247,11 @@ class Multiline extends Form\Control
     /**
      * Typecast each loaded value.
      */
-    protected function loadRowData()
+    protected function typeCastLoadValues(array $values): array
     {
         $dataRows = [];
 
-        foreach ($this->getApp()->decodeJson($_POST[$this->short_name]) as $k => $row) {
+        foreach ($values as $k => $row) {
             foreach ($row as $fieldName => $value) {
                 if ($fieldName === '__atkml') {
                     $dataRows[$k][$fieldName] = $value;
@@ -710,7 +710,7 @@ class Multiline extends Form\Control
 
                 break;
             case 'on-change':
-                $response = call_user_func($this->onChangeFunction, $this->getApp()->decodeJson($_POST['rows']), $this->form);
+                $response = call_user_func($this->onChangeFunction, $this->typeCastLoadValues($this->getApp()->decodeJson($_POST['rows'])), $this->form);
                 $this->renderCallback->terminateAjax($this->renderCallback->getAjaxec($response));
 
                 break;

--- a/src/Form/Control/Multiline.php
+++ b/src/Form/Control/Multiline.php
@@ -422,7 +422,7 @@ class Multiline extends Form\Control
     {
         if (!$modelEntity && !$this->form->model->isEntity()) {
             throw new Exception('Model entity is not set.');
-        } else if (!$modelEntity) {
+        } elseif (!$modelEntity) {
             $modelEntity = $this->form->model;
         }
 

--- a/src/Form/Control/Multiline.php
+++ b/src/Form/Control/Multiline.php
@@ -332,7 +332,7 @@ class Multiline extends Form\Control
                 }
 
                 if ($fieldName === $model->id_field && $value) {
-                    $entity = $model->load( $this->getApp()->ui_persistence->typecastLoadField($model->getField($fieldName), $value));
+                    $entity = $model->load($this->getApp()->ui_persistence->typecastLoadField($model->getField($fieldName), $value));
                 }
 
                 if ($model->getField($fieldName)->isEditable()) {

--- a/src/Form/Control/Multiline.php
+++ b/src/Form/Control/Multiline.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
  *
  * // Add Multiline form control and set model for Invoice items.
  * $ml = $form->addControl('ml', ['Multiline::class']);
- * $ml->setReferenceModel($invoice->ref('Items'), 'invoice_id', ['item','cat','qty','price', 'total']);
+ * $ml->setReferenceModel('Items', null, ['item', 'cat', 'qty', 'price', 'total']);
  *
  * $form->onSubmit(function($form) use ($ml) {
  *     // Save Form model and then Multiline model
@@ -435,9 +435,11 @@ class Multiline extends Form\Control
      */
     public function setReferenceModel(string $refModelName, Model $modelEntity = null, array $fieldNames = []): Model
     {
-        if (!$modelEntity && !$this->form->model->isEntity()) {
-            throw new Exception('Model entity is not set.');
-        } elseif (!$modelEntity) {
+        if ($modelEntity === null) {
+            if (!$this->form->model->isEntity()) {
+                throw new Exception('Model entity is not set.');
+            }
+
             $modelEntity = $this->form->model;
         }
 

--- a/src/Form/Control/Multiline.php
+++ b/src/Form/Control/Multiline.php
@@ -344,15 +344,10 @@ class Multiline extends Form\Control
         $currentIds = array_column($model->export(), $model->id_field);
 
         foreach ($this->rowData as $row) {
-            $entity = $model->createEntity();
-
+            $entity = $model->tryLoad($row[$model->id_field] ?? null);
             foreach ($row as $fieldName => $value) {
                 if ($fieldName === '__atkml') {
                     continue;
-                }
-
-                if ($fieldName === $model->id_field && $value) {
-                    $entity = $model->load($value);
                 }
 
                 if ($model->getField($fieldName)->isEditable()) {

--- a/src/Persistence/Ui.php
+++ b/src/Persistence/Ui.php
@@ -136,6 +136,7 @@ class Ui extends \Atk4\Data\Persistence
         switch ($f->type) {
             case 'integer':
                 $value = (int) $value;
+
                 break;
             case 'string':
             case 'text':

--- a/src/Persistence/Ui.php
+++ b/src/Persistence/Ui.php
@@ -134,6 +134,9 @@ class Ui extends \Atk4\Data\Persistence
         }
 
         switch ($f->type) {
+            case 'integer':
+                $value = (int) $value;
+                break;
             case 'string':
             case 'text':
                 break;

--- a/src/Table/Column/Status.php
+++ b/src/Table/Column/Status.php
@@ -71,20 +71,20 @@ class Status extends Table\Column
         }
 
         switch ($cl) {
-        case 'positive':
-            $ic = 'checkmark';
+            case 'positive':
+                $ic = 'checkmark';
 
-            break;
-        case 'negative':
-            $ic = 'close';
+                break;
+            case 'negative':
+                $ic = 'close';
 
-            break;
-        case 'default':
-            $ic = 'question';
+                break;
+            case 'default':
+                $ic = 'question';
 
-            break;
-        default:
-            $ic = '';
+                break;
+            default:
+                $ic = '';
         }
 
         return [


### PR DESCRIPTION
Align with latest data changes.

### BC-BREAK

Multiline->setReferenceModel() method parameters has changed.

You now have to passed the reference name and the model entity to where reference apply:

````
$multiline->setReferenceModel('Products', $categoryModel->load($id));
````
