### PR TITLE
fix visible flag in CardTable

### DIFF
--- a/src/CardTable.php
+++ b/src/CardTable.php
@@ -29,9 +29,13 @@ class CardTable extends Table
 
         $model->assertIsLoaded();
 
+        if ($columns === null) {
+            $columns = array_keys($model->getFields('visible'));
+        }
+
         $data = [];
         foreach ($model->get() as $key => $value) {
-            if ($columns === null || in_array($key, $columns, true)) {
+            if (in_array($key, $columns, true)) {
                 $data[] = [
                     'id' => $key,
                     'field' => $model->getField($key)->getCaption(),


### PR DESCRIPTION
CardTable always was showing all fields including ID field (system field) and also fields marked with `ui/visible=false`. Normally we don't show such fields in views, for example, Table view will not show them.

This PR fixes that and hide visible=false fields from CardTable view.