### PR TITLE
Add custom decimal separator support for atk4_money type

### DIFF
--- a/demos/collection/card-deck.php
+++ b/demos/collection/card-deck.php
@@ -14,8 +14,8 @@ require_once __DIR__ . '/../init-app.php';
 Header::addTo($app, ['Card Deck', 'size' => 1, 'subHeader' => 'Card can be display in a deck, also using model action.']);
 
 $countries = new Country($app->db);
-$countries->addCalculatedField('Cost', ['expr' => function (Country $country) {
-    return '$ ' . number_format(random_int(500, 1500));
+$countries->addCalculatedField('Cost', ['type' => 'atk4_money', 'expr' => function (Country $country) {
+    return random_int(500, 1500);
 }]);
 
 $action = $countries->addUserAction('book', [

--- a/docs/multiline.rst
+++ b/docs/multiline.rst
@@ -176,7 +176,7 @@ In this case we display a message when any of the control value for 'qty' and 'b
             $box = $cols['box'] ?? 0;
             $total += $qty * $box;
         }
-        return new JsToast('The new Total is '.number_format($total, 2));
+        return new JsToast('The new Total is ' . $app->ui_persistence->typecastSaveField(new Field(['type' => 'atk4_money']), $total));
     }, ['qty', 'box']);
 
 

--- a/docs/table.rst
+++ b/docs/table.rst
@@ -261,7 +261,7 @@ The tag will override model value. Here is example usage of :php:meth:`Table\\Co
 
 
     class ExpiredColumn extends \Atk4\Ui\Table\Column
-        public function getDataCellHtml()
+        public function getDataCellHtml(): string
         {
             return '{$_expired}';
         }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1782,9 +1782,6 @@ parameters:
             path: 'src/Table/Column.php'
             message: '~^Method Atk4\\Ui\\Table\\Column::setHeaderDropdown\(\) has parameter \$items with no type specified\.$~'
         -
-            path: 'src/Table/Column.php'
-            message: '~^Method Atk4\\Ui\\Table\\Column::getTagAttributes\(\) has parameter \$position with no type specified\.$~'
-        -
             path: 'src/Table/Column/ActionButtons.php'
             message: '~^Method Atk4\\Ui\\Table\\Column\\ActionButtons::addButton\(\) has parameter \$isDisabled with no type specified\.$~'
         -
@@ -1814,9 +1811,6 @@ parameters:
         -
             path: 'src/Table/Column/ColorRating.php'
             message: '~^Method Atk4\\Ui\\Table\\Column\\ColorRating::createGradientSingle\(\) has parameter \$steps with no type specified\.$~'
-        -
-            path: 'src/Table/Column/ColorRating.php'
-            message: '~^Method Atk4\\Ui\\Table\\Column\\ColorRating::getTagAttributes\(\) has parameter \$position with no type specified\.$~'
         -
             path: 'src/Table/Column/ColorRating.php'
             message: '~^Method Atk4\\Ui\\Table\\Column\\ColorRating::getColorFromValue\(\) has no return type specified\.$~'
@@ -1856,9 +1850,6 @@ parameters:
         -
             path: 'src/Table/Column/KeyValue.php'
             message: '~^Property Atk4\\Ui\\Table\\Column\\KeyValue::\$values has no type specified\.$~'
-        -
-            path: 'src/Table/Column/Money.php'
-            message: '~^Method Atk4\\Ui\\Table\\Column\\Money::getTagAttributes\(\) has parameter \$position with no type specified\.$~'
         -
             path: 'src/Table/Column/Multiformat.php'
             message: '~^Method Atk4\\Ui\\Table\\Column\\Multiformat::__construct\(\) has parameter \$callback with no type specified\.$~'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -576,9 +576,6 @@ parameters:
             path: 'src/Form/Control/Lookup.php'
             message: '~^Left side of && is always true\.$~'
         -
-            path: 'src/Form/Control/Money.php'
-            message: '~^Ternary operator condition is always true\.$~'
-        -
             path: 'src/Form/Control/Multiline.php'
             message: '~^Negated boolean expression is always false\.$~'
         -

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -660,17 +660,8 @@ parameters:
             path: 'src/UserAction/BasicExecutor.php'
             message: '~^Negated boolean expression is always false\.$~'
         -
-            path: 'src/UserAction/BasicExecutor.php'
-            message: '~^Instanceof between Atk4\\Ui\\JsExpressionable and Closure will always evaluate to false\.$~'
-        -
-            path: 'src/UserAction/ConfirmationExecutor.php'
-            message: '~^Instanceof between Atk4\\Ui\\JsExpressionable and Closure will always evaluate to false\.$~'
-        -
             path: 'src/UserAction/FormExecutor.php'
             message: '~^Negated boolean expression is always false\.$~'
-        -
-            path: 'src/UserAction/JsCallbackExecutor.php'
-            message: '~^Instanceof between Atk4\\Ui\\JsExpressionable and Closure will always evaluate to false\.$~'
         -
             path: 'src/View.php'
             message: '~^Negated boolean expression is always false\.$~'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -474,9 +474,6 @@ parameters:
             path: 'src/Text.php'
             message: '~^Property Atk4\\Ui\\Text::\$defaultTemplate \(string\) does not accept default value of type false\.$~'
         -
-            path: 'src/UserAction/JsCallbackExecutor.php'
-            message: '~^Property Atk4\\Ui\\UserAction\\JsCallbackExecutor::\$jsSuccess \(Atk4\\Ui\\JsExpressionable\) does not accept array\|Closure\.$~'
-        -
             path: 'src/View.php'
             message: '~^Parameter #1 \$object \(Atk4\\Ui\\View\) of method Atk4\\Ui\\View::add\(\) should be contravariant with parameter \$object \(Atk4\\Ui\\AbstractView\) of method Atk4\\Ui\\AbstractView::add\(\)$~'
         -

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1083,12 +1083,6 @@ parameters:
             path: 'src/Columns.php'
             message: '~^Method Atk4\\Ui\\Columns::addRow\(\) has no return type specified\.$~'
         -
-            path: 'src/Component/InlineEdit.php'
-            message: '~^Instanceof between Closure and Closure will always evaluate to true\.$~'
-        -
-            path: 'src/Component/InlineEdit.php'
-            message: '~^Method Atk4\\Ui\\Component\\InlineEdit::onChange\(\) has no return type specified\.$~'
-        -
             path: 'src/Console.php'
             message: '~^Property Atk4\\Ui\\Console::\$last_exit_code has no type specified\.$~'
         -
@@ -1119,18 +1113,6 @@ parameters:
             path: 'src/Crud.php'
             message: '~^Method Atk4\\Ui\\Crud::setItemsAction\(\) has no return type specified\.$~'
         -
-            path: 'src/Crud.php'
-            message: '~^Method Atk4\\Ui\\Crud::onFormEdit\(\) has no return type specified\.$~'
-        -
-            path: 'src/Crud.php'
-            message: '~^Method Atk4\\Ui\\Crud::onFormAdd\(\) has no return type specified\.$~'
-        -
-            path: 'src/Crud.php'
-            message: '~^Method Atk4\\Ui\\Crud::onFormAddEdit\(\) has no return type specified\.$~'
-        -
-            path: 'src/Dropdown.php'
-            message: '~^Method Atk4\\Ui\\Dropdown::onChange\(\) has no return type specified\.$~'
-        -
             path: 'src/Form.php'
             message: '~^Method Atk4\\Ui\\Form::initLayout\(\) has no return type specified\.$~'
         -
@@ -1145,9 +1127,6 @@ parameters:
         -
             path: 'src/Form/Control.php'
             message: '~^Property Atk4\\Ui\\Form\\Control::\$width has no type specified\.$~'
-        -
-            path: 'src/Form/Control.php'
-            message: '~^Method Atk4\\Ui\\Form\\Control::onChange\(\) has no return type specified\.$~'
         -
             path: 'src/Form/Control.php'
             message: '~^Method Atk4\\Ui\\Form\\Control::jsInput\(\) has parameter \$action with no type specified\.$~'
@@ -1169,9 +1148,6 @@ parameters:
         -
             path: 'src/Form/Control/Calendar.php'
             message: '~^Method Atk4\\Ui\\Form\\Control\\Calendar::setOption\(\) has parameter \$value with no type specified\.$~'
-        -
-            path: 'src/Form/Control/Calendar.php'
-            message: '~^Method Atk4\\Ui\\Form\\Control\\Calendar::onChange\(\) has no return type specified\.$~'
         -
             path: 'src/Form/Control/Checkbox.php'
             message: '~^Method Atk4\\Ui\\Form\\Control\\Checkbox::jsChecked\(\) has parameter \$action with no type specified\.$~'
@@ -1263,9 +1239,6 @@ parameters:
             path: 'src/Form/Control/Password.php'
             message: '~^Property Atk4\\Ui\\Form\\Control\\Password::\$inputType has no type specified\.$~'
         -
-            path: 'src/Form/Control/Radio.php'
-            message: '~^Method Atk4\\Ui\\Form\\Control\\Radio::onChange\(\) has no return type specified\.$~'
-        -
             path: 'src/Form/Control/ScopeBuilder.php'
             message: '~^Property Atk4\\Ui\\Form\\Control\\ScopeBuilder::\$atkLookupOptions has no type specified\.$~'
         -
@@ -1316,12 +1289,6 @@ parameters:
         -
             path: 'src/Form/Control/Upload.php'
             message: '~^Method Atk4\\Ui\\Form\\Control\\Upload::addJsAction\(\) has parameter \$action with no type specified\.$~'
-        -
-            path: 'src/Form/Control/Upload.php'
-            message: '~^Method Atk4\\Ui\\Form\\Control\\Upload::onUpload\(\) has no return type specified\.$~'
-        -
-            path: 'src/Form/Control/Upload.php'
-            message: '~^Method Atk4\\Ui\\Form\\Control\\Upload::onDelete\(\) has no return type specified\.$~'
         -
             path: 'src/Form/Control/UploadImage.php'
             message: '~^Method Atk4\\Ui\\Form\\Control\\UploadImage::setThumbnailSrc\(\) has no return type specified\.$~'
@@ -1422,9 +1389,6 @@ parameters:
             path: 'src/ItemsPerPageSelector.php'
             message: '~^Method Atk4\\Ui\\ItemsPerPageSelector::jsSetLabel\(\) has parameter \$ipp with no type specified\.$~'
         -
-            path: 'src/ItemsPerPageSelector.php'
-            message: '~^Method Atk4\\Ui\\ItemsPerPageSelector::onPageLengthSelect\(\) has no return type specified\.$~'
-        -
             path: 'src/JsCallback.php'
             message: '~^Method Atk4\\Ui\\JsCallback::setConfirm\(\) has no return type specified\.$~'
         -
@@ -1494,9 +1458,6 @@ parameters:
             path: 'src/JsNotify.php'
             message: '~^Method Atk4\\Ui\\JsNotify::attachTo\(\) has parameter \$to with no type specified\.$~'
         -
-            path: 'src/JsPaginator.php'
-            message: '~^Method Atk4\\Ui\\JsPaginator::onScroll\(\) has no return type specified\.$~'
-        -
             path: 'src/JsReload.php'
             message: '~^Property Atk4\\Ui\\JsReload::\$includeStorage has no type specified\.$~'
         -
@@ -1526,9 +1487,6 @@ parameters:
         -
             path: 'src/JsSearch.php'
             message: '~^Property Atk4\\Ui\\JsSearch::\$btnStyle has no type specified\.$~'
-        -
-            path: 'src/JsSortable.php'
-            message: '~^Method Atk4\\Ui\\JsSortable::onReorder\(\) has no return type specified\.$~'
         -
             path: 'src/JsSse.php'
             message: '~^Method Atk4\\Ui\\JsSse::send\(\) has no return type specified\.$~'
@@ -1719,9 +1677,6 @@ parameters:
             path: 'src/Panel/Right.php'
             message: '~^Method Atk4\\Ui\\Panel\\Right::addConfirmation\(\) has no return type specified\.$~'
         -
-            path: 'src/Panel/Right.php'
-            message: '~^Method Atk4\\Ui\\Panel\\Right::onOpen\(\) has no return type specified\.$~'
-        -
             path: 'src/Popup.php'
             message: '~^Method Atk4\\Ui\\Popup::__construct\(\) has parameter \$triggerBy with no type specified\.$~'
         -
@@ -1818,12 +1773,6 @@ parameters:
             path: 'src/Table/Column/DragHandler.php'
             message: '~^Property Atk4\\Ui\\Table\\Column\\DragHandler::\$class has no type specified\.$~'
         -
-            path: 'src/Table/Column/DragHandler.php'
-            message: '~^Property Atk4\\Ui\\Table\\Column\\DragHandler::\$tag has no type specified\.$~'
-        -
-            path: 'src/Table/Column/DragHandler.php'
-            message: '~^Method Atk4\\Ui\\Table\\Column\\DragHandler::onReorder\(\) has no return type specified\.$~'
-        -
             path: 'src/Table/Column/FilterModel.php'
             message: '~^Method Atk4\\Ui\\Table\\Column\\FilterModel::afterInit\(\) has no return type specified\.$~'
         -
@@ -1844,9 +1793,6 @@ parameters:
         -
             path: 'src/Table/Column/FilterPopup.php'
             message: '~^Method Atk4\\Ui\\Table\\Column\\FilterPopup::setFilterCondition\(\) has parameter \$tableModel with no type specified\.$~'
-        -
-            path: 'src/Table/Column/JsHeader.php'
-            message: '~^Method Atk4\\Ui\\Table\\Column\\JsHeader::onSelectItem\(\) has no return type specified\.$~'
         -
             path: 'src/Table/Column/KeyValue.php'
             message: '~^Property Atk4\\Ui\\Table\\Column\\KeyValue::\$values has no type specified\.$~'

--- a/src/App.php
+++ b/src/App.php
@@ -880,43 +880,13 @@ class App
      * ]);
      * --> <a href="hello"><b class="red"><i class="blue">welcome</i></b></a>'
      *
-     * @param string|array $tag
      * @param string|array $attr
      * @param string|array $value
      */
-    public function getTag($tag = null, $attr = null, $value = null): string
+    public function getTag(string $tag = null, $attr = null, $value = null): string
     {
         if ($tag === null) {
             $tag = 'div';
-        } elseif (is_array($tag)) {
-            $tmp = $tag;
-
-            if (isset($tmp[0])) {
-                $tag = $tmp[0];
-
-                if (is_array($tag)) {
-                    // OH a bunch of tags
-                    $output = '';
-                    foreach ($tmp as $subtag) {
-                        $output .= $this->getTag($subtag);
-                    }
-
-                    return $output;
-                }
-
-                unset($tmp[0]);
-            } else {
-                $tag = 'div';
-            }
-
-            if (isset($tmp[1])) {
-                $value = $tmp[1];
-                unset($tmp[1]);
-            } else {
-                $value = null;
-            }
-
-            $attr = $tmp;
         }
 
         $tag = strtolower($tag);

--- a/src/Component/InlineEdit.php
+++ b/src/Component/InlineEdit.php
@@ -75,7 +75,7 @@ class InlineEdit extends View
         $this->cb = \Atk4\Ui\JsCallback::addTo($this);
 
         // Set default validation error handler.
-        if (!$this->formatErrorMsg || !($this->formatErrorMsg instanceof \Closure)) {
+        if (!$this->formatErrorMsg) {
             $this->formatErrorMsg = function ($e, $value) {
                 $caption = $this->model->getField($this->fieldName)->getCaption();
 
@@ -117,7 +117,7 @@ class InlineEdit extends View
      * The function will receive one param:
      *  value: the new input value.
      */
-    public function onChange(\Closure $fx)
+    public function onChange(\Closure $fx): void
     {
         if (!$this->autoSave) {
             $value = $this->getApp()->ui_persistence->typecastLoadField($this->model->getField($this->fieldName), $_POST['value'] ?? null);

--- a/src/Component/InlineEdit.php
+++ b/src/Component/InlineEdit.php
@@ -130,11 +130,9 @@ class InlineEdit extends View
     /**
      * On success notifier.
      *
-     * @param string $message
-     *
      * @return \Atk4\Ui\JsToast
      */
-    public function jsSuccess($message)
+    public function jsSuccess(string $message)
     {
         return new JsToast([
             'title' => 'Success',

--- a/src/Crud.php
+++ b/src/Crud.php
@@ -301,7 +301,7 @@ class Crud extends Grid
      * Set callback for edit action in Crud.
      * Callback function will receive the Edit Form and Executor as param.
      */
-    public function onFormEdit(\Closure $fx)
+    public function onFormEdit(\Closure $fx): void
     {
         $this->setOnActions('edit', $fx);
     }
@@ -310,7 +310,7 @@ class Crud extends Grid
      * Set callback for add action in Crud.
      * Callback function will receive the Add Form and Executor as param.
      */
-    public function onFormAdd(\Closure $fx)
+    public function onFormAdd(\Closure $fx): void
     {
         $this->setOnActions('add', $fx);
     }
@@ -319,7 +319,7 @@ class Crud extends Grid
      * Set callback for both edit and add action form.
      * Callback function will receive Forms and Executor as param.
      */
-    public function onFormAddEdit(\Closure $fx)
+    public function onFormAddEdit(\Closure $fx): void
     {
         $this->onFormEdit($fx);
         $this->onFormAdd($fx);

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -37,7 +37,7 @@ class Dropdown extends Lister
      *
      * @param \Closure $fx handler where new selected Item value is passed too
      */
-    public function onChange(\Closure $fx)
+    public function onChange(\Closure $fx): void
     {
         // setting dropdown option for using callback url.
         $this->dropdownOptions['onChange'] = new JsFunction(['value', 'name', 't'], [

--- a/src/Form/Control.php
+++ b/src/Form/Control.php
@@ -146,7 +146,7 @@ class Control extends View
      * @param string|\Atk4\Ui\JsExpression|array|\Closure $expr
      * @param array|bool                                  $default
      */
-    public function onChange($expr, $default = [])
+    public function onChange($expr, $default = []): void
     {
         if (is_string($expr)) {
             $expr = new \Atk4\Ui\JsExpression($expr);

--- a/src/Form/Control/Calendar.php
+++ b/src/Form/Control/Calendar.php
@@ -80,7 +80,7 @@ class Calendar extends Input
      * @param string|JsExpression|array $expr
      * @param array|bool                $default
      */
-    public function onChange($expr, $default = [])
+    public function onChange($expr, $default = []): void
     {
         if (is_string($expr)) {
             $expr = new \Atk4\Ui\JsExpression($expr);

--- a/src/Form/Control/Money.php
+++ b/src/Form/Control/Money.php
@@ -12,8 +12,9 @@ class Money extends Input
     public function getValue()
     {
         $res = parent::getValue();
+        $res = str_replace("\u{00a0}" /* Unicode NBSP */, ' ', $res);
 
-        return $res === null ? null : trim(str_replace($this->getApp()->ui_persistence->currency, '', $res), ' ' . "\u{00a0}" /* Unicode NBSP */);
+        return trim(str_replace($this->getApp()->ui_persistence->currency, '', $res ?? null));
     }
 
     protected function renderView(): void

--- a/src/Form/Control/Money.php
+++ b/src/Form/Control/Money.php
@@ -17,7 +17,7 @@ class Money extends Input
             return;
         }
 
-        return number_format($v, $this->getApp()->ui_persistence->currency_decimals);
+        return number_format($v, $this->getApp()->ui_persistence->currency_decimals, $this->getApp()->ui_persistence->decimal_separator, $this->getApp()->ui_persistence->thousands_separator);
     }
 
     protected function renderView(): void

--- a/src/Form/Control/Money.php
+++ b/src/Form/Control/Money.php
@@ -17,7 +17,7 @@ class Money extends Input
             return;
         }
 
-        return number_format($v, $this->getApp()->ui_persistence->currency_decimals, $this->getApp()->ui_persistence->decimal_separator, $this->getApp()->ui_persistence->thousands_separator);
+        return number_format($v, $this->getApp()->ui_persistence->currency_decimals, $this->getApp()->ui_persistence->currency_decimal_separator, $this->getApp()->ui_persistence->currency_thousands_separator);
     }
 
     protected function renderView(): void

--- a/src/Form/Control/Money.php
+++ b/src/Form/Control/Money.php
@@ -11,10 +11,10 @@ class Money extends Input
 {
     public function getValue()
     {
-        $res = parent::getValue();
+        $res = parent::getValue() ?? null;
         $res = str_replace("\u{00a0}" /* Unicode NBSP */, ' ', $res);
 
-        return trim(str_replace($this->getApp()->ui_persistence->currency, '', $res ?? null));
+        return trim(str_replace($this->getApp()->ui_persistence->currency, '', $res));
     }
 
     protected function renderView(): void

--- a/src/Form/Control/Money.php
+++ b/src/Form/Control/Money.php
@@ -11,13 +11,9 @@ class Money extends Input
 {
     public function getValue()
     {
-        $v = $this->entityField ? $this->entityField->get() : ($this->content ?: null);
+        $res = parent::getValue();
 
-        if ($v === null) {
-            return;
-        }
-
-        return number_format($v, $this->getApp()->ui_persistence->currency_decimals, $this->getApp()->ui_persistence->currency_decimal_separator, $this->getApp()->ui_persistence->currency_thousands_separator);
+        return $res === null ? null : trim(str_replace($this->getApp()->ui_persistence->currency, '', $res), ' ' . "\u{00a0}" /* Unicode NBSP */);
     }
 
     protected function renderView(): void

--- a/src/Form/Control/Multiline.php
+++ b/src/Form/Control/Multiline.php
@@ -59,7 +59,7 @@ use Atk4\Ui\View;
  *         }
  *     }
  *
- *   return $form->js(true, null, 'input[name="grand_total"]')->val(number_format($grand_total, 2));
+ *   return $form->js(true, null, 'input[name="grand_total"]')->val($app->ui_persistence->typecastSaveField(new Field(['type' => 'atk4_money']), $grand_total));
  * }, ['qty', 'price']);
  *
  * Finally, it's also possible to use Multiline for quickly adding records to a

--- a/src/Form/Control/Radio.php
+++ b/src/Form/Control/Radio.php
@@ -73,7 +73,7 @@ class Radio extends Form\Control
      * @param string|\Atk4\Ui\JsExpression|array|\Closure $expr
      * @param array|bool                                  $default
      */
-    public function onChange($expr, $default = [])
+    public function onChange($expr, $default = []): void
     {
         if (is_string($expr)) {
             $expr = new \Atk4\Ui\JsExpression($expr);

--- a/src/Form/Control/TreeItemSelector.php
+++ b/src/Form/Control/TreeItemSelector.php
@@ -84,10 +84,8 @@ class TreeItemSelector extends Form\Control
      * Provide a function to be execute when clicking an item in tree selector.
      * The executing function will receive an array with item state in it
      * when allowMultiple is true or a single value when false.
-     *
-     * @return $this
      */
-    public function onItem(\Closure $fx)
+    public function onItem(\Closure $fx): void
     {
         $this->cb = JsCallback::addTo($this)->set(function ($j, $data) use ($fx) {
             $value = $this->getApp()->decodeJson($data);
@@ -97,8 +95,6 @@ class TreeItemSelector extends Form\Control
 
             return $fx($value);
         }, ['data' => 'value']);
-
-        return $this;
     }
 
     /**

--- a/src/Form/Control/Upload.php
+++ b/src/Form/Control/Upload.php
@@ -144,7 +144,7 @@ class Upload extends Input
     /**
      * Call when user is uploading a file.
      */
-    public function onUpload(\Closure $fx)
+    public function onUpload(\Closure $fx): void
     {
         $this->hasUploadCb = true;
         if (($_POST['f_upload_action'] ?? null) === self::UPLOAD_ACTION) {
@@ -186,7 +186,7 @@ class Upload extends Input
     /**
      * Call when user is removing an already upload file.
      */
-    public function onDelete(\Closure $fx)
+    public function onDelete(\Closure $fx): void
     {
         $this->hasDeleteCb = true;
         if (($_POST['f_upload_action'] ?? null) === self::DELETE_ACTION) {

--- a/src/ItemsPerPageSelector.php
+++ b/src/ItemsPerPageSelector.php
@@ -61,7 +61,7 @@ class ItemsPerPageSelector extends View
      * The callback should return a View to be reload after an item
      * has been select.
      */
-    public function onPageLengthSelect(\Closure $fx)
+    public function onPageLengthSelect(\Closure $fx): void
     {
         $this->cb->set(function () use ($fx) {
             $ipp = isset($_GET['ipp']) ? (int) $_GET['ipp'] : null;

--- a/src/JsPaginator.php
+++ b/src/JsPaginator.php
@@ -81,7 +81,7 @@ class JsPaginator extends JsCallback
     /**
      * Callback when container has been scroll to bottom.
      */
-    public function onScroll(\Closure $fx)
+    public function onScroll(\Closure $fx): void
     {
         $page = $this->getPage();
         $this->set(function () use ($fx, $page) {

--- a/src/JsSortable.php
+++ b/src/JsSortable.php
@@ -60,7 +60,7 @@ class JsSortable extends JsCallback
     /**
      * Callback when container has been reorder.
      */
-    public function onReorder(\Closure $fx)
+    public function onReorder(\Closure $fx): void
     {
         $this->set(function () use ($fx) {
             $sortOrders = explode(',', $_POST['order'] ?? '');

--- a/src/Panel/Right.php
+++ b/src/Panel/Right.php
@@ -150,7 +150,7 @@ class Right extends View implements Loadable
      * Callback to execute when panel open if dynamic content is set.
      * Differ the callback execution to the FlyoutContent.
      */
-    public function onOpen(\Closure $callback)
+    public function onOpen(\Closure $callback): void
     {
         $this->getDynamicContent()->onLoad($callback);
     }

--- a/src/Persistence/Ui.php
+++ b/src/Persistence/Ui.php
@@ -25,15 +25,15 @@ class Ui extends Persistence
     /** @var string */
     public $locale = 'en';
 
-    /** @var string */
+    /** @var string Currency symbol for 'atk4_money' type. */
     public $currency = '€';
-    /** @var int Default decimal count for 'atk4_money' type. */
+    /** @var int Number of decimal digits for 'atk4_money' type. */
     public $currency_decimals = 2;
-    /** @var string Default decimal separator character for 'atk4_money' type. */
-    public $decimal_separator = '.';
-    /** @var string Default thousand digit separator for 'atk4_money' type. */
-    public $thousands_separator = ',';
-    
+    /** @var string Decimal point separator for 'atk4_money' type. */
+    public $currency_decimal_separator = '.';
+    /** @var string Thousands separator for 'atk4_money' type. */
+    public $currency_thousands_separator = "\u{00a0}"; // Unicode NBSP
+
     /** @var string */
     public $timezone;
     /** @var string */
@@ -95,7 +95,8 @@ class Ui extends Persistence
                 break;
             case 'atk4_money':
                 $value = parent::_typecastLoadField($field, $value);
-                $value = ($this->currency ? $this->currency . ' ' : '') . number_format($value, $this->currency_decimals, $this->decimal_separator, $this->thousands_separator);
+                $value = ($this->currency ? $this->currency . "\u{00a0}" /* Unicode NBSP */ : '')
+                    . number_format($value, $this->currency_decimals, $this->currency_decimal_separator, $this->currency_thousands_separator);
 
                 break;
             case 'date':

--- a/src/Persistence/Ui.php
+++ b/src/Persistence/Ui.php
@@ -32,7 +32,7 @@ class Ui extends Persistence
     /** @var string Decimal point separator for 'atk4_money' type. */
     public $currency_decimal_separator = '.';
     /** @var string Thousands separator for 'atk4_money' type. */
-    public $currency_thousands_separator = "\u{00a0}"; // Unicode NBSP
+    public $currency_thousands_separator = ' ';
 
     /** @var string */
     public $timezone;
@@ -95,8 +95,10 @@ class Ui extends Persistence
                 break;
             case 'atk4_money':
                 $value = parent::_typecastLoadField($field, $value);
-                $value = ($this->currency ? $this->currency . "\u{00a0}" /* Unicode NBSP */ : '')
-                    . number_format($value, $this->currency_decimals, $this->currency_decimal_separator, $this->currency_thousands_separator);
+                $valueDecimals = strlen(preg_replace('~^[^.]$|^.+\.|0+$~s', '', number_format($value, 12, '.', '')));
+                $value = ($this->currency ? $this->currency . ' ' : '')
+                    . number_format($value, max($this->currency_decimals, $valueDecimals), $this->currency_decimal_separator, $this->currency_thousands_separator);
+                $value = str_replace(' ', "\u{00a0}" /* Unicode NBSP */, $value);
 
                 break;
             case 'date':
@@ -142,6 +144,27 @@ class Ui extends Persistence
                     } elseif (mb_strtolower($value) === mb_strtolower($this->no)) {
                         $value = '0';
                     }
+                }
+
+                break;
+            case 'atk4_money':
+                if (is_string($value)) {
+                    $value = str_replace([' ', "\u{00a0}" /* Unicode NBSP */, '_', $this->currency, '$', '€'], '', $value);
+                    $dSep = $this->currency_decimal_separator;
+                    $tSeps = array_filter(
+                        array_unique([$dSep, $this->currency_thousands_separator, '.', ',']),
+                        fn ($sep) => strpos($value, $sep) !== false
+                    );
+                    usort($tSeps, fn ($sepA, $sepB) => strrpos($value, $sepB) <=> strrpos($value, $sepA));
+                    foreach ($tSeps as $tSep) {
+                        if ($tSep === $dSep || strlen($value) - strrpos($value, $tSep) !== 4) {
+                            $dSep = $tSep;
+
+                            break;
+                        }
+                    }
+                    $value = str_replace(array_diff($tSeps, [$dSep]), '', $value);
+                    $value = str_replace($dSep, '.', $value);
                 }
 
                 break;

--- a/src/Persistence/Ui.php
+++ b/src/Persistence/Ui.php
@@ -29,7 +29,11 @@ class Ui extends Persistence
     public $currency = '€';
     /** @var int Default decimal count for 'atk4_money' type. */
     public $currency_decimals = 2;
-
+    /** @var string Default decimal separator character for 'atk4_money' type. */
+    public $decimal_separator = '.';
+    /** @var string Default thousand digit separator for 'atk4_money' type. */
+    public $thousands_separator = ',';
+    
     /** @var string */
     public $timezone;
     /** @var string */
@@ -91,7 +95,7 @@ class Ui extends Persistence
                 break;
             case 'atk4_money':
                 $value = parent::_typecastLoadField($field, $value);
-                $value = ($this->currency ? $this->currency . ' ' : '') . number_format($value, $this->currency_decimals);
+                $value = ($this->currency ? $this->currency . ' ' : '') . number_format($value, $this->currency_decimals, $this->decimal_separator, $this->thousands_separator);
 
                 break;
             case 'date':

--- a/src/Table.php
+++ b/src/Table.php
@@ -537,15 +537,13 @@ class Table extends Lister
      * rows, pointer will be used and rows will be highlighted as you hover.
      *
      * @param JsChain|\Closure|JsExpressionable $action Code to execute
-     *
-     * @return Jquery
      */
-    public function onRowClick($action)
+    public function onRowClick($action): void
     {
         $this->addClass('selectable');
         $this->js(true)->find('tbody')->css('cursor', 'pointer');
 
-        return $this->on('click', 'tbody>tr', $action);
+        $this->on('click', 'tbody>tr', $action);
     }
 
     /**

--- a/src/Table/Column.php
+++ b/src/Table/Column.php
@@ -225,7 +225,7 @@ class Column
         return $this;
     }
 
-    public function getTagAttributes($position, array $attr = []): array
+    public function getTagAttributes(string $position, array $attr = []): array
     {
         // "all" applies on all positions
         // $position is for specific position classes
@@ -246,7 +246,7 @@ class Column
      * @param string|array $value    either html or array defining HTML structure, see App::getTag help
      * @param array        $attr     extra attributes to apply on the tag
      */
-    public function getTag($position, $value, $attr = []): string
+    public function getTag(string $position, $value, $attr = []): string
     {
         $attr = $this->getTagAttributes($position, $attr);
 

--- a/src/Table/Column.php
+++ b/src/Table/Column.php
@@ -345,11 +345,8 @@ class Column
      * you should use $this->table->onHook('beforeRow' or 'afterRow', ...);
      *
      * @param Field $field
-     * @param array $extra_tags
-     *
-     * @return string
      */
-    public function getDataCellHtml(Field $field = null, $extra_tags = [])
+    public function getDataCellHtml(Field $field = null, array $extra_tags = []): string
     {
         return $this->getTag('body', [$this->getDataCellTemplate($field)], $extra_tags);
     }

--- a/src/Table/Column/ActionButtons.php
+++ b/src/Table/Column/ActionButtons.php
@@ -98,7 +98,7 @@ class ActionButtons extends Table\Column
         return $this->addButton($button, $modal->show(array_merge([$this->name => $this->getOwner()->jsRow()->data('id')], $args)));
     }
 
-    public function getTag($position, $value, $attr = []): string
+    public function getTag(string $position, $value, $attr = []): string
     {
         if ($this->table->hasCollapsingCssActionColumn && $position === 'body') {
             $attr['class'][] = 'collapsing';

--- a/src/Table/Column/ActionMenu.php
+++ b/src/Table/Column/ActionMenu.php
@@ -46,7 +46,7 @@ class ActionMenu extends Table\Column
         parent::init();
     }
 
-    public function getTag($position, $value, $attr = []): string
+    public function getTag(string $position, $value, $attr = []): string
     {
         if ($this->table->hasCollapsingCssActionColumn && $position === 'body') {
             $attr['class'][] = 'collapsing';

--- a/src/Table/Column/ColorRating.php
+++ b/src/Table/Column/ColorRating.php
@@ -153,7 +153,7 @@ class ColorRating extends Table\Column
         return parent::getTagAttributes($position, $attr);
     }
 
-    public function getDataCellHtml(Field $field = null, $extra_tags = [])
+    public function getDataCellHtml(Field $field = null, array $extra_tags = []): string
     {
         if ($field === null) {
             throw new Exception('ColorRating can be used only with model field');

--- a/src/Table/Column/ColorRating.php
+++ b/src/Table/Column/ColorRating.php
@@ -145,7 +145,7 @@ class ColorRating extends Table\Column
         }
     }
 
-    public function getTagAttributes($position, array $attr = []): array
+    public function getTagAttributes(string $position, array $attr = []): array
     {
         $attr['style'] ??= '';
         $attr['style'] .= '{$_' . $this->shortName . '_color_rating}';

--- a/src/Table/Column/DragHandler.php
+++ b/src/Table/Column/DragHandler.php
@@ -30,7 +30,7 @@ class DragHandler extends Table\Column
     /**
      * Callback when table has been reorder using handle.
      */
-    public function onReorder(\Closure $fx)
+    public function onReorder(\Closure $fx): void
     {
         $this->cb->onReorder($fx);
     }

--- a/src/Table/Column/DragHandler.php
+++ b/src/Table/Column/DragHandler.php
@@ -12,6 +12,7 @@ use Atk4\Ui\Table;
 class DragHandler extends Table\Column
 {
     public $class;
+    /** @var string */
     public $tag = 'i';
     /** @var \Atk4\Ui\JsCallback */
     public $cb;

--- a/src/Table/Column/Html.php
+++ b/src/Table/Column/Html.php
@@ -19,10 +19,8 @@ class Html extends Table\Column
      * Replace parent method.
      *
      * @param Field $field
-     *
-     * @return string
      */
-    public function getDataCellHtml(Field $field = null, $extra_tags = [])
+    public function getDataCellHtml(Field $field = null, array $extra_tags = []): string
     {
         return '{$_' . $field->shortName . '}';
     }

--- a/src/Table/Column/JsHeader.php
+++ b/src/Table/Column/JsHeader.php
@@ -14,7 +14,7 @@ class JsHeader extends JsCallback
     /**
      * Function to call when header menu item is select.
      */
-    public function onSelectItem(\Closure $fx)
+    public function onSelectItem(\Closure $fx): void
     {
         $this->set(function () use ($fx) {
             return $fx($_GET['id'] ?? null, $_GET['item'] ?? null);

--- a/src/Table/Column/Money.php
+++ b/src/Table/Column/Money.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Atk4\Ui\Table\Column;
 
+use Atk4\Data\Field;
 use Atk4\Data\Model;
 use Atk4\Ui\Table;
 
@@ -25,7 +26,7 @@ class Money extends Table\Column
         return parent::getTagAttributes($position, $attr);
     }
 
-    public function getDataCellHtml(\Atk4\Data\Field $field = null, $extra_tags = [])
+    public function getDataCellHtml(Field $field = null, array $extra_tags = []): string
     {
         if (!isset($field)) {
             throw new \Atk4\Ui\Exception('Money column requires a field');

--- a/src/Table/Column/Money.php
+++ b/src/Table/Column/Money.php
@@ -18,7 +18,7 @@ class Money extends Table\Column
     // overrides
     public $attr = ['all' => ['class' => ['right aligned single line']]];
 
-    public function getTagAttributes($position, array $attr = []): array
+    public function getTagAttributes(string $position, array $attr = []): array
     {
         $attr = array_merge_recursive($attr, ['class' => ['{$_' . $this->shortName . '_class}']]);
 

--- a/src/Table/Column/Multiformat.php
+++ b/src/Table/Column/Multiformat.php
@@ -18,7 +18,7 @@ class Multiformat extends Table\Column
     /** @var \Closure Method to execute which will return array of seeds for decorators */
     public $callback;
 
-    public function getDataCellHtml(Field $field = null, $extra_tags = [])
+    public function getDataCellHtml(Field $field = null, array $extra_tags = []): string
     {
         return '{$c_' . $this->shortName . '}';
     }

--- a/src/Table/Column/Status.php
+++ b/src/Table/Column/Status.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Atk4\Ui\Table\Column;
 
+use Atk4\Data\Field;
 use Atk4\Data\Model;
 use Atk4\Ui\Table;
 
@@ -27,7 +28,7 @@ class Status extends Table\Column
         $this->states = $states;
     }
 
-    public function getDataCellHtml(\Atk4\Data\Field $field = null, $extra_tags = [])
+    public function getDataCellHtml(Field $field = null, array $extra_tags = []): string
     {
         if ($field === null) {
             throw new \Atk4\Ui\Exception('Status can be used only with model field');

--- a/src/Table/Column/Tooltip.php
+++ b/src/Table/Column/Tooltip.php
@@ -40,7 +40,7 @@ class Tooltip extends Table\Column
         }
     }
 
-    public function getDataCellHtml(Field $field = null, $extra_tags = [])
+    public function getDataCellHtml(Field $field = null, array $extra_tags = []): string
     {
         if ($field === null) {
             throw new Exception('Tooltip can be used only with model field');

--- a/src/UserAction/BasicExecutor.php
+++ b/src/UserAction/BasicExecutor.php
@@ -43,7 +43,7 @@ class BasicExecutor extends \Atk4\Ui\View implements ExecutorInterface
     /** @var array list of validated arguments */
     protected $validArguments = [];
 
-    /** @var JsExpressionable array|\Closure JsExpression to return if action was successful, e.g "new JsToast('Thank you')" */
+    /** @var JsExpressionable|\Closure JsExpression to return if action was successful, e.g "new JsToast('Thank you')" */
     protected $jsSuccess;
 
     public function getAction(): Model\UserAction

--- a/src/UserAction/ConfirmationExecutor.php
+++ b/src/UserAction/ConfirmationExecutor.php
@@ -34,7 +34,7 @@ class ConfirmationExecutor extends Modal implements JsExecutorInterface
     public $loaderUi = 'ui basic segment';
     /** @var array|View|null Loader shim object or seed. */
     public $loaderShim;
-    /** @var JsExpressionable */
+    /** @var JsExpressionable|\Closure JsExpression to return if action was successful, e.g "new JsToast('Thank you')" */
     public $jsSuccess;
 
     /** @var string css class for modal size. */

--- a/src/UserAction/JsCallbackExecutor.php
+++ b/src/UserAction/JsCallbackExecutor.php
@@ -32,7 +32,7 @@ class JsCallbackExecutor extends JsCallback implements ExecutorInterface
     /** @var Model\UserAction The model user action */
     public $action;
 
-    /** @var JsExpressionable array|\Closure JsExpression to return if action was successful, e.g "new JsToast('Thank you')" */
+    /** @var JsExpressionable|\Closure JsExpression to return if action was successful, e.g "new JsToast('Thank you')" */
     public $jsSuccess;
 
     public function getAction(): Model\UserAction
@@ -86,20 +86,6 @@ class JsCallbackExecutor extends JsCallback implements ExecutorInterface
 
             return $js;
         }, $args);
-
-        return $this;
-    }
-
-    /**
-     * Set jsSuccess property.
-     *
-     * @param array|\Closure $fx
-     *
-     * @return $this
-     */
-    public function setJsSuccess($fx)
-    {
-        $this->jsSuccess = $fx;
 
         return $this;
     }

--- a/src/UserAction/ModalExecutor.php
+++ b/src/UserAction/ModalExecutor.php
@@ -161,7 +161,6 @@ class ModalExecutor extends Modal implements JsExecutorInterface
      */
     protected function jsGetExecute($obj, $id): array
     {
-        // @phpstan-ignore-next-line
         $success = $this->jsSuccess instanceof \Closure
             ? ($this->jsSuccess)($this, $this->action->getModel(), $id, $obj)
             : $this->jsSuccess;

--- a/src/UserAction/PanelExecutor.php
+++ b/src/UserAction/PanelExecutor.php
@@ -147,7 +147,6 @@ class PanelExecutor extends Right implements JsExecutorInterface
      */
     protected function jsGetExecute($obj, $id): array
     {
-        // @phpstan-ignore-next-line
         $success = $this->jsSuccess instanceof \Closure
             ? ($this->jsSuccess)($this, $this->action->getModel(), $id, $obj)
             : $this->jsSuccess;

--- a/src/UserAction/StepExecutorTrait.php
+++ b/src/UserAction/StepExecutorTrait.php
@@ -57,7 +57,7 @@ trait StepExecutorTrait
     /** @var bool */
     protected $actionInitialized = false;
 
-    /** @var JsExpressionable array|\Closure JsExpression to return if action was successful, e.g "new JsToast('Thank you')" */
+    /** @var JsExpressionable|\Closure JsExpression to return if action was successful, e.g "new JsToast('Thank you')" */
     public $jsSuccess;
 
     /** @var array A seed for creating form in order to edit arguments/fields user entry. */

--- a/src/UserAction/VpExecutor.php
+++ b/src/UserAction/VpExecutor.php
@@ -160,7 +160,6 @@ class VpExecutor extends View implements JsExecutorInterface
      */
     protected function jsGetExecute($obj, $id): array
     {
-        // @phpstan-ignore-next-line
         $success = $this->jsSuccess instanceof \Closure
             ? ($this->jsSuccess)($this, $this->action->getModel(), $id, $obj)
             : $this->jsSuccess;

--- a/tests/PersistenceUiTest.php
+++ b/tests/PersistenceUiTest.php
@@ -42,7 +42,10 @@ class PersistenceUiTest extends TestCase
         yield [[], [], '1', '1'];
         yield [[], ['type' => 'string'], '1', '1'];
         yield [[], ['type' => 'integer'], 1, '1'];
-        yield [[], ['type' => 'float'], 1.1001, '1.1001'];
+        yield [[], ['type' => 'integer'], -10000, '-10000'];
+        yield [[], ['type' => 'float'], 1.0, '1'];
+        yield [[], ['type' => 'float'], -10000.0, '-10000'];
+        yield [[], ['type' => 'float'], 1.100123, '1.100123'];
         yield [[], ['type' => 'boolean'], false, 'No'];
         yield [[], ['type' => 'boolean'], true, 'Yes'];
 
@@ -58,5 +61,16 @@ class PersistenceUiTest extends TestCase
             yield [['timezone' => $tz, 'time_format' => 'g:i:s A'], ['type' => 'time'], $evalTime, '10:20:00 AM'];
             yield [['timezone' => $tz, 'datetime_format' => 'j.n.Y g:i:s A'], ['type' => 'datetime'], $evalDatetime, '2.1.2022 10:20:30 AM'];
         }
+
+        $fixSpaceToNbspFx = fn (string $v) => str_replace(' ', "\u{00a0}", $v);
+        yield [[], ['type' => 'atk4_money'], 1.0, $fixSpaceToNbspFx('€ 1.00')];
+        yield [['currency' => ''], ['type' => 'atk4_money'], 1.0, $fixSpaceToNbspFx('1.00')];
+        yield [['currency' => '$'], ['type' => 'atk4_money'], 1.0, $fixSpaceToNbspFx('$ 1.00')];
+        yield [[], ['type' => 'atk4_money'], 1.1023, $fixSpaceToNbspFx('€ 1.1023')];
+        yield [['currency_decimals' => 4], ['type' => 'atk4_money'], 1.102, $fixSpaceToNbspFx('€ 1.1020')];
+        yield [['currency_decimal_separator' => ','], ['type' => 'atk4_money'], 1.0, $fixSpaceToNbspFx('€ 1,00')];
+        yield [[], ['type' => 'atk4_money'], 1000.0, $fixSpaceToNbspFx('€ 1 000.00')];
+        yield [['currency_thousands_separator' => ','], ['type' => 'atk4_money'], 1000.0, $fixSpaceToNbspFx('€ 1,000.00')];
+        yield [['currency_decimal_separator' => ',', 'currency_thousands_separator' => '.'], ['type' => 'atk4_money'], 1000.0, $fixSpaceToNbspFx('€ 1.000,00')];
     }
 }

--- a/tests/TagTest.php
+++ b/tests/TagTest.php
@@ -28,13 +28,13 @@ class TagTest extends TestCase
 
     public function testEscaping(): void
     {
-        $this->assertTagRender('<div foo="he&quot;llo">', [['foo' => 'he"llo']]);
+        $this->assertTagRender('<div foo="he&quot;llo">', [null, ['foo' => 'he"llo']]);
         $this->assertTagRender('<b>bold text &gt;&gt;</b>', ['b', 'bold text >>']);
     }
 
     public function testElementSubstitution(): void
     {
-        $this->assertTagRender('<a foo="hello">', [['a', 'foo' => 'hello']]);
+        $this->assertTagRender('<a foo="hello">', ['a', ['foo' => 'hello']]);
         $this->assertTagRender('<a>link</a>', ['b', ['a'], 'link']);
         $this->assertTagRender('<a/>', ['b/', ['a']]);
         $this->assertTagRender('</b>', ['/b']);


### PR DESCRIPTION
Introduce support for configuring decimal and thousands separators for `atk4_money` type.

by default we use:
- `.` (point) as a decimal point separator as this is more or less international (in EU, `,` is default, but in `US`, it may be interchanged to thousands deparator)
- ` `&nbsp;(NBSP) as a thousands separator as this is readable across the world and also pastable directly to MS Excel:
  ![image](https://user-images.githubusercontent.com/2228672/173182571-c281e7bd-863d-4137-bb70-2c0054124a85.png)
  \* NBSP does not work implicitly in MS Excel, but when copyed from web, NBSP is transformed to regular SP by the most common webbrowsers like Chrome or Firefox
  \* also MS Excels accept spaces strictly only as a thousands separator (at least 3 num digits must follow), leading/trailing space, space after currency symbol, but not anywhere else (like `1 2.3`, `1.888 999`)