### PR TITLE
Remove View::id prop in favor of NameTrait::name

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ $app = new \Atk4\Ui\App();
 $app->initLayout([\Atk4\Ui\Layout\Centered::class]);
 
 $form = \Atk4\Ui\Form::addTo($app);
-
 $form->addField('email');
 $form->onSubmit(function (Form $form) {
     // implement subscribe here
@@ -93,7 +92,8 @@ $app = new \Atk4\Ui\App('hello world');
 $app->initLayout([\Atk4\Ui\Layout\Admin::class]);
 $app->db = \Atk4\Data\Persistence::connect('mysql://user:pass@localhost/atk');
 
-\Atk4\Ui\Crud::addTo($app)->setModel(new User($app->db));
+\Atk4\Ui\Crud::addTo($app)
+    ->setModel(new User($app->db));
 ```
 
 ATK Data allows you to set up relations between models:
@@ -104,7 +104,7 @@ class User extends Model {
         parent::init();
 
         $this->addField('name');
-        $this->addField('gender', ['enum' => 'female','male','other']);
+        $this->addField('gender', ['enum' => 'female', 'male', 'other']);
         $this->hasMany('Purchases', ['model' => [Purchase::class]]);
     }
 }
@@ -117,10 +117,10 @@ use \Atk4\Mastercrud\MasterCrud;
 
 // set up $app here
 
-$master_crud = MasterCrud::addTo($app);
-$master_crud->setModel(new User($app->db), [
-    'Purchases' => []
-]);
+$master_crud = MasterCrud::addTo($app)
+    ->setModel(new User($app->db), [
+        'Purchases' => [],
+    ]);
 
 ```
 
@@ -136,7 +136,7 @@ As of version 2.0 - Agile Toolkit offers support for User Actions. Those are eas
 
 ``` php
 $this->addAction('archive', function (Model $m) {
-    $m->get('is_archived') = true;
+    $m->set('is_archived', true);
     $this->saveAndUnload();
 });
 ```
@@ -159,7 +159,8 @@ $tabs = \Atk4\Ui\Tabs::addTo($app);
 $tabs->addTab('Users', function (\Atk4\Ui\VirtualPage $p) use ($app) {
     // this tab is loaded dynamically, but also contains dynamic component
 
-    \Atk4\Ui\Crud::addTo($p)->setModel(new User($app->db));
+    \Atk4\Ui\Crud::addTo($p)
+        ->setModel(new User($app->db));
 });
 
 $tabs->addTab('Settings', function (\Atk4\Ui\VirtualPage $p) use ($app) {
@@ -167,7 +168,8 @@ $tabs->addTab('Settings', function (\Atk4\Ui\VirtualPage $p) use ($app) {
 
     $m = new Settings($app->db);
     $m = $m->load(2);
-    \Atk4\Ui\Form::addTo($p)->setModel($m);
+    \Atk4\Ui\Form::addTo($p)
+        ->setModel($m);
 });
 ```
 
@@ -210,7 +212,8 @@ class User extends \Atk4\Data\Model {
     }
 }
 
-\Atk4\Ui\Crud::addTo($app)->setModel(new User($app->db));
+\Atk4\Ui\Crud::addTo($app)
+    ->setModel(new User($app->db));
 ```
 
 The result is here:
@@ -221,7 +224,7 @@ The result is here:
 
 Agile UI comes with many built-in components:
 
-_All components can be view using the [demos](ui.agiletoolkit.org/demos) application._
+_All components can be view using the [demos](https://ui.agiletoolkit.org/demos/) application._
 
 | Component                                                    | Description                                                  | Introduced |
 | ------------------------------------------------------------ | ------------------------------------------------------------ | ---------- |

--- a/demos/_unit-test/scope-builder.php
+++ b/demos/_unit-test/scope-builder.php
@@ -40,7 +40,7 @@ $form->addControl('qb', [\Atk4\Ui\Form\Control\ScopeBuilder::class, 'model' => $
 
 $form->onSubmit(function (Form $form) use ($model) {
     $message = $form->model->get('qb')->toWords($model);
-    $view = (new \Atk4\Ui\View(['id' => false]))->addClass('atk-scope-builder-response');
+    $view = (new \Atk4\Ui\View(['name' => false]))->addClass('atk-scope-builder-response');
     $view->invokeInit();
 
     $view->set($message);

--- a/demos/basic/columns.php
+++ b/demos/basic/columns.php
@@ -23,7 +23,7 @@ $app->addStyle('
 }
 ');
 
-$page = \Atk4\Ui\View::addTo($app, ['id' => 'example']);
+$page = \Atk4\Ui\View::addTo($app, ['name' => 'example']);
 
 \Atk4\Ui\Header::addTo($page, ['Basic Usage']);
 

--- a/demos/collection/card-deck.php
+++ b/demos/collection/card-deck.php
@@ -6,6 +6,7 @@ namespace Atk4\Ui\Demos;
 
 use Atk4\Ui\Button;
 use Atk4\Ui\Header;
+use Atk4\Ui\UserAction\ExecutorFactory;
 
 /** @var \Atk4\Ui\App $app */
 require_once __DIR__ . '/../init-app.php';
@@ -24,7 +25,7 @@ $action = $countries->addUserAction('book', [
 ]);
 
 // Create custom button for this action in card.
-$app->getExecutorFactory()->registerTrigger($app->getExecutorFactory()::CARD_BUTTON, [Button::class, null, 'blue', 'icon' => 'plane'], $action);
+$app->getExecutorFactory()->registerTrigger(ExecutorFactory::CARD_BUTTON, [Button::class, null, 'blue', 'icon' => 'plane'], $action);
 
 $action->args = [
     'email' => ['type' => 'string', 'required' => true, 'caption' => 'Please let us know your email address:'],

--- a/demos/data-action/jsactionsgrid.php
+++ b/demos/data-action/jsactionsgrid.php
@@ -7,6 +7,7 @@ namespace Atk4\Ui\Demos;
 use Atk4\Core\Factory;
 use Atk4\Data\Model\UserAction;
 use Atk4\Ui\Icon;
+use Atk4\Ui\UserAction\ExecutorFactory;
 use Atk4\Ui\View;
 
 /** @var \Atk4\Ui\App $app */
@@ -23,7 +24,7 @@ $multiAction = $country->getUserAction('multi_step');
 $specialItem = Factory::factory([View::class], ['id' => false, 'class' => ['item'], 'content' => 'Multi Step']);
 Icon::addTo($specialItem, ['content' => 'window maximize outline']);
 // register this menu item in factory.
-$app->getExecutorFactory()->registerTrigger($app->getExecutorFactory()::TABLE_MENU_ITEM, $specialItem, $multiAction);
+$app->getExecutorFactory()->registerTrigger(ExecutorFactory::TABLE_MENU_ITEM, $specialItem, $multiAction);
 
 \Atk4\Ui\Header::addTo($app, ['Execute model action from Grid menu items', 'subHeader' => 'Setting grid menu items in order to execute model actions or javascript.']);
 

--- a/demos/data-action/jsactionsgrid.php
+++ b/demos/data-action/jsactionsgrid.php
@@ -21,7 +21,7 @@ DemoActionsUtil::setupDemoActions($country);
 
 // creating special menu item for multi_step action.
 $multiAction = $country->getUserAction('multi_step');
-$specialItem = Factory::factory([View::class], ['id' => false, 'class' => ['item'], 'content' => 'Multi Step']);
+$specialItem = Factory::factory([View::class], ['name' => false, 'class' => ['item'], 'content' => 'Multi Step']);
 Icon::addTo($specialItem, ['content' => 'window maximize outline']);
 // register this menu item in factory.
 $app->getExecutorFactory()->registerTrigger(ExecutorFactory::TABLE_MENU_ITEM, $specialItem, $multiAction);
@@ -31,12 +31,12 @@ $app->getExecutorFactory()->registerTrigger(ExecutorFactory::TABLE_MENU_ITEM, $s
 $grid = \Atk4\Ui\Grid::addTo($app, ['menu' => false]);
 $grid->setModel($country);
 
-$divider = Factory::factory([View::class], ['id' => false, 'class' => ['divider'], 'content' => '']);
+$divider = Factory::factory([View::class], ['name' => false, 'class' => ['divider'], 'content' => '']);
 
-$modelHeader = Factory::factory([View::class], ['id' => false, 'class' => ['header'], 'content' => 'Model Actions']);
+$modelHeader = Factory::factory([View::class], ['name' => false, 'class' => ['header'], 'content' => 'Model Actions']);
 Icon::addTo($modelHeader, ['content' => 'database']);
 
-$jsHeader = Factory::factory([View::class], ['id' => false, 'class' => ['header'], 'content' => 'Js Actions']);
+$jsHeader = Factory::factory([View::class], ['name' => false, 'class' => ['header'], 'content' => 'Js Actions']);
 Icon::addTo($jsHeader, ['content' => 'file code']);
 
 $grid->addActionMenuItem($jsHeader);

--- a/demos/javascript/js.php
+++ b/demos/javascript/js.php
@@ -19,7 +19,7 @@ $b = Button::addTo($app, ['Hidden Button']);
 $b->js(true)->hide();
 
 // This button hides when clicked
-$b = Button::addTo($app, ['id' => 'b2'])->set('Hide on click Button');
+$b = Button::addTo($app, ['name' => 'b2'])->set('Hide on click Button');
 $b->js('click')->hide();
 
 Button::addTo($app, ['Redirect'])->on('click', null, $app->jsRedirect(['foo' => 'bar']));

--- a/docs/render.rst
+++ b/docs/render.rst
@@ -91,7 +91,7 @@ will create its own tree independent from the main one.
 Agile UI sometimes uses the following approach to render element on the outside:
 
 1. Create new instance of $sub_view.
-2. Set $sub_view->id = false;
+2. Set $sub_view->name = false;
 3. Calls $view->add($sub_view);
 4. executes $sub_view->renderHtml()
 

--- a/docs/view.rst
+++ b/docs/view.rst
@@ -203,12 +203,12 @@ If you happen to pass more key/values to the constructor or as second argument
 to add() they will be treated as default values for the properties of that
 specific view::
 
-    $view = View::addTo($app, ['ui' => 'segment', 'id' => 'test-id']);
+    $view = View::addTo($app, ['ui' => 'segment', 'name' => 'test-id']);
 
 For a more IDE-friendly format, however, I recommend to use the following syntax::
 
     $view = View::addTo($app, ['ui' => 'segment']);
-    $view->id = 'test-id';
+    $view->name = 'test-id';
 
 You must be aware of a difference here - passing array to constructor will
 override default property before call to `init()`. Most of the components
@@ -222,7 +222,7 @@ If you are don't specify key for the properties, they will be considered an
 extra class for a view::
 
     $view = View::addTo($app, ['inverted', 'orange', 'ui' => 'segment']);
-    $view->id = 'test-id';
+    $view->name = 'test-id';
 
 You can either specify multiple classes one-by-one or as a single string
 "inverted orange".
@@ -407,9 +407,9 @@ Unique ID tag
 
     ID to be used with the top-most element.
 
-Agile UI will maintain unique ID for all the elements. The tag is set through 'id' property::
+Agile UI will maintain unique ID for all the elements. The tag is set through 'name' property::
 
-    $b = new \Atk4\Ui\Button(['id' => 'my-button3']);
+    $b = new \Atk4\Ui\Button(['name' => 'my-button3']);
     echo $b->render();
 
 Outputs:

--- a/src/Card.php
+++ b/src/Card.php
@@ -26,6 +26,7 @@ namespace Atk4\Ui;
 
 use Atk4\Core\Factory;
 use Atk4\Data\Model;
+use Atk4\Ui\UserAction\ExecutorFactory;
 
 class Card extends View
 {
@@ -285,7 +286,7 @@ class Card extends View
     {
         $defaults = [];
 
-        $btn = $this->addButton($button ?? $this->getExecutorFactory()->createTrigger($action, $this->getExecutorFactory()::CARD_BUTTON));
+        $btn = $this->addButton($button ?? $this->getExecutorFactory()->createTrigger($action, ExecutorFactory::CARD_BUTTON));
 
         // Setting arg for model id. $args[0] is consider to hold a model id, i.e. as a js expression.
         if ($this->model && $this->model->isLoaded() && !isset($args[0])) {

--- a/src/CardDeck.php
+++ b/src/CardDeck.php
@@ -10,6 +10,7 @@ namespace Atk4\Ui;
 use Atk4\Core\Factory;
 use Atk4\Data\Model;
 use Atk4\Ui\Component\ItemSearch;
+use Atk4\Ui\UserAction\ExecutorFactory;
 use Atk4\Ui\UserAction\ExecutorInterface;
 
 class CardDeck extends View
@@ -327,7 +328,7 @@ class CardDeck extends View
             $defaults['args'] = $args;
         }
 
-        $btn = $this->btns->add($this->getExecutorFactory()->createTrigger($executor->getAction(), $this->getExecutorFactory()::CARD_BUTTON));
+        $btn = $this->btns->add($this->getExecutorFactory()->createTrigger($executor->getAction(), ExecutorFactory::CARD_BUTTON));
         if ($executor->getAction()->enabled === false) {
             $btn->addClass('disabled');
         }

--- a/src/Crud.php
+++ b/src/Crud.php
@@ -6,6 +6,7 @@ namespace Atk4\Ui;
 
 use Atk4\Core\Factory;
 use Atk4\Data\Model;
+use Atk4\Ui\UserAction\ExecutorFactory;
 
 /**
  * Implements a more sophisticated and interactive Data-Table component.
@@ -118,7 +119,7 @@ class Crud extends Grid
                 if ($action->enabled) {
                     $executor = $this->initActionExecutor($action);
                     $this->menuItems[$k]['item'] = $this->menu->addItem(
-                        $this->getExecutorFactory()->createTrigger($action, $this->getExecutorFactory()::MENU_ITEM)
+                        $this->getExecutorFactory()->createTrigger($action, ExecutorFactory::MENU_ITEM)
                     );
                     $this->menuItems[$k]['executor'] = $executor;
                 }

--- a/src/Form/Control.php
+++ b/src/Form/Control.php
@@ -157,7 +157,7 @@ class Control extends View
             $default['stopPropagation'] = $default;
         }
 
-        $this->on('change', '#' . $this->id . '_input', $expr, $default);
+        $this->on('change', '#' . $this->name . '_input', $expr, $default);
     }
 
     /**
@@ -170,7 +170,7 @@ class Control extends View
      */
     public function jsInput($when = null, $action = null)
     {
-        return $this->js($when, $action, '#' . $this->id . '_input');
+        return $this->js($when, $action, '#' . $this->name . '_input');
     }
 
     /**

--- a/src/Form/Control/Calendar.php
+++ b/src/Form/Control/Calendar.php
@@ -105,7 +105,7 @@ class Calendar extends Input
      */
     public function getJsInstance(): JsExpression
     {
-        return (new Jquery('#' . $this->id . '_input'))->get(0)->_flatpickr;
+        return (new Jquery('#' . $this->name . '_input'))->get(0)->_flatpickr;
     }
 
     private function expandPhpDtFormat(string $phpFormat): string

--- a/src/Form/Control/Dropdown.php
+++ b/src/Form/Control/Dropdown.php
@@ -134,7 +134,7 @@ class Dropdown extends Input
         return $this->getApp()->getTag('input', array_merge([
             'name' => $this->short_name,
             'type' => $this->inputType,
-            'id' => $this->id . '_input',
+            'id' => $this->name . '_input',
             'value' => $this->getValue(),
             'readonly' => $this->readonly ? 'readonly' : false,
             'disabled' => $this->disabled ? 'disabled' : false,

--- a/src/Form/Control/Input.php
+++ b/src/Form/Control/Input.php
@@ -9,6 +9,7 @@ use Atk4\Ui\Button;
 use Atk4\Ui\Form;
 use Atk4\Ui\Icon;
 use Atk4\Ui\Label;
+use Atk4\Ui\UserAction\ExecutorFactory;
 use Atk4\Ui\UserAction\JsCallbackExecutor;
 
 /**
@@ -155,7 +156,7 @@ class Input extends Form\Control
         }
         if ($button instanceof UserAction || $button instanceof JsCallbackExecutor) {
             $executor = ($button instanceof UserAction)
-                ? $this->getExecutorFactory()->create($button, $this, $this->getExecutorFactory()::JS_EXECUTOR)
+                ? $this->getExecutorFactory()->create($button, $this, ExecutorFactory::JS_EXECUTOR)
                 : $button;
             $button = $this->add($this->getExecutorFactory()->createTrigger($executor->getAction()), $spot);
             $this->addClass('action');

--- a/src/Form/Control/Input.php
+++ b/src/Form/Control/Input.php
@@ -110,7 +110,7 @@ class Input extends Form\Control
             'name' => $this->short_name,
             'type' => $this->inputType,
             'placeholder' => $this->placeholder,
-            'id' => $this->id . '_input',
+            'id' => $this->name . '_input',
             'value' => $this->getValue(),
             'readonly' => $this->readonly ? 'readonly' : false,
             'disabled' => $this->disabled ? 'disabled' : false,

--- a/src/Form/Control/Lookup.php
+++ b/src/Form/Control/Lookup.php
@@ -344,7 +344,7 @@ class Lookup extends Input
         return $this->getApp()->getTag('input', array_merge([
             'name' => $this->short_name,
             'type' => 'hidden',
-            'id' => $this->id . '_input',
+            'id' => $this->name . '_input',
             'value' => $this->getValue(),
             'readonly' => $this->readonly ? 'readonly' : false,
             'disabled' => $this->disabled ? 'disabled' : false,

--- a/src/Form/Control/Textarea.php
+++ b/src/Form/Control/Textarea.php
@@ -26,7 +26,7 @@ class Textarea extends Input
                 'type' => $this->inputType,
                 'rows' => $this->rows,
                 'placeholder' => $this->placeholder,
-                'id' => $this->id . '_input',
+                'id' => $this->name . '_input',
                 'readonly' => $this->readonly ? 'readonly' : false,
                 'disabled' => $this->disabled ? 'disabled' : false,
             ], $this->inputAttr),

--- a/src/Form/Control/TreeItemSelector.php
+++ b/src/Form/Control/TreeItemSelector.php
@@ -46,9 +46,16 @@ class TreeItemSelector extends Form\Control
      *
      * Each item may have it's own children by adding nodes children to it.
      *   $items = [
-     *       ['name' => 'Electronics', 'id' => 'P100', 'nodes' => [['name' => 'Phone', 'id' => 'P100', 'nodes' => [['name' => 'iPhone', 'id' => 502], ['name' => 'Google Pixels', 'id' => 503]]], ['name' => 'Tv' , 'id' => 501], ['name' => 'Radio' , 'id' => 601]]],
+     *       ['name' => 'Electronics', 'id' => 'P100', 'nodes' => [
+     *           ['name' => 'Phone', 'id' => 'P100', 'nodes' => [
+     *               ['name' => 'iPhone', 'id' => 502],
+     *               ['name' => 'Google Pixels', 'id' => 503],
+     *           ]],
+     *           ['name' => 'Tv' , 'id' => 501],
+     *           ['name' => 'Radio' , 'id' => 601],
+     *       ]],
      *       ['name' => 'Cleaner' , 'id' => 201],
-     *       ['name' => 'Appliances' , 'id' => 301]
+     *       ['name' => 'Appliances' , 'id' => 301],
      *   ];
      *
      * When adding nodes array into an item, it will automatically be treated as a group unless empty.

--- a/src/Form/Layout.php
+++ b/src/Form/Layout.php
@@ -198,7 +198,7 @@ class Layout extends AbstractLayout
             // Controls get extra pampering
             $template->dangerouslySetHtml('Input', $element->getHtml());
             $template->trySet('label', $label);
-            $template->trySet('label_for', $element->id . '_input');
+            $template->trySet('label_for', $element->name . '_input');
             $template->set('control_class', $element->getControlClass());
 
             if ($element->entityField->getField()->required) {
@@ -211,7 +211,7 @@ class Layout extends AbstractLayout
 
             if ($element->hint && $template->hasTag('Hint')) {
                 $hint = Factory::factory($this->defaultHint);
-                $hint->id = $element->id . '_hint';
+                $hint->name = $element->name . '_hint';
                 if (is_object($element->hint) || is_array($element->hint)) {
                     $hint->add($element->hint);
                 } else {

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -9,6 +9,7 @@ use Atk4\Core\HookTrait;
 use Atk4\Data\Model;
 use Atk4\Ui\Table\Column\ActionButtons;
 use Atk4\Ui\UserAction\ConfirmationExecutor;
+use Atk4\Ui\UserAction\ExecutorFactory;
 use Atk4\Ui\UserAction\ExecutorInterface;
 
 /**
@@ -373,7 +374,7 @@ class Grid extends View
      */
     public function addExecutorButton(UserAction\ExecutorInterface $executor, Button $button = null)
     {
-        $btn = $button ? $this->add($button) : $this->getExecutorFactory()->createTrigger($executor->getAction(), $this->getExecutorFactory()::TABLE_BUTTON);
+        $btn = $button ? $this->add($button) : $this->getExecutorFactory()->createTrigger($executor->getAction(), ExecutorFactory::TABLE_BUTTON);
         $confirmation = $executor->getAction()->getConfirmation() ?: '';
         $disabled = is_bool($executor->getAction()->enabled) ? !$executor->getAction()->enabled : $executor->getAction()->enabled;
 
@@ -404,7 +405,7 @@ class Grid extends View
 
     public function addExecutorMenuItem(ExecutorInterface $executor)
     {
-        $item = $this->getExecutorFactory()->createTrigger($executor->getAction(), $this->getExecutorFactory()::TABLE_MENU_ITEM);
+        $item = $this->getExecutorFactory()->createTrigger($executor->getAction(), ExecutorFactory::TABLE_MENU_ITEM);
         // ConfirmationExecutor take care of showing the user confirmation, thus make it empty.
         $confirmation = !$executor instanceof ConfirmationExecutor ? ($executor->getAction()->getConfirmation() ?: '') : '';
         $disabled = is_bool($executor->getAction()->enabled) ? !$executor->getAction()->enabled : $executor->getAction()->enabled;

--- a/src/JsCallback.php
+++ b/src/JsCallback.php
@@ -186,7 +186,7 @@ class JsCallback extends Callback implements JsExpressionable
         if ($response instanceof Modal) {
             $html = $response->getHtml();
         } else {
-            $modal = new Modal(['id' => false]);
+            $modal = new Modal(['name' => false]);
             $modal->add($response);
             $html = $modal->getHtml();
         }

--- a/src/Table/Column/ActionButtons.php
+++ b/src/Table/Column/ActionButtons.php
@@ -48,7 +48,7 @@ class ActionButtons extends Table\Column
                 $button = [1 => $button];
             }
 
-            $button = Factory::factory([Button::class], Factory::mergeSeeds($button, ['id' => false]));
+            $button = Factory::factory([Button::class], Factory::mergeSeeds($button, ['name' => false]));
         }
 
         if ($isDisabled === true) {

--- a/src/Table/Column/ActionMenu.php
+++ b/src/Table/Column/ActionMenu.php
@@ -68,7 +68,7 @@ class ActionMenu extends Table\Column
         $name = $this->name . '_action_' . (count($this->items) + 1);
 
         if (!is_object($item)) {
-            $item = Factory::factory([\Atk4\Ui\View::class], ['id' => false, 'ui' => 'item', 'content' => $item]);
+            $item = Factory::factory([\Atk4\Ui\View::class], ['name' => false, 'ui' => 'item', 'content' => $item]);
         }
 
         $this->items[] = $item;

--- a/src/UserAction/BasicExecutor.php
+++ b/src/UserAction/BasicExecutor.php
@@ -58,7 +58,7 @@ class BasicExecutor extends \Atk4\Ui\View implements ExecutorInterface
     {
         $this->action = $action;
         if (!$this->executorButton) {
-            $this->executorButton = $this->getExecutorFactory()->createTrigger($action, $this->getExecutorFactory()::BASIC_BUTTON);
+            $this->executorButton = $this->getExecutorFactory()->createTrigger($action, ExecutorFactory::BASIC_BUTTON);
         }
     }
 

--- a/src/UserAction/ExecutorFactory.php
+++ b/src/UserAction/ExecutorFactory.php
@@ -217,7 +217,7 @@ class ExecutorFactory
 
                 break;
             case self::TABLE_MENU_ITEM:
-                $seed = [Item::class, $this->getActionCaption($action, $type), 'id' => false, ['class' => 'item']];
+                $seed = [Item::class, $this->getActionCaption($action, $type), 'name' => false, ['class' => 'item']];
 
                 break;
             default:

--- a/src/UserAction/StepExecutorTrait.php
+++ b/src/UserAction/StepExecutorTrait.php
@@ -351,7 +351,7 @@ trait StepExecutorTrait
         $this->btns = (new View())->addStyle(['min-height' => '24px']);
         $this->prevStepBtn = Button::addTo($this->btns, ['Prev'])->addStyle(['float' => 'left !important']);
         $this->nextStepBtn = Button::addTo($this->btns, ['Next', 'blue']);
-        $this->execActionBtn = $this->getExecutorFactory()->createTrigger($action, $this->getExecutorFactory()::MODAL_BUTTON);
+        $this->execActionBtn = $this->getExecutorFactory()->createTrigger($action, ExecutorFactory::MODAL_BUTTON);
         $this->btns->add($this->execActionBtn);
 
         return $this->btns;

--- a/src/View.php
+++ b/src/View.php
@@ -45,9 +45,6 @@ class View extends AbstractView implements JsExpressionable
      */
     public $ui = false;
 
-    /** @var string ID of the element, that's unique and is used in JS operations. */
-    public $id;
-
     /** @var array List of classes that needs to be added. */
     public $class = [];
 
@@ -236,10 +233,6 @@ class View extends AbstractView implements JsExpressionable
         $addLater = $this->_add_later;
         $this->_add_later = [];
         parent::init();
-
-        if ($this->id === null) {
-            $this->id = $this->name;
-        }
 
         if ($this->region && !$this->template && !$this->defaultTemplate && $this->issetOwner() && $this->getOwner()->template) {
             $this->template = $this->getOwner()->template->cloneRegion($this->region);
@@ -641,8 +634,8 @@ class View extends AbstractView implements JsExpressionable
             $this->template->tryDel('_ui');
         }
 
-        if ($this->id) {
-            $this->template->trySet('_id', $this->id);
+        if ($this->name) {
+            $this->template->trySet('_id', $this->name);
         }
 
         if ($this->element) {
@@ -1139,7 +1132,7 @@ class View extends AbstractView implements JsExpressionable
     {
         $this->assertIsInitialized();
 
-        return json_encode('#' . $this->id, \JSON_UNESCAPED_UNICODE | \JSON_THROW_ON_ERROR);
+        return json_encode('#' . $this->name, \JSON_UNESCAPED_UNICODE | \JSON_THROW_ON_ERROR);
     }
 
     /**

--- a/tests/JsIntegrationTest.php
+++ b/tests/JsIntegrationTest.php
@@ -14,9 +14,9 @@ class JsIntegrationTest extends TestCase
     {
         $v = new Button(['icon' => 'pencil']);
         $html = $v->render();
-        $this->assertNotNull($v->icon->id);
+        $this->assertNotNull($v->icon->name);
 
-        $this->assertNotSame($v->id, $v->icon->id);
+        $this->assertNotSame($v->name, $v->icon->name);
     }
 
     public function testIdIntegrity2(): void
@@ -26,7 +26,7 @@ class JsIntegrationTest extends TestCase
         $b2 = Button::addTo($v);
         $html = $v->render();
 
-        $this->assertNotSame($b1->id, $b2->id);
+        $this->assertNotSame($b1->name, $b2->name);
     }
 
     /**
@@ -34,7 +34,7 @@ class JsIntegrationTest extends TestCase
      */
     public function testBasicChain1(): void
     {
-        $v = new Button(['id' => 'b']);
+        $v = new Button(['name' => 'b']);
         $j = $v->js()->hide();
         $v->render();
 
@@ -46,7 +46,7 @@ class JsIntegrationTest extends TestCase
      */
     public function testBasicChain2(): void
     {
-        $v = new Button(['id' => 'b']);
+        $v = new Button(['name' => 'b']);
         $j = $v->js(true)->hide();
         $v->getHtml();
 
@@ -60,7 +60,7 @@ class JsIntegrationTest extends TestCase
      */
     public function testBasicChain3(): void
     {
-        $v = new Button(['id' => 'b']);
+        $v = new Button(['name' => 'b']);
         $v->js('click')->hide();
         $v->getHtml();
 
@@ -77,8 +77,8 @@ class JsIntegrationTest extends TestCase
     public function testBasicChain4(): void
     {
         $bb = new View(['ui' => 'buttons']);
-        $b1 = Button::addTo($bb, ['id' => 'b1']);
-        $b2 = Button::addTo($bb, ['id' => 'b2']);
+        $b1 = Button::addTo($bb, ['name' => 'b1']);
+        $b2 = Button::addTo($bb, ['name' => 'b2']);
 
         $b1->on('click', $b2->js()->hide());
         $bb->getHtml();

--- a/tests/TableColumnColorRatingTest.php
+++ b/tests/TableColumnColorRatingTest.php
@@ -22,10 +22,7 @@ class TableColumnColorRatingTest extends TestCase
         $arr = [
             'table' => [
                 1 => [
-                    'id' => 1,
-                    'name' => 'bar',
-                    'ref' => 'ref123',
-                    'rating' => 3,
+                    'id' => 1, 'name' => 'bar', 'ref' => 'ref123', 'rating' => 3,
                 ],
             ],
         ];

--- a/tests/TableColumnLinkTest.php
+++ b/tests/TableColumnLinkTest.php
@@ -18,7 +18,11 @@ class TableColumnLinkTest extends TestCase
 
     protected function setUp(): void
     {
-        $arr = ['table' => [1 => ['id' => 1, 'name' => 'bar', 'ref' => 'ref123', 'salary' => -123]]];
+        $arr = [
+            'table' => [
+                1 => ['id' => 1, 'name' => 'bar', 'ref' => 'ref123', 'salary' => -123],
+            ],
+        ];
         $db = new Persistence\Array_($arr);
         $m = new \Atk4\Data\Model($db, ['table' => 'table']);
         $m->addField('name');
@@ -259,7 +263,11 @@ class TableColumnLinkTest extends TestCase
     public function testLink10(): void
     {
         // need to reset all to set a nulled value in field name model
-        $arr = ['table' => [1 => ['id' => 1, 'name' => '', 'ref' => 'ref123', 'salary' => -123]]];
+        $arr = [
+            'table' => [
+                1 => ['id' => 1, 'name' => '', 'ref' => 'ref123', 'salary' => -123],
+            ],
+        ];
         $db = new Persistence\Array_($arr);
         $m = new \Atk4\Data\Model($db, ['table' => 'table']);
         $m->addField('name');


### PR DESCRIPTION
part of https://github.com/atk4/ui/pull/1765

`View::id` was basically a copy of `NameTrait::name`, but it was not used consistently

Final deduplicated name might be not the most intuitive one, but it is given by core trait `NameTrait::name` and is also much more used than `View::id` in the current code base. In the future, we might introduce a more intuitive getter for it with stricter global uniqueness check.