### PR TITLE
Impl. transactional session management

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -92,6 +92,10 @@
         }
     },
     "config": {
+        "allow-plugins": {
+            "ergebnis/composer-normalize": true,
+            "phpstan/extension-installer": true
+        },
         "sort-packages": true
     }
 }

--- a/docs/session.rst
+++ b/docs/session.rst
@@ -27,7 +27,7 @@ Later when you need the value, you can simply recall it::
 Properties
 ==========
 
-.. php:attr:: session_key
+.. php:attr:: rootNamespace
 
     Internal property to make sure that all session data will be stored in one
     "container" (array key).
@@ -35,13 +35,13 @@ Properties
 Methods
 =======
 
-.. php:method:: startSession($options = [])
+.. php:method:: startSession()
 
     Create new session.
 
-.. php:method:: destroySession()
+.. php:method:: closeSession()
 
-    Destroy existing session.
+    Close existing session.
 
 .. php:method:: memorize($key, $value)
 

--- a/src/App.php
+++ b/src/App.php
@@ -105,7 +105,7 @@ class App
     /** @var Persistence|Persistence\Sql */
     public $db;
 
-    /** @var App\Session */
+    /** @var App\SessionManager */
     public $session;
 
     /** @var string[] Extra HTTP headers to send on exit. */
@@ -188,7 +188,7 @@ class App
         }
 
         if ($this->session === null) {
-            $this->session = new App\Session();
+            $this->session = new App\SessionManager();
         }
 
         // setting up default executor factory.

--- a/src/App/SessionManager.php
+++ b/src/App/SessionManager.php
@@ -57,6 +57,27 @@ class SessionManager
     }
 
     /**
+     * @param mixed $value
+     */
+    protected function _memorize(string $namespace, string $key, $value): void
+    {
+        $_SESSION[$this->rootNamespace][$namespace][$key] = $value;
+    }
+
+    protected function _forget(string $namespace = null, string $key = null): void
+    {
+        if ($namespace === null) {
+            unset($_SESSION[$this->rootNamespace]);
+        } else {
+            if ($key === null) {
+                unset($_SESSION[$this->rootNamespace][$namespace]);
+            } else {
+                unset($_SESSION[$this->rootNamespace][$namespace][$key]);
+            }
+        }
+    }
+
+    /**
      * @return mixed
      */
     public function atomicSession(\Closure $fx, bool $readAndCloseImmediately = false)
@@ -155,7 +176,7 @@ class SessionManager
     public function memorize(string $namespace, string $key, $value)
     {
         return $this->atomicSession(function () use ($namespace, $key, $value) {
-            $_SESSION[$this->rootNamespace][$namespace][$key] = $value;
+            $this->_memorize($namespace, $key, $value);
 
             return $value;
         });
@@ -192,17 +213,11 @@ class SessionManager
     /**
      * Forget session data for $key. If $key is omitted will forget all
      * associated session data.
-     *
-     * @param string $key Optional key of data to forget
      */
     public function forget(string $namespace, string $key = null): void
     {
         $this->atomicSession(function () use ($namespace, $key) {
-            if ($key === null) {
-                unset($_SESSION[$this->rootNamespace][$namespace]);
-            } else {
-                unset($_SESSION[$this->rootNamespace][$namespace][$key]);
-            }
+            $this->_forget($namespace, $key);
         });
     }
 }

--- a/src/App/SessionManager.php
+++ b/src/App/SessionManager.php
@@ -6,7 +6,7 @@ namespace Atk4\Ui\App;
 
 use Atk4\Ui\Exception;
 
-class Session
+class SessionManager
 {
     /** @var string Session container key. */
     protected $session_key = '__atk_session';

--- a/src/App/SessionManager.php
+++ b/src/App/SessionManager.php
@@ -98,6 +98,11 @@ class SessionManager
         }
     }
 
+    /**
+     * @param bool $found
+     *
+     * @return mixed
+     */
     protected function recallWithCache(string $namespace, string $key, &$found)
     {
         $found = false;
@@ -114,6 +119,8 @@ class SessionManager
 
             return $res;
         }
+
+        return null;
     }
 
     /**

--- a/src/App/SessionManager.php
+++ b/src/App/SessionManager.php
@@ -57,27 +57,6 @@ class SessionManager
     }
 
     /**
-     * @param mixed $value
-     */
-    protected function _memorize(string $namespace, string $key, $value): void
-    {
-        $_SESSION[$this->rootNamespace][$namespace][$key] = $value;
-    }
-
-    protected function _forget(string $namespace = null, string $key = null): void
-    {
-        if ($namespace === null) {
-            unset($_SESSION[$this->rootNamespace]);
-        } else {
-            if ($key === null) {
-                unset($_SESSION[$this->rootNamespace][$namespace]);
-            } else {
-                unset($_SESSION[$this->rootNamespace][$namespace][$key]);
-            }
-        }
-    }
-
-    /**
      * @return mixed
      */
     public function atomicSession(\Closure $fx, bool $readAndCloseImmediately = false)
@@ -176,7 +155,7 @@ class SessionManager
     public function memorize(string $namespace, string $key, $value)
     {
         return $this->atomicSession(function () use ($namespace, $key, $value) {
-            $this->_memorize($namespace, $key, $value);
+            $_SESSION[$this->rootNamespace][$namespace][$key] = $value;
 
             return $value;
         });
@@ -217,7 +196,11 @@ class SessionManager
     public function forget(string $namespace, string $key = null): void
     {
         $this->atomicSession(function () use ($namespace, $key) {
-            $this->_forget($namespace, $key);
+            if ($key === null) {
+                unset($_SESSION[$this->rootNamespace][$namespace]);
+            } else {
+                unset($_SESSION[$this->rootNamespace][$namespace][$key]);
+            }
         });
     }
 }

--- a/src/App/SessionManager.php
+++ b/src/App/SessionManager.php
@@ -155,7 +155,7 @@ class SessionManager
             }
 
             return $_SESSION[$this->rootNamespace][$namespace][$key];
-        });
+        }, true);
     }
 
     /**

--- a/src/App/SessionManager.php
+++ b/src/App/SessionManager.php
@@ -9,7 +9,7 @@ use Atk4\Ui\Exception;
 class SessionManager
 {
     /** @var string Session container key. */
-    protected $session_key = '__atk_session';
+    protected $rootNamespace = '__atk_session';
 
     /**
      * Create new session.
@@ -33,7 +33,7 @@ class SessionManager
     /**
      * Destroy existing session.
      */
-    public function destroySession(): void
+    public function closeSession(): void
     {
         if (session_status() === \PHP_SESSION_ACTIVE) {
             session_destroy();
@@ -52,7 +52,7 @@ class SessionManager
     {
         $this->startSession();
 
-        $_SESSION[$this->session_key][$namespace][$key] = $value;
+        $_SESSION[$this->rootNamespace][$namespace][$key] = $value;
 
         return $value;
     }
@@ -68,7 +68,7 @@ class SessionManager
     {
         $this->startSession();
 
-        if (!isset($_SESSION[$this->session_key][$namespace][$key])) {
+        if (!isset($_SESSION[$this->rootNamespace][$namespace][$key])) {
             if ($default instanceof \Closure) {
                 $default = $default($key);
             }
@@ -91,7 +91,7 @@ class SessionManager
     {
         $this->startSession();
 
-        if (!isset($_SESSION[$this->session_key][$namespace][$key])) {
+        if (!isset($_SESSION[$this->rootNamespace][$namespace][$key])) {
             if ($default instanceof \Closure) {
                 $default = $default($key);
             }
@@ -99,7 +99,7 @@ class SessionManager
             return $default;
         }
 
-        return $_SESSION[$this->session_key][$namespace][$key];
+        return $_SESSION[$this->rootNamespace][$namespace][$key];
     }
 
     /**
@@ -113,9 +113,9 @@ class SessionManager
         $this->startSession();
 
         if ($key === null) {
-            unset($_SESSION[$this->session_key][$namespace]);
+            unset($_SESSION[$this->rootNamespace][$namespace]);
         } else {
-            unset($_SESSION[$this->session_key][$namespace][$key]);
+            unset($_SESSION[$this->rootNamespace][$namespace][$key]);
         }
     }
 }

--- a/src/App/SessionManager.php
+++ b/src/App/SessionManager.php
@@ -28,7 +28,7 @@ class SessionManager
 
     protected function startSession(bool $readAndCloseImmediately): void
     {
-        $this->isSessionActive();
+        $this->isSessionActive(); // assert session is not disabled
 
         $options = $this->createStartSessionOptions();
         if ($readAndCloseImmediately) {

--- a/src/App/SessionManager.php
+++ b/src/App/SessionManager.php
@@ -11,33 +11,70 @@ class SessionManager
     /** @var string Session container key. */
     protected $rootNamespace = '__atk_session';
 
-    /**
-     * Create new session.
-     *
-     * @param array $options Options for session_start()
-     */
-    public function startSession(array $options = []): void
+    protected function isSessionActive(): bool
     {
-        switch (session_status()) {
-            case \PHP_SESSION_DISABLED:
-                // @codeCoverageIgnoreStart - impossible to test
-                throw new Exception('Sessions are disabled on server');
-                // @codeCoverageIgnoreEnd
-            case \PHP_SESSION_NONE:
-                session_start($options);
+        $status = session_status();
+        if ($status === \PHP_SESSION_DISABLED) {
+            throw new Exception('Session support is disabled');
+        }
 
-                break;
+        return $status === \PHP_SESSION_ACTIVE;
+    }
+
+    protected function createStartSessionOptions(): array
+    {
+        return [];
+    }
+
+    protected function startSession(bool $readAndCloseImmediately): void
+    {
+        $this->isSessionActive();
+
+        $options = $this->createStartSessionOptions();
+        if ($readAndCloseImmediately) {
+            $options['read_and_close'] = true;
+        }
+        $res = session_start($options);
+
+        if (!$res) {
+            throw new Exception('Failed to start a session');
+        }
+    }
+
+    protected function closeSession(bool $writeBeforeClose): void
+    {
+        if ($writeBeforeClose) {
+            $res = session_write_close();
+        } else {
+            $res = session_abort();
+        }
+        unset($_SESSION);
+
+        if (!$res) {
+            throw new Exception('Failed to close a session');
         }
     }
 
     /**
-     * Destroy existing session.
+     * @return mixed
      */
-    public function closeSession(): void
+    public function atomicSession(\Closure $fx, bool $readAndCloseImmediately = false)
     {
-        if (session_status() === \PHP_SESSION_ACTIVE) {
-            session_destroy();
-            unset($_SESSION);
+        $wasActive = $this->isSessionActive();
+
+        if (!$wasActive) {
+            $this->startSession($readAndCloseImmediately);
+        }
+
+        $e = null;
+        try {
+            return $fx();
+        } catch (\Throwable $e) {
+            throw $e;
+        } finally {
+            if (!$wasActive && !$readAndCloseImmediately) {
+                $this->closeSession($e === null);
+            }
         }
     }
 
@@ -50,56 +87,56 @@ class SessionManager
      */
     public function memorize(string $namespace, string $key, $value)
     {
-        $this->startSession();
+        return $this->atomicSession(function () use ($namespace, $key, $value) {
+            $_SESSION[$this->rootNamespace][$namespace][$key] = $value;
 
-        $_SESSION[$this->rootNamespace][$namespace][$key] = $value;
-
-        return $value;
+            return $value;
+        });
     }
 
     /**
      * Similar to memorize, but if value for key exist, will return it.
      *
-     * @param mixed $default
+     * @param mixed $defaultValue
      *
-     * @return mixed Previously memorized data or $default
+     * @return mixed Previously memorized data or $defaultValue
      */
-    public function learn(string $namespace, string $key, $default = null)
+    public function learn(string $namespace, string $key, $defaultValue = null)
     {
-        $this->startSession();
+        return $this->atomicSession(function () use ($namespace, $key, $defaultValue) {
+            if (!isset($_SESSION[$this->rootNamespace][$namespace][$key])) {
+                if ($defaultValue instanceof \Closure) {
+                    $defaultValue = $defaultValue($key);
+                }
 
-        if (!isset($_SESSION[$this->rootNamespace][$namespace][$key])) {
-            if ($default instanceof \Closure) {
-                $default = $default($key);
+                return $this->memorize($namespace, $key, $defaultValue);
             }
 
-            return $this->memorize($namespace, $key, $default);
-        }
-
-        return $this->recall($namespace, $key);
+            return $this->recall($namespace, $key);
+        });
     }
 
     /**
      * Returns session data for this object. If not previously set, then
-     * $default is returned.
+     * $defaultValue is returned.
      *
-     * @param mixed $default
+     * @param mixed $defaultValue
      *
-     * @return mixed Previously memorized data or $default
+     * @return mixed Previously memorized data or $defaultValue
      */
-    public function recall(string $namespace, string $key, $default = null)
+    public function recall(string $namespace, string $key, $defaultValue = null)
     {
-        $this->startSession();
+        return $this->atomicSession(function () use ($namespace, $key, $defaultValue) {
+            if (!isset($_SESSION[$this->rootNamespace][$namespace][$key])) {
+                if ($defaultValue instanceof \Closure) {
+                    $defaultValue = $defaultValue($key);
+                }
 
-        if (!isset($_SESSION[$this->rootNamespace][$namespace][$key])) {
-            if ($default instanceof \Closure) {
-                $default = $default($key);
+                return $defaultValue;
             }
 
-            return $default;
-        }
-
-        return $_SESSION[$this->rootNamespace][$namespace][$key];
+            return $_SESSION[$this->rootNamespace][$namespace][$key];
+        });
     }
 
     /**
@@ -110,12 +147,12 @@ class SessionManager
      */
     public function forget(string $namespace, string $key = null): void
     {
-        $this->startSession();
-
-        if ($key === null) {
-            unset($_SESSION[$this->rootNamespace][$namespace]);
-        } else {
-            unset($_SESSION[$this->rootNamespace][$namespace][$key]);
-        }
+        $this->atomicSession(function () use ($namespace, $key) {
+            if ($key === null) {
+                unset($_SESSION[$this->rootNamespace][$namespace]);
+            } else {
+                unset($_SESSION[$this->rootNamespace][$namespace][$key]);
+            }
+        });
     }
 }

--- a/src/App/SessionManager.php
+++ b/src/App/SessionManager.php
@@ -28,12 +28,11 @@ class SessionManager
 
     protected function startSession(bool $readAndCloseImmediately): void
     {
-        $this->isSessionActive(); // assert session is not disabled
-
         $options = $this->createStartSessionOptions();
         if ($readAndCloseImmediately) {
             $options['read_and_close'] = true;
         }
+
         $res = session_start($options);
 
         if (!$res) {
@@ -48,7 +47,6 @@ class SessionManager
         } else {
             $res = session_abort();
         }
-        unset($_SESSION);
 
         if (!$res) {
             throw new Exception('Failed to close a session');
@@ -72,8 +70,12 @@ class SessionManager
         } catch (\Throwable $e) {
             throw $e;
         } finally {
-            if (!$wasActive && !$readAndCloseImmediately) {
-                $this->closeSession($e === null);
+            if (!$wasActive) {
+                if (!$readAndCloseImmediately) {
+                    $this->closeSession($e === null);
+                }
+
+                unset($_SESSION);
             }
         }
     }

--- a/src/SessionTrait.php
+++ b/src/SessionTrait.php
@@ -8,7 +8,7 @@ use Atk4\Core\TraitUtil;
 
 trait SessionTrait
 {
-    private function getSession(): App\Session
+    private function getSessionManager(): App\SessionManager
     {
         // all methods use this method, so we better check NameTrait existence here in one place
         if (!TraitUtil::hasNameTrait($this)) {
@@ -27,7 +27,7 @@ trait SessionTrait
      */
     public function memorize(string $key, $value)
     {
-        return $this->getSession()->memorize($this->name, $key, $value);
+        return $this->getSessionManager()->memorize($this->name, $key, $value);
     }
 
     /**
@@ -39,7 +39,7 @@ trait SessionTrait
      */
     public function learn(string $key, $default = null)
     {
-        return $this->getSession()->learn($this->name, $key, $default);
+        return $this->getSessionManager()->learn($this->name, $key, $default);
     }
 
     /**
@@ -52,7 +52,7 @@ trait SessionTrait
      */
     public function recall(string $key, $default = null)
     {
-        return $this->getSession()->recall($this->name, $key, $default);
+        return $this->getSessionManager()->recall($this->name, $key, $default);
     }
 
     /**
@@ -65,7 +65,7 @@ trait SessionTrait
      */
     public function forget(string $key = null)
     {
-        $this->getSession()->forget($this->name, $key);
+        $this->getSessionManager()->forget($this->name, $key);
 
         return $this;
     }

--- a/src/SessionTrait.php
+++ b/src/SessionTrait.php
@@ -19,6 +19,14 @@ trait SessionTrait
     }
 
     /**
+     * @return mixed
+     */
+    public function atomicSession(\Closure $fx, bool $readAndCloseImmediately = false)
+    {
+        return $this->getSessionManager()->atomicSession($fx, $readAndCloseImmediately);
+    }
+
+    /**
      * Remember data in object-relevant session data.
      *
      * @param mixed $value

--- a/src/SessionTrait.php
+++ b/src/SessionTrait.php
@@ -12,7 +12,7 @@ trait SessionTrait
     {
         // all methods use this method, so we better check NameTrait existence here in one place
         if (!TraitUtil::hasNameTrait($this)) {
-            throw new Exception('Object should have NameTrait applied to use session');
+            throw new Exception('Object must have NameTrait applied to use session');
         }
 
         return $this->getApp()->session;

--- a/src/SessionTrait.php
+++ b/src/SessionTrait.php
@@ -41,33 +41,31 @@ trait SessionTrait
     /**
      * Similar to memorize, but if value for key exist, will return it.
      *
-     * @param mixed $default
+     * @param mixed $defaultValue
      *
-     * @return mixed Previously memorized data or $default
+     * @return mixed Previously memorized data or $defaultValue
      */
-    public function learn(string $key, $default = null)
+    public function learn(string $key, $defaultValue = null)
     {
-        return $this->getSessionManager()->learn($this->name, $key, $default);
+        return $this->getSessionManager()->learn($this->name, $key, $defaultValue);
     }
 
     /**
      * Returns session data for this object. If not previously set, then
-     * $default is returned.
+     * $defaultValue is returned.
      *
-     * @param mixed $default
+     * @param mixed $defaultValue
      *
-     * @return mixed Previously memorized data or $default
+     * @return mixed Previously memorized data or $defaultValue
      */
-    public function recall(string $key, $default = null)
+    public function recall(string $key, $defaultValue = null)
     {
-        return $this->getSessionManager()->recall($this->name, $key, $default);
+        return $this->getSessionManager()->recall($this->name, $key, $defaultValue);
     }
 
     /**
      * Forget session data for $key. If $key is omitted will forget all
      * associated session data.
-     *
-     * @param string $key Optional key of data to forget
      *
      * @return $this
      */

--- a/tests/DemosTest.php
+++ b/tests/DemosTest.php
@@ -154,6 +154,7 @@ class DemosTest extends TestCase
             } catch (\Throwable $e) {
                 // session_start() or ini_set() functions can be used only with native HTTP tests
                 // override test expectation here to finish there tests cleanly (TODO better to make the code testable without calling these functions)
+                // TODO impl. volatile session manager for unit testing
                 if ($e instanceof \ErrorException && preg_match('~^(session_start|ini_set)\(\).* headers already sent$~', $e->getMessage())) {
                     $this->expectExceptionObject($e);
                 }

--- a/tests/SessionTraitTest.php
+++ b/tests/SessionTraitTest.php
@@ -65,9 +65,9 @@ class SessionTraitTest extends TestCase
         $m = new SessionMock($this->app);
 
         $this->assertFalse(isset($_SESSION));
-        $m->getApp()->session->startSession();
-        $this->assertTrue(isset($_SESSION));
-        $m->getApp()->session->closeSession();
+        $m->atomicSession(function (): void {
+            $this->assertTrue(isset($_SESSION));
+        });
         $this->assertFalse(isset($_SESSION));
     }
 
@@ -81,18 +81,23 @@ class SessionTraitTest extends TestCase
 
         // value as string
         $m->memorize('foo', 'bar');
-        $this->assertSame('bar', $_SESSION['__atk_session'][$m->name]['foo']);
+        $m->atomicSession(function () use ($m): void {
+            $this->assertSame('bar', $_SESSION['__atk_session'][$m->name]['foo']);
+        }, true);
 
         // value as null
         $m->memorize('foo', null);
-        $this->assertNull($_SESSION['__atk_session'][$m->name]['foo']);
+        $m->atomicSession(function () use ($m): void {
+            $this->assertNull($_SESSION['__atk_session'][$m->name]['foo']);
+        }, true);
 
         // value as object
         $o = new \stdClass();
+        $o->foo = 'x';
         $m->memorize('foo', $o);
-        $this->assertSame($o, $_SESSION['__atk_session'][$m->name]['foo']);
-
-        $m->getApp()->session->closeSession();
+        $m->atomicSession(function () use ($m, $o): void {
+            $this->assertSame(serialize($o), serialize($_SESSION['__atk_session'][$m->name]['foo']));
+        }, true);
     }
 
     /**

--- a/tests/SessionTraitTest.php
+++ b/tests/SessionTraitTest.php
@@ -67,7 +67,7 @@ class SessionTraitTest extends TestCase
         $this->assertFalse(isset($_SESSION));
         $m->getApp()->session->startSession();
         $this->assertTrue(isset($_SESSION));
-        $m->getApp()->session->destroySession();
+        $m->getApp()->session->closeSession();
         $this->assertFalse(isset($_SESSION));
     }
 
@@ -92,7 +92,7 @@ class SessionTraitTest extends TestCase
         $m->memorize('foo', $o);
         $this->assertSame($o, $_SESSION['__atk_session'][$m->name]['foo']);
 
-        $m->getApp()->session->destroySession();
+        $m->getApp()->session->closeSession();
     }
 
     /**


### PR DESCRIPTION
- and close session immediately by default, thus prevent blocking of other php scripts
- it can coeexist with apps that open the session manually before atk, then the session is used, but never closed
- custom driver can be easily implemented /wo the need to change the global session driver

to utilize the non-blocking behaviour, session must be NOT started manually using `session_start` or autostart