### PR TITLE
Add health check to phpunit webserver

### DIFF
--- a/demos/interactive/loader.php
+++ b/demos/interactive/loader.php
@@ -57,6 +57,6 @@ ViewTester::addTo($app);
         'red',
     ],
 ])->set(function ($p) {
-    usleep(500 * 1000);
+    usleep(500_000);
     \Atk4\Ui\LoremIpsum::addTo($p, ['size' => 2]);
 });

--- a/src/Behat/Context.php
+++ b/src/Behat/Context.php
@@ -85,14 +85,14 @@ class Context extends RawMinkContext implements BehatContext
         $c = 0;
         while (microtime(true) - $s <= $maxWaitdurationMs / 1000) {
             $this->getSession()->wait($maxWaitdurationMs, $finishedScript);
-            usleep(10000);
+            usleep(10_000);
             if ($this->getSession()->evaluateScript($finishedScript)) {
                 if (++$c >= 2) {
                     return;
                 }
             } else {
                 $c = 0;
-                usleep(20000);
+                usleep(20_000);
             }
         }
 

--- a/src/Table/Column/FilterModel/TypeDatetime.php
+++ b/src/Table/Column/FilterModel/TypeDatetime.php
@@ -78,7 +78,7 @@ class TypeDatetime extends Column\FilterModel
                     break;
                 case 'within':
                     $d1 = $this->getDatetime($filter['value'])->setTime(0, 0, 0);
-                    $d2 = $this->getDatetime($filter['range'])->setTime(23, 59, 59, 999999);
+                    $d2 = $this->getDatetime($filter['range'])->setTime(23, 59, 59, 999_999);
                     if ($d2 >= $d1) {
                         $value = $model->persistence->typecastSaveField($model->getField($filter['name']), $d1);
                         $value2 = $model->persistence->typecastSaveField($model->getField($filter['name']), $d2);
@@ -92,7 +92,7 @@ class TypeDatetime extends Column\FilterModel
                 case '!=':
                 case '=':
                     $d1 = clone $this->getDatetime($filter['value'])->setTime(0, 0, 0);
-                    $d2 = $this->getDatetime($filter['value'])->setTime(23, 59, 59, 999999);
+                    $d2 = $this->getDatetime($filter['value'])->setTime(23, 59, 59, 999_999);
                     if ($d2 >= $d1) {
                         $value = $model->persistence->typecastSaveField($model->getField($filter['name']), $d1);
                         $value2 = $model->persistence->typecastSaveField($model->getField($filter['name']), $d2);
@@ -106,7 +106,7 @@ class TypeDatetime extends Column\FilterModel
                     break;
                 case '>':
                 case '<=':
-                    $model->addCondition($filter['name'], $filter['op'], $this->getDatetime($filter['value'])->setTime(23, 59, 59, 999999));
+                    $model->addCondition($filter['name'], $filter['op'], $this->getDatetime($filter['value'])->setTime(23, 59, 59, 999_999));
 
                     break;
                 case '<':

--- a/src/View.php
+++ b/src/View.php
@@ -154,7 +154,7 @@ class View extends AbstractView implements JsExpressionable
                 $oldData = $data;
                 $data = [];
                 foreach ($oldData as $k => $row) {
-                    $data[$k + 1000 * 1000 * 1000] = $row; // large offset to prevent accessing wrong data by old key
+                    $data[$k + 1000_000_000] = $row; // large offset to prevent accessing wrong data by old key
                 }
             } else {
                 throw new Exception('Source data contains unsupported zero key');

--- a/tests/DemosHttpTest.php
+++ b/tests/DemosHttpTest.php
@@ -34,7 +34,7 @@ class DemosHttpTest extends DemosTest
     public static function tearDownAfterClass(): void
     {
         // stop the test server
-        usleep(250 * 1000);
+        usleep(250_000);
         self::$_process->stop(1); // TODO we may need to add pcntl_async_signals/pcntl_signal to CoverageUtil.php
         self::$_process = null;
 
@@ -80,7 +80,18 @@ class DemosHttpTest extends DemosTest
         self::$_process = Process::fromShellCommandline('php ' . implode(' ', array_map('escapeshellarg', $cmdArgs)));
         self::$_process->disableOutput();
         self::$_process->start();
-        usleep(250 * 1000);
+
+        // wait until server is ready
+        $ts = microtime(true);
+        while (microtime(true) - $ts < 5) {
+            usleep(20_000);
+            try {
+                $this->getResponseFromRequest('?ping');
+
+                break;
+            } catch (\GuzzleHttp\Exception\ConnectException $e) {
+            }
+        }
     }
 
     protected function getClient(): Client

--- a/tests/DemosHttpTest.php
+++ b/tests/DemosHttpTest.php
@@ -46,6 +46,8 @@ class DemosHttpTest extends DemosTest
         }
         rmdir(self::$_processSessionDir);
         self::$_processSessionDir = null;
+
+        parent::tearDownAfterClass();
     }
 
     protected function setUp(): void
@@ -57,6 +59,8 @@ class DemosHttpTest extends DemosTest
 
             $this->setupWebserver();
         }
+
+        parent::setUp();
     }
 
     private function setupWebserver(): void
@@ -83,13 +87,16 @@ class DemosHttpTest extends DemosTest
 
         // wait until server is ready
         $ts = microtime(true);
-        while (microtime(true) - $ts < 5) {
+        while (true) {
             usleep(20_000);
             try {
                 $this->getResponseFromRequest('?ping');
 
                 break;
             } catch (\GuzzleHttp\Exception\ConnectException $e) {
+                if (microtime(true) - $ts > 5) {
+                    throw $e;
+                }
             }
         }
     }


### PR DESCRIPTION
Should fix random CI failures:

```
1) Atk4\Ui\Tests\DemosHttpNoExitTest::testDemoLateOutputErrorHeadersAlreadySent
GuzzleHttp\Exception\ConnectException: cURL error 7: Failed to connect to localhost port 9687 after 0 ms: Connection refused (see http://curl.haxx.se/libcurl/c/libcurl-errors.html)

/__w/ui/ui/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php:186
/__w/ui/ui/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php:150
/__w/ui/ui/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php:103
/__w/ui/ui/vendor/guzzlehttp/guzzle/src/Handler/CurlHandler.php:43
/__w/ui/ui/vendor/guzzlehttp/guzzle/src/Handler/Proxy.php:28
/__w/ui/ui/vendor/guzzlehttp/guzzle/src/Handler/Proxy.php:51
/__w/ui/ui/vendor/guzzlehttp/guzzle/src/PrepareBodyMiddleware.php:37
/__w/ui/ui/vendor/guzzlehttp/guzzle/src/Middleware.php:30
/__w/ui/ui/vendor/guzzlehttp/guzzle/src/RedirectMiddleware.php:70
/__w/ui/ui/vendor/guzzlehttp/guzzle/src/Middleware.php:59
/__w/ui/ui/vendor/guzzlehttp/guzzle/src/HandlerStack.php:67
/__w/ui/ui/vendor/guzzlehttp/guzzle/src/Client.php:277
/__w/ui/ui/vendor/guzzlehttp/guzzle/src/Client.php:125
/__w/ui/ui/vendor/guzzlehttp/guzzle/src/Client.php:131
/__w/ui/ui/tests/DemosTest.php:217
/__w/ui/ui/tests/DemosTest.php:240
/__w/ui/ui/tests/DemosHttpTest.php:107
phpvfscomposer:///__w/ui/ui/vendor/phpunit/phpunit/phpunit:60
```