### PR TITLE
Fix duplicated Modal code when loaded using AJAX

### DIFF
--- a/demos/collection/grid.php
+++ b/demos/collection/grid.php
@@ -55,7 +55,8 @@ $deleteExecutor->onHook(BasicExecutor::HOOK_AFTER_EXECUTE, function () {
         new JsToast('Simulating delete in demo mode.'),
     ];
 });
-$grid->addExecutorButton($deleteExecutor, new Button(['icon' => 'times circle outline']));
+// TODO button is added not only to the table rows, but also below the table!
+// $grid->addExecutorButton($deleteExecutor, new Button(['icon' => 'times circle outline']));
 
 $sel = $grid->addSelection();
 $grid->menu->addItem('show selection')->on('click', new \Atk4\Ui\JsExpression(

--- a/src/App.php
+++ b/src/App.php
@@ -205,7 +205,10 @@ class App
      */
     public function registerPortals($portal): void
     {
-        $this->portals[$portal->short_name] = $portal;
+        // TODO in https://github.com/atk4/ui/pull/1771 it has been discovered this method causes DOM code duplication,
+        // for some reasons, it seems even not needed, at least all Unit & Behat tests pass
+        // must be investigated
+        // $this->portals[$portal->short_name] = $portal;
     }
 
     public function setExecutorFactory(ExecutorFactory $factory)

--- a/src/App.php
+++ b/src/App.php
@@ -391,8 +391,8 @@ class App
             foreach ($this->getRenderedPortals() as $key => $modal) {
                 // add modal rendering to output
                 $keys[] = '#' . $key;
-                $output['atkjs'] = $output['atkjs'] . ';' . $modal['js'];
-                $output['html'] = $output['html'] . $modal['html'];
+                $output['atkjs'] .= ';' . $modal['js'];
+                $output['html'] .= $modal['html'];
             }
             if ($keys) {
                 $ids = implode(',', $keys);

--- a/src/Form/Control/Dropdown.php
+++ b/src/Form/Control/Dropdown.php
@@ -247,7 +247,7 @@ class Dropdown extends Input
     protected function renderView(): void
     {
         if ($this->isMultiple) {
-            $this->defaultClass = $this->defaultClass . ' multiple';
+            $this->defaultClass .= ' multiple';
         }
 
         $this->addClass($this->defaultClass);


### PR DESCRIPTION
discovered during investigation of #1732

wrapping `demos/data-action/jsactions-panel.php` RightPanel demo works well even if wrapped inside Loader

duplicated code/ID is now tested in Behat after every step

```
  Scenario:                                        # tests-behat/callback.feature:12
    Given I am on "_unit-test/callback-nested.php" # Behat\MinkExtension\Context\MinkContext::visit()
    Then I press button "Load1"                    # Atk4\Ui\Behat\Context::iPressButton()
    Then I should see "Loader-1"                   # Behat\MinkExtension\Context\
                                                     MinkContext::assertPageContainsText()
    Then I press button "Load2"                    # Atk4\Ui\Behat\Context::iPressButton()
    │
    ╳  Exception: Page contains elements with duplicate ID:
         "atk_icon", "_ea0591c61f4b3107cf54838053b3adc3___useraction_modalexecutor",
         "_395f2da8a6a5c80767b0042937355326__tion_modalexecutor_loader",
         "_5fc141f467ea245de8f9515e9dba36b5__modalexecutor_loader_view",
         "_54e1cbc5bc6bbbb943063a6b5646b718__action_modalexecutor_view",
         "_59434c8e5978a6c002cbfdf93e3567b5__modalexecutor_view_button",
         "_365d92f1164005c843c56306fed35810__dalexecutor_view_button_2",
         "_365d92f1164005c843c56306fed35810__dalexecutor_view_button_3",
         "_f0a382c18a3f238d2ca01ecfe1d8bfac__seraction_modalexecutor_2",
         "_10ceb07386588d34599519a11fd9c342__on_modalexecutor_2_loader",
         "_d767499edd1aa3fc1207a1e884d12391__dalexecutor_2_loader_view",
         "_451b4b9ca5c98b9c0e30300079193a29__tion_modalexecutor_2_view",
         "_e35de19f435359fb1223eb830dbe63b5__dalexecutor_2_view_button",
         "_8b700a87c50e78df6714556cb335e1ca__lexecutor_2_view_button_2",
         "_8b700a87c50e78df6714556cb335e1ca__lexecutor_2_view_button_3"
       in src/Behat/Context.php:190
    ╳  Stack trace:
    ╳  #0 src/Behat/Context.php(67): Atk4\Ui\Behat\Context->assertNoInvalidNorDuplicateId()
    │
    └─ @AfterStep # Atk4\Ui\Behat\Context::waitUntilLoadingAndAnimationFinished()
```