### PR TITLE
Allow to initialize CascadeDropdown values

### DIFF
--- a/src/Form/Control/DropdownCascade.php
+++ b/src/Form/Control/DropdownCascade.php
@@ -67,7 +67,7 @@ class DropdownCascade extends Dropdown
     /**
      * Allow initializing CascadeDropdown with preset value.
      *
-     * @param string|int $value The initial ID value to set this dropdown using reference model values
+     * @param mixed $value The initial ID value to set this dropdown using reference model values
      * @param mixed $junk
      */
     public function set($value = null, $junk = null): self

--- a/src/Form/Control/DropdownCascade.php
+++ b/src/Form/Control/DropdownCascade.php
@@ -67,14 +67,14 @@ class DropdownCascade extends Dropdown
     /**
      * Allow initializing CascadeDropdown with preset value.
      *
-     * @param string|int $initialValue       The initial ID value to set this dropdown using reference model values
-     * @param string|int $fromReferenceValue The Cascade from reference ID value where reference model values
+     * @param string|int $value The initial ID value to set this dropdown using reference model values
+     * @param mixed $junk
      */
-    public function setInitialValues($initialValue, $fromReferenceValue): self
+    public function set($value = null, $junk = null): self
     {
-        $this->dropdownOptions['values'] = $this->getJsValues($this->getNewValues($fromReferenceValue), $initialValue);
+        $this->dropdownOptions['values'] = $this->getJsValues($this->getNewValues($this->cascadeFromControl->field->get()), $value);
 
-        return $this;
+        return parent::set($value, $junk);
     }
 
     /**

--- a/src/Form/Control/DropdownCascade.php
+++ b/src/Form/Control/DropdownCascade.php
@@ -69,8 +69,10 @@ class DropdownCascade extends Dropdown
      *
      * @param mixed $value The initial ID value to set this dropdown using reference model values
      * @param mixed $junk
+     *
+     * @return $this
      */
-    public function set($value = null, $junk = null): self
+    public function set($value = null, $junk = null)
     {
         $this->dropdownOptions['values'] = $this->getJsValues($this->getNewValues($this->cascadeFromControl->field->get()), $value);
 

--- a/src/Form/Control/DropdownCascade.php
+++ b/src/Form/Control/DropdownCascade.php
@@ -45,9 +45,8 @@ class DropdownCascade extends Dropdown
 
         $this->model = $this->cascadeFromControl->model ? $this->cascadeFromControl->model->ref($this->reference) : null;
 
-        // populate default dropdown values and add it via dropdownOptions.
-        $values = $this->getJsValues($this->getNewValues($this->cascadeFromControlValue), $this->field->get());
-        $this->dropdownOptions = array_merge($this->dropdownOptions, ['values' => $values]);
+        // populate default dropdown values
+        $this->dropdownOptions['values'] = $this->getJsValues($this->getNewValues($this->cascadeFromControlValue), $this->field->get());
 
         // js to execute for the onChange handler of the parent dropdown.
         $expr = [


### PR DESCRIPTION
Two values for proper initialization of the DropdownCascade is need: The actual value of the dropdown and the reference value for populating the dropdown items.

Usage:

```
$form = Form::addTo($app);

$form->addControl('cat', [Form\Control\Dropdown::class, 'model' => new Category($app->db)])->set(2);

$form->addControl('sub', [Form\Control\DropdownCascade::class, 'cascadeFrom' => 'cat', 'reference' => Category::hinting()->fieldName()->SubCategories])->set(9);

$form->addControl('prod', [Form\Control\DropdownCascade::class, 'cascadeFrom' => 'sub', 'reference' => SubCategory::hinting()->fieldName()->Products])->set(3)
```

<img width="487" alt="Screen Shot 2021-09-14 at 3 10 11 PM" src="https://user-images.githubusercontent.com/2204478/133319312-68bb44cf-6001-4b2b-9a1d-29ee8cdfcbf7.png">
