### PR TITLE
Drop `$class` param from `View` constructor

### DIFF
--- a/demos/_includes/PromotionText.php
+++ b/demos/_includes/PromotionText.php
@@ -40,7 +40,7 @@ class PromotionText extends \Atk4\Ui\View
 
         \Atk4\Ui\View::addTo($this, ['ui' => 'divider']);
 
-        \Atk4\Ui\Message::addTo($this, ['Cool fact!', 'info', 'icon' => 'book'])->text
+        \Atk4\Ui\Message::addTo($this, ['Cool fact!', 'type' => 'info', 'icon' => 'book'])->text
             ->addParagraph('This entire demo is coded in Agile Toolkit and takes up less than 300 lines of very simple code!');
     }
 }

--- a/demos/_includes/PromotionText.php
+++ b/demos/_includes/PromotionText.php
@@ -28,14 +28,14 @@ class PromotionText extends \Atk4\Ui\View
                 HTML
         );
 
-        $gl = \Atk4\Ui\GridLayout::addTo($this, [null, 'stackable divided', 'columns' => 4]);
-        \Atk4\Ui\Button::addTo($gl, ['Explore UI components', 'primary basic fluid', 'iconRight' => 'right arrow'], ['r1c1'])
+        $gl = \Atk4\Ui\GridLayout::addTo($this, ['class.stackable divided' => true, 'columns' => 4]);
+        \Atk4\Ui\Button::addTo($gl, ['Explore UI components', 'class.primary basic fluid' => true, 'iconRight' => 'right arrow'], ['r1c1'])
             ->link('https://github.com/atk4/ui/#bundled-and-planned-components');
-        \Atk4\Ui\Button::addTo($gl, ['Try out interactive features', 'primary basic fluid', 'iconRight' => 'right arrow'], ['r1c2'])
+        \Atk4\Ui\Button::addTo($gl, ['Try out interactive features', 'class.primary basic fluid' => true, 'iconRight' => 'right arrow'], ['r1c2'])
             ->link(['interactive/tabs']);
-        \Atk4\Ui\Button::addTo($gl, ['Dive into Agile Data', 'primary basic fluid', 'iconRight' => 'right arrow'], ['r1c3'])
+        \Atk4\Ui\Button::addTo($gl, ['Dive into Agile Data', 'class.primary basic fluid' => true, 'iconRight' => 'right arrow'], ['r1c3'])
             ->link('https://git.io/ad');
-        \Atk4\Ui\Button::addTo($gl, ['More ATK Add-ons', 'primary basic fluid', 'iconRight' => 'right arrow'], ['r1c4'])
+        \Atk4\Ui\Button::addTo($gl, ['More ATK Add-ons', 'class.primary basic fluid' => true, 'iconRight' => 'right arrow'], ['r1c4'])
             ->link('https://github.com/atk4/ui/#add-ons-and-integrations');
 
         \Atk4\Ui\View::addTo($this, ['ui' => 'divider']);

--- a/demos/_includes/ReloadTest.php
+++ b/demos/_includes/ReloadTest.php
@@ -10,7 +10,7 @@ class ReloadTest extends \Atk4\Ui\View
     {
         parent::init();
 
-        $label = \Atk4\Ui\Label::addTo($this, ['Testing...', 'detail' => '', 'red']);
+        $label = \Atk4\Ui\Label::addTo($this, ['Testing...', 'detail' => '', 'class.red' => true]);
         $reload = new \Atk4\Ui\JsReload($this, [$this->name => 'ok']);
 
         if (isset($_GET[$this->name])) {

--- a/demos/_includes/Session.php
+++ b/demos/_includes/Session.php
@@ -17,6 +17,7 @@ class Session
 
     public function __construct(App $app)
     {
+        $this->name = 'demo';
         $this->setApp($app);
     }
 }

--- a/demos/_includes/ViewTester.php
+++ b/demos/_includes/ViewTester.php
@@ -14,7 +14,7 @@ class ViewTester extends \Atk4\Ui\View
     {
         parent::init();
 
-        $label = \Atk4\Ui\Label::addTo($this, ['CallBack', 'detail' => 'fail', 'red']);
+        $label = \Atk4\Ui\Label::addTo($this, ['CallBack', 'detail' => 'fail', 'class.red' => true]);
         $reload = new \Atk4\Ui\JsReload($this, [$this->name => 'ok']);
 
         if (isset($_GET[$this->name])) {

--- a/demos/_unit-test/callback.php
+++ b/demos/_unit-test/callback.php
@@ -24,7 +24,7 @@ $form->getControl($m->fieldName()->name)->caption = 'TestName';
 $table = \Atk4\Ui\Table::addTo($app);
 $table->setModel($m);
 
-$button = Button::addTo($app, ['First', ['ui' => 'atk-test']]);
+$button = Button::addTo($app, ['First', 'class.atk-test' => true]);
 $button->on('click', new \Atk4\Ui\JsModal('Edit First Record', $vp));
 
 $form->onSubmit(function (Form $form) use ($table) {

--- a/demos/basic/button.php
+++ b/demos/basic/button.php
@@ -61,7 +61,7 @@ $forkButtonClass = AnonymousClassNameCache::get_class(fn () => new class(0) /* n
     {
         Icon::addTo(Button::addTo($this, ['Forks', 'blue']), ['fork']);
         Label::addTo($this, [number_format($n), 'basic blue left pointing']);
-        parent::__construct(null, 'labeled');
+        parent::__construct(['class.labeled' => true]);
     }
 });
 

--- a/demos/basic/button.php
+++ b/demos/basic/button.php
@@ -26,17 +26,17 @@ $app->add($b1);
 $b1->link(['index']);
 
 \Atk4\Ui\Header::addTo($app, ['Properties', 'size' => 2]);
-Button::addTo($app, ['Primary button', 'primary']);
-Button::addTo($app, ['Load', 'labeled', 'icon' => 'pause']);
+Button::addTo($app, ['Primary button', 'class.primary' => true]);
+Button::addTo($app, ['Load', 'class.labeled' => true, 'icon' => 'pause']);
 Button::addTo($app, ['Next', 'iconRight' => 'right arrow']);
-Button::addTo($app, [null, 'circular', 'icon' => 'settings']);
+Button::addTo($app, ['class.circular' => true, 'icon' => 'settings']);
 
 \Atk4\Ui\Header::addTo($app, ['Big Button', 'size' => 2]);
-Button::addTo($app, ['Click me', 'big primary', 'icon' => 'check']);
+Button::addTo($app, ['Click me', 'class.big primary' => true, 'icon' => 'check']);
 
 \Atk4\Ui\Header::addTo($app, ['Button Intent', 'size' => 2]);
-Button::addTo($app, ['Yes', 'positive basic']);
-Button::addTo($app, ['No', 'negative basic']);
+Button::addTo($app, ['Yes', 'class.positive basic' => true]);
+Button::addTo($app, ['No', 'class.negative basic' => true]);
 
 \Atk4\Ui\Header::addTo($app, ['Combining Buttons', 'size' => 2]);
 
@@ -59,8 +59,8 @@ Button::addTo($bar, ['icon' => 'upload', 'class.disabled' => true]);
 $forkButtonClass = AnonymousClassNameCache::get_class(fn () => new class(0) /* need 0 argument here for constructor */ extends Button {
     public function __construct($n)
     {
-        Icon::addTo(Button::addTo($this, ['Forks', 'blue']), ['fork']);
-        Label::addTo($this, [number_format($n), 'basic blue left pointing']);
+        Icon::addTo(Button::addTo($this, ['Forks', 'class.blue' => true]), ['fork']);
+        Label::addTo($this, [number_format($n), 'class.basic blue left pointing' => true]);
         parent::__construct(['class.labeled' => true]);
     }
 });
@@ -73,11 +73,11 @@ $app->add($forkButton);
 $view = \Atk4\Ui\View::addTo($app, ['template' => new HtmlTemplate('Hello, {$tag1}, my name is {$tag2}')]);
 
 Button::addTo($view, ['World'], ['tag1']);
-Button::addTo($view, ['Agile UI', 'blue'], ['tag2']);
+Button::addTo($view, ['Agile UI', 'class.blue' => true], ['tag2']);
 
 \Atk4\Ui\Header::addTo($app, ['Attaching', 'size' => 2]);
 
-Button::addTo($app, ['Previous', 'top attached']);
+Button::addTo($app, ['Previous', 'class.top attached' => true]);
 \Atk4\Ui\Table::addTo($app, ['class.attached' => true, 'header' => false])
     ->setSource(['One', 'Two', 'Three', 'Four']);
-Button::addTo($app, ['Next', 'bottom attached']);
+Button::addTo($app, ['Next', 'class.bottom attached' => true]);

--- a/demos/basic/button.php
+++ b/demos/basic/button.php
@@ -78,6 +78,6 @@ Button::addTo($view, ['Agile UI', 'blue'], ['tag2']);
 \Atk4\Ui\Header::addTo($app, ['Attaching', 'size' => 2]);
 
 Button::addTo($app, ['Previous', 'top attached']);
-\Atk4\Ui\Table::addTo($app, ['attached', 'header' => false])
+\Atk4\Ui\Table::addTo($app, ['class.attached' => true, 'header' => false])
     ->setSource(['One', 'Two', 'Three', 'Four']);
 Button::addTo($app, ['Next', 'bottom attached']);

--- a/demos/basic/columns.php
+++ b/demos/basic/columns.php
@@ -35,7 +35,7 @@ $c = \Atk4\Ui\Columns::addTo($page);
 \Atk4\Ui\Header::addTo($page, ['Specifying widths, using rows or automatic flow']);
 
 // highlight class will show cells as boxes, even though they contain nothing
-$c = \Atk4\Ui\Columns::addTo($page, [null, 'highlight']);
+$c = \Atk4\Ui\Columns::addTo($page, ['class.highlight' => true]);
 $c->addColumn(3);
 $c->addColumn(5);
 $c->addColumn(2);
@@ -54,12 +54,12 @@ $r->addColumn();
 $c = \Atk4\Ui\Columns::addTo($page, ['internally celled']);
 
 $r = $c->addRow();
-\Atk4\Ui\Icon::addTo($r->addColumn([2, 'right aligned']), ['huge home']);
+\Atk4\Ui\Icon::addTo($r->addColumn([2, 'class.right aligned' => true]), ['huge home']);
 \Atk4\Ui\LoremIpsum::addTo($r->addColumn(12), [1]);
 \Atk4\Ui\Icon::addTo($r->addColumn(2), ['huge trash']);
 
 $r = $c->addRow();
-\Atk4\Ui\Icon::addTo($r->addColumn([2, 'right aligned']), ['huge home']);
+\Atk4\Ui\Icon::addTo($r->addColumn([2, 'class.right aligned' => true]), ['huge home']);
 \Atk4\Ui\LoremIpsum::addTo($r->addColumn(12), [1]);
 \Atk4\Ui\Icon::addTo($r->addColumn(2), ['huge trash']);
 
@@ -83,5 +83,5 @@ $boxClass = AnonymousClassNameCache::get_class(fn () => new class() extends \Atk
 });
 
 $c = \Atk4\Ui\Columns::addTo($page, ['width' => 4]);
-$boxClass::addTo($c->addColumn(), [null, 'red']);
-$boxClass::addTo($c->addColumn([null, null, 'right floated']), [null, 'blue']);
+$boxClass::addTo($c->addColumn(), ['class.red' => true]);
+$boxClass::addTo($c->addColumn(['class.right floated' => true]), ['class.blue' => true]);

--- a/demos/basic/header.php
+++ b/demos/basic/header.php
@@ -44,4 +44,4 @@ $seg = \Atk4\Ui\View::addTo($app, ['ui' => 'segment']);
 \Atk4\Ui\Header::addTo($seg, ['Center-aligned', 'aligned' => 'center', 'image' => $img, 'subHeader' => 'header with image']);
 
 $seg = \Atk4\Ui\View::addTo($app, ['ui' => 'segment']);
-\Atk4\Ui\Header::addTo($seg, ['Center-aligned', 'aligned' => 'center', 'image' => [$img, 'disabled'], 'subHeader' => 'header with image']);
+\Atk4\Ui\Header::addTo($seg, ['Center-aligned', 'aligned' => 'center', 'image' => [$img, 'class.disabled' => true], 'subHeader' => 'header with image']);

--- a/demos/basic/header.php
+++ b/demos/basic/header.php
@@ -14,7 +14,7 @@ $seg = \Atk4\Ui\View::addTo($app, ['ui' => 'segment']);
 \Atk4\Ui\Header::addTo($seg, ['H2 Header', 'size' => 2]);
 \Atk4\Ui\Header::addTo($seg, ['H3 Header', 'size' => 3]);
 \Atk4\Ui\Header::addTo($seg, ['H4 Header', 'size' => 4]);
-\Atk4\Ui\Header::addTo($seg, ['H5 Header', 'size' => 5, 'dividing']);
+\Atk4\Ui\Header::addTo($seg, ['H5 Header', 'size' => 5, 'class.dividing' => true]);
 \Atk4\Ui\View::addTo($seg, ['element' => 'P'])->set('This is a following paragraph of text');
 
 \Atk4\Ui\Header::addTo($seg, ['H1', 'size' => 1, 'subHeader' => 'H1 subheader']);
@@ -27,7 +27,7 @@ $seg = \Atk4\Ui\View::addTo($app, ['ui' => 'segment']);
 \Atk4\Ui\Header::addTo($seg, ['Small Header', 'size' => 'small']);
 \Atk4\Ui\Header::addTo($seg, ['Tiny Header', 'size' => 'tiny']);
 
-\Atk4\Ui\Header::addTo($seg, ['Sub Header', 'sub']);
+\Atk4\Ui\Header::addTo($seg, ['Sub Header', 'class.sub' => true]);
 
 $seg = \Atk4\Ui\View::addTo($app, ['ui' => 'segment']);
 \Atk4\Ui\Header::addTo($seg, ['Header with icon', 'icon' => 'settings']);

--- a/demos/basic/label.php
+++ b/demos/basic/label.php
@@ -26,12 +26,12 @@ $toggle = \Atk4\Ui\Label::addTo($app, ['icon' => 'toggle ' . ($val ? 'on' : 'off
 $toggle->on('click', new \Atk4\Ui\JsReload($toggle, ['toggle' => $val ? null : 1]));
 
 $menu = \Atk4\Ui\Menu::addTo($app);
-\Atk4\Ui\Label::addTo($menu->addItem('Inbox'), ['20', 'floating red']);
-\Atk4\Ui\Label::addTo($menu->addMenu('Others')->addItem('Draft'), ['10', 'floating blue']);
+\Atk4\Ui\Label::addTo($menu->addItem('Inbox'), ['20', 'class.floating red' => true]);
+\Atk4\Ui\Label::addTo($menu->addMenu('Others')->addItem('Draft'), ['10', 'class.floating blue' => true]);
 
 $seg = \Atk4\Ui\View::addTo($app, ['ui' => 'segment']);
 \Atk4\Ui\Header::addTo($seg, ['Label Group']);
-$labels = \Atk4\Ui\View::addTo($seg, [false, 'tag', 'ui' => 'labels']);
+$labels = \Atk4\Ui\View::addTo($seg, [false, 'class.tag' => true, 'ui' => 'labels']);
 \Atk4\Ui\Label::addTo($seg, ['$9.99']);
 \Atk4\Ui\Label::addTo($seg, ['$19.99']);
 \Atk4\Ui\Label::addTo($seg, ['$24.99']);
@@ -40,12 +40,12 @@ $columns = \Atk4\Ui\Columns::addTo($app);
 
 $c = $columns->addColumn();
 $seg = \Atk4\Ui\View::addTo($c, ['ui' => 'raised segment']);
-\Atk4\Ui\Label::addTo($seg, ['Left Column', 'top attached', 'icon' => 'book']);
-\Atk4\Ui\Label::addTo($seg, ['Lorem', 'red ribbon', 'icon' => 'cut']);
+\Atk4\Ui\Label::addTo($seg, ['Left Column', 'class.top attached' => true, 'icon' => 'book']);
+\Atk4\Ui\Label::addTo($seg, ['Lorem', 'class.red ribbon' => true, 'icon' => 'cut']);
 \Atk4\Ui\LoremIpsum::addTo($seg, ['size' => 1]);
 
 $c = $columns->addColumn();
 $seg = \Atk4\Ui\View::addTo($c, ['ui' => 'raised segment']);
-\Atk4\Ui\Label::addTo($seg, ['Right Column', 'top attached', 'icon' => 'book']);
+\Atk4\Ui\Label::addTo($seg, ['Right Column', 'class.top attached' => true, 'icon' => 'book']);
 \Atk4\Ui\LoremIpsum::addTo($seg, ['size' => 1]);
-\Atk4\Ui\Label::addTo($seg, ['Ipsum', 'orange bottom right attached', 'icon' => 'cut']);
+\Atk4\Ui\Label::addTo($seg, ['Ipsum', 'class.orange bottom right attached' => true, 'icon' => 'cut']);

--- a/demos/basic/menu.php
+++ b/demos/basic/menu.php
@@ -29,12 +29,12 @@ $submenu->addItem('one');
 $submenu->addItem('two');
 
 $menu = \Atk4\Ui\Menu::addTo($app, ['vertical pointing']);
-$menu->addItem(['Inbox', 'label' => ['123', 'teal left pointing']]);
+$menu->addItem(['Inbox', 'label' => ['123', 'class.teal left pointing' => true]]);
 $menu->addItem('Spam');
 \Atk4\Ui\Form\Control\Input::addTo($menu->addItem(), ['placeholder' => 'Search', 'icon' => 'search'])->addClass('transparent');
 
 $menu = \Atk4\Ui\Menu::addTo($app, ['secondary vertical pointing']);
-$menu->addItem(['Inbox', 'label' => ['123', 'teal left pointing']]);
+$menu->addItem(['Inbox', 'label' => ['123', 'class.teal left pointing' => true]]);
 $menu->addItem('Spam');
 \Atk4\Ui\Form\Control\Input::addTo($menu->addItem(), ['placeholder' => 'Search', 'icon' => 'search'])->addClass('transparent');
 $menu = \Atk4\Ui\Menu::addTo($app, ['vertical']);

--- a/demos/basic/menu.php
+++ b/demos/basic/menu.php
@@ -22,7 +22,7 @@ $dropdown->onChange(function ($itemId) {
 
 $submenu = $menu->addMenu('Sub-menu');
 $submenu->addItem('one', 'one.php');
-$submenu->addItem(['two', 'label' => 'VIP', 'disabled']);
+$submenu->addItem(['two', 'label' => 'VIP', 'class.disabled' => true]);
 
 $submenu = $submenu->addMenu('Sub-menu');
 $submenu->addItem('one');

--- a/demos/basic/view.php
+++ b/demos/basic/view.php
@@ -16,11 +16,11 @@ $img = $app->cdn['atk'] . '/logo.png';
 \Atk4\Ui\View::addTo($app)->set('just a <div> element');
 
 \Atk4\Ui\Header::addTo($app, ['View can specify CSS class']);
-\Atk4\Ui\View::addTo($app, ['ui' => 'segment', 'raised'])->set('Segment');
+\Atk4\Ui\View::addTo($app, ['ui' => 'segment', 'class.raised' => true])->set('Segment');
 
 \Atk4\Ui\Header::addTo($app, ['View can contain stuff']);
 \Atk4\Ui\Header::addTo(\Atk4\Ui\View::addTo($app, ['ui' => 'segment'])
-    ->addClass('inverted red circular'), ['Buy', 'inverted', 'subHeader' => '$' . (random_int(100, 1000) / 100)]);
+    ->addClass('inverted red circular'), ['Buy', 'class.inverted' => true, 'subHeader' => '$' . (random_int(100, 1000) / 100)]);
 
 \Atk4\Ui\Header::addTo($app, ['View can use JavaScript']);
 \Atk4\Ui\View::addTo($app, ['ui' => 'heart rating'])
@@ -48,7 +48,7 @@ $planeTemplate->set('num', random_int(100, 999));
 $plane = \Atk4\Ui\View::addTo($app, ['template' => $planeTemplate]);
 
 \Atk4\Ui\Header::addTo($app, ['Can be rendered into HTML']);
-\Atk4\Ui\View::addTo($app, ['ui' => 'segment', 'raised', 'element' => 'pre'])->set($plane->render());
+\Atk4\Ui\View::addTo($app, ['ui' => 'segment', 'class.raised' => true, 'element' => 'pre'])->set($plane->render());
 
 \Atk4\Ui\Header::addTo($app, ['Has a unique global identifier']);
 \Atk4\Ui\Label::addTo($app, ['Plane ID: ', 'detail' => $plane->name]);
@@ -62,7 +62,7 @@ $plane = \Atk4\Ui\View::addTo($app, ['template' => $planeTemplate]);
 \Atk4\Ui\Header::addTo($app, ['Can be on a Virtual Page']);
 $vp = \Atk4\Ui\VirtualPage::addTo($app)->set(function ($page) use ($planeTemplate) {
     $plane = View::addTo($page, ['template' => $planeTemplate]);
-    \Atk4\Ui\Label::addTo($page, ['Plane ID: ', 'bottom attached', 'detail' => $plane->name]);
+    \Atk4\Ui\Label::addTo($page, ['Plane ID: ', 'class.bottom attached' => true, 'detail' => $plane->name]);
 });
 
 \Atk4\Ui\Button::addTo($app, ['Show $plane in a dialog', 'icon' => 'clone'])->on('click', new \Atk4\Ui\JsModal('Plane Box', $vp));

--- a/demos/collection/card-deck.php
+++ b/demos/collection/card-deck.php
@@ -25,7 +25,7 @@ $action = $countries->addUserAction('book', [
 ]);
 
 // Create custom button for this action in card.
-$app->getExecutorFactory()->registerTrigger(ExecutorFactory::CARD_BUTTON, [Button::class, null, 'blue', 'icon' => 'plane'], $action);
+$app->getExecutorFactory()->registerTrigger(ExecutorFactory::CARD_BUTTON, [Button::class, 'class.blue' => true, 'icon' => 'plane'], $action);
 
 $action->args = [
     'email' => ['type' => 'string', 'required' => true, 'caption' => 'Please let us know your email address:'],

--- a/demos/collection/crud.php
+++ b/demos/collection/crud.php
@@ -57,7 +57,7 @@ $model->onHook(\Atk4\Data\Model::HOOK_VALIDATE, function (Country $model, $inten
 $crud->setModel($model);
 
 // Because Crud inherits Grid, you can also define custom actions
-$crud->addModalAction(['icon' => [\Atk4\Ui\Icon::class, 'cogs']], 'Details', function ($p, $id) use ($crud) {
+$crud->addModalAction(['icon' => 'cogs'], 'Details', function ($p, $id) use ($crud) {
     $model = Country::assertInstanceOf($crud->model);
     \Atk4\Ui\Message::addTo($p, ['Details for: ' . $model->load($id)->name . ' (id: ' . $id . ')']);
 });

--- a/demos/collection/crud.php
+++ b/demos/collection/crud.php
@@ -79,7 +79,7 @@ $myExecutorClass = AnonymousClassNameCache::get_class(fn () => new class() exten
             \Atk4\Ui\Grid::addTo($right, ['menu' => false, 'ipp' => 5])
                 ->setModel(File::assertInstanceOf($this->getAction()->getModel())->SubFolder);
         } else {
-            \Atk4\Ui\Message::addTo($right, ['Not a folder', 'warning']);
+            \Atk4\Ui\Message::addTo($right, ['Not a folder', 'type' => 'warning']);
         }
 
         return $result;

--- a/demos/collection/grid.php
+++ b/demos/collection/grid.php
@@ -43,7 +43,7 @@ $grid->addActionButton('Say HI', function ($j, $id) use ($grid) {
     return 'Loaded "' . $model->load($id)->name . '" from ID=' . $id;
 });
 
-$grid->addModalAction(['icon' => [\Atk4\Ui\Icon::class, 'external']], 'Modal Test', function ($p, $id) {
+$grid->addModalAction(['icon' => 'external'], 'Modal Test', function ($p, $id) {
     \Atk4\Ui\Message::addTo($p, ['Clicked on ID=' . $id]);
 });
 

--- a/demos/collection/grid.php
+++ b/demos/collection/grid.php
@@ -30,7 +30,7 @@ if ($grid->stickyGet('no-ajax')) {
 
 $grid->menu->addItem(['Add Country', 'icon' => 'add square'], new \Atk4\Ui\JsExpression('alert(123)'));
 $grid->menu->addItem(['Re-Import', 'icon' => 'power'], new \Atk4\Ui\JsReload($grid));
-$grid->menu->addItem(['Delete All', 'icon' => 'trash', 'red active']);
+$grid->menu->addItem(['Delete All', 'icon' => 'trash', 'class.red active' => true]);
 
 $grid->addColumn(null, [\Atk4\Ui\Table\Column\Template::class, 'hello<b>world</b>']);
 

--- a/demos/collection/multitable.php
+++ b/demos/collection/multitable.php
@@ -21,7 +21,7 @@ $finderClass = AnonymousClassNameCache::get_class(fn () => new class() extends \
         $this->addClass('internally celled');
 
         // lets add our first table here
-        $table = \Atk4\Ui\Table::addTo($this->addColumn(), ['header' => false, 'very basic selectable'])->addStyle('cursor', 'pointer');
+        $table = \Atk4\Ui\Table::addTo($this->addColumn(), ['header' => false, 'class.very basic selectable' => true])->addStyle('cursor', 'pointer');
         $table->setModel($model, [$model->title_field]);
 
         $selections = explode(',', $_GET[$this->name] ?? '');

--- a/demos/collection/multitable.php
+++ b/demos/collection/multitable.php
@@ -55,7 +55,7 @@ $finderClass = AnonymousClassNameCache::get_class(fn () => new class() extends \
 
             $pushModel = $pushModel->ref($ref);
 
-            $table = \Atk4\Ui\Table::addTo($this->addColumn(), ['header' => false, 'very basic selectable'])->addStyle('cursor', 'pointer');
+            $table = \Atk4\Ui\Table::addTo($this->addColumn(), ['header' => false, 'class.very basic selectable' => true])->addStyle('cursor', 'pointer');
             $table->setModel($pushModel->setLimit(10), [$pushModel->title_field]);
 
             if ($selections) {
@@ -79,11 +79,11 @@ $model->setOrder([$model->fieldName()->is_folder => 'desc', $model->fieldName()-
 
 $vp = \Atk4\Ui\VirtualPage::addTo($app)->set(function (\Atk4\Ui\VirtualPage $vp) use ($model) {
     $model->importFromFilesystem('.');
-    \Atk4\Ui\Button::addTo($vp, ['Import Complete', 'big green fluid'])->link('multitable.php');
+    \Atk4\Ui\Button::addTo($vp, ['Import Complete', 'class.big green fluid' => true])->link('multitable.php');
     $vp->js(true)->closest('.modal')->find('.header')->remove();
 });
 
-\Atk4\Ui\Button::addTo($app, ['Re-Import From Filesystem', 'top attached'])->on('click', new \Atk4\Ui\JsModal('Now importing ... ', $vp));
+\Atk4\Ui\Button::addTo($app, ['Re-Import From Filesystem', 'class.top attached' => true])->on('click', new \Atk4\Ui\JsModal('Now importing ... ', $vp));
 
 $finderClass::addTo($app, ['bottom attached'])
     ->addClass('top attached segment')

--- a/demos/data-action/actions.php
+++ b/demos/data-action/actions.php
@@ -72,7 +72,7 @@ $btn = \Atk4\Ui\Button::addTo($rightColumn, ['Import File']);
 $btn->on('click', $executor, ['confirm' => 'This will import a lot of file. Are you sure?']);
 
 Header::addTo($rightColumn, ['BasicExecutor']);
-$executor = UserAction\BasicExecutor::addTo($rightColumn, ['executorButton' => [Button::class, 'Import', 'primary']]);
+$executor = UserAction\BasicExecutor::addTo($rightColumn, ['executorButton' => [Button::class, 'Import', 'class.primary' => true]]);
 $executor->setAction($action->getActionForEntity($files->createEntity()));
 $executor->ui = 'segment';
 $executor->description = 'Execute Import action using "BasicExecutor" with argument "path" equal to "."';
@@ -84,7 +84,7 @@ $executor->onHook(UserAction\BasicExecutor::HOOK_AFTER_EXECUTE, function ($x) {
 View::addTo($rightColumn, ['ui' => 'hidden divider']);
 
 Header::addTo($rightColumn, ['PreviewExecutor']);
-$executor = UserAction\PreviewExecutor::addTo($rightColumn, ['executorButton' => [Button::class, 'Confirm', 'primary']]);
+$executor = UserAction\PreviewExecutor::addTo($rightColumn, ['executorButton' => [Button::class, 'Confirm', 'class.primary' => true]]);
 $executor->setAction($action->getActionForEntity($files->createEntity()));
 $executor->ui = 'segment';
 $executor->previewType = 'console';
@@ -95,7 +95,7 @@ $executor->onHook(UserAction\BasicExecutor::HOOK_AFTER_EXECUTE, function ($x, $r
 });
 
 Header::addTo($leftColumn, ['FormExecutor']);
-$executor = UserAction\FormExecutor::addTo($leftColumn, ['executorButton' => [Button::class, 'Save Name Only', 'primary']]);
+$executor = UserAction\FormExecutor::addTo($leftColumn, ['executorButton' => [Button::class, 'Save Name Only', 'class.primary' => true]]);
 $executor->setAction($action->getActionForEntity($files->createEntity()));
 $executor->ui = 'segment';
 $executor->description = 'Only fields set in $action[field] array will be added in form.';
@@ -107,7 +107,7 @@ $executor->onHook(UserAction\BasicExecutor::HOOK_AFTER_EXECUTE, function ($x, $r
 View::addTo($leftColumn, ['ui' => 'hidden divider']);
 
 Header::addTo($leftColumn, ['ArgumentFormExecutor']);
-$executor = UserAction\ArgumentFormExecutor::addTo($leftColumn, ['executorButton' => [Button::class, 'Run Import', 'primary']]);
+$executor = UserAction\ArgumentFormExecutor::addTo($leftColumn, ['executorButton' => [Button::class, 'Run Import', 'class.primary' => true]]);
 $executor->setAction($action->getActionForEntity($files->createEntity()));
 $executor->description = 'ArgumentFormExecutor will ask user about arguments set in actions.';
 $executor->ui = 'segment';

--- a/demos/data-action/factory-view.php
+++ b/demos/data-action/factory-view.php
@@ -13,7 +13,7 @@ use Atk4\Ui\View;
 /** @var \Atk4\Ui\App $app */
 require_once __DIR__ . '/../init-app.php';
 
-Button::addTo($app, ['Executor Factory in App instance', 'small left floated basic blue', 'icon' => 'left arrow'])
+Button::addTo($app, ['Executor Factory in App instance', 'class.small left floated basic blue' => true, 'icon' => 'left arrow'])
     ->link(['factory']);
 View::addTo($app, ['ui' => 'ui clearing divider']);
 

--- a/demos/data-action/factory.php
+++ b/demos/data-action/factory.php
@@ -12,7 +12,7 @@ use Atk4\Ui\View;
 /** @var \Atk4\Ui\App $app */
 require_once __DIR__ . '/../init-app.php';
 
-Button::addTo($app, ['Executor Factory in View Instance', 'small right floated basic blue', 'iconRight' => 'right arrow'])
+Button::addTo($app, ['Executor Factory in View Instance', 'class.small right floated basic blue' => true, 'iconRight' => 'right arrow'])
     ->link(['factory-view']);
 View::addTo($app, ['ui' => 'ui clearing divider']);
 

--- a/demos/form-control/checkbox.php
+++ b/demos/form-control/checkbox.php
@@ -18,12 +18,12 @@ Form\Control\Checkbox::addTo($app, ['Make my profile visible']);
 Form\Control\Checkbox::addTo($app, ['Make my profile visible ticked'])->set(true);
 
 View::addTo($app, ['ui' => 'divider']);
-Form\Control\Checkbox::addTo($app, ['Accept terms and conditions', 'slider']);
+Form\Control\Checkbox::addTo($app, ['Accept terms and conditions', 'class.slider' => true]);
 
 View::addTo($app, ['ui' => 'divider']);
-Form\Control\Checkbox::addTo($app, ['Subscribe to weekly newsletter', 'toggle']);
+Form\Control\Checkbox::addTo($app, ['Subscribe to weekly newsletter', 'class.toggle' => true]);
 View::addTo($app, ['ui' => 'divider']);
-Form\Control\Checkbox::addTo($app, ['Look for the clues', 'disabled toggle'])->set(true);
+Form\Control\Checkbox::addTo($app, ['Look for the clues', 'class.disabled toggle' => true])->set(true);
 
 View::addTo($app, ['ui' => 'divider']);
 Form\Control\Checkbox::addTo($app, ['Custom setting?'])->js(true)->checkbox('set indeterminate');

--- a/demos/form-control/input.php
+++ b/demos/form-control/input.php
@@ -38,12 +38,12 @@ Form\Control\Line::addTo($app, [
     'labelRight' => $dd,
 ]);
 
-Form\Control\Line::addTo($app, ['placeholder' => 'Weight', 'labelRight' => new \Atk4\Ui\Label(['kg', 'basic'])]);
-Form\Control\Line::addTo($app, ['label' => '$', 'labelRight' => new \Atk4\Ui\Label(['.00', 'basic'])]);
+Form\Control\Line::addTo($app, ['placeholder' => 'Weight', 'labelRight' => new \Atk4\Ui\Label(['kg', 'class.basic' => true])]);
+Form\Control\Line::addTo($app, ['label' => '$', 'labelRight' => new \Atk4\Ui\Label(['.00', 'class.basic' => true])]);
 
 Form\Control\Line::addTo($app, [
     'iconLeft' => 'tags',
-    'labelRight' => new \Atk4\Ui\Label(['Add Tag', 'tag']),
+    'labelRight' => new \Atk4\Ui\Label(['Add Tag', 'class.tag' => true]),
 ]);
 
 // left/right corner is not supported, but here is work-around:
@@ -68,22 +68,22 @@ Form\Control\Line::addTo($app, [
 Form\Control\Line::addTo($app, ['action' => 'Search']);
 
 Form\Control\Line::addTo($app, ['actionLeft' => new \Atk4\Ui\Button([
-    'Checkout', 'icon' => 'cart', 'teal',
+    'Checkout', 'class.teal' => true, 'icon' => 'cart',
 ])]);
 
 Form\Control\Line::addTo($app, ['iconLeft' => 'search',  'action' => 'Search']);
 
-$dd = new \Atk4\Ui\DropdownButton(['This Page', 'basic']);
+$dd = new \Atk4\Ui\DropdownButton(['This Page', 'class.basic' => true]);
 $dd->setSource(['This Organisation', 'Entire Site']);
 Form\Control\Line::addTo($app, ['iconLeft' => 'search',  'action' => $dd]);
 
 // double actions are not supported but you can add them yourself
-$dd = new \Atk4\Ui\Dropdown(['Articles', 'compact selection']);
+$dd = new \Atk4\Ui\Dropdown(['Articles', 'class.compact selection' => true]);
 $dd->setSource(['All', 'Services', 'Products']);
 \Atk4\Ui\Button::addTo(Form\Control\Line::addTo($app, ['iconLeft' => 'search',  'action' => $dd]), ['Search'], ['AfterAfterInput']);
 
 Form\Control\Line::addTo($app, ['action' => new \Atk4\Ui\Button([
-    'Copy', 'iconRight' => 'copy', 'teal',
+    'Copy', 'class.teal' => true, 'iconRight' => 'copy',
 ])]);
 
 Form\Control\Line::addTo($app, ['action' => new \Atk4\Ui\Button([

--- a/demos/form-control/lookup-dep.php
+++ b/demos/form-control/lookup-dep.php
@@ -12,7 +12,7 @@ require_once __DIR__ . '/../init-app.php';
 \Atk4\Ui\Header::addTo($app, ['Lookup dependency']);
 
 $form = Form::addTo($app, ['class.segment' => true]);
-\Atk4\Ui\Label::addTo($form, ['Input information here', 'top attached'], ['AboveControls']);
+\Atk4\Ui\Label::addTo($form, ['Input information here', 'class.top attached' => true], ['AboveControls']);
 
 $form->addControl('starts_with', [
     Form\Control\Dropdown::class,
@@ -53,7 +53,7 @@ $form->onSubmit(function (Form $form) {
 \Atk4\Ui\Header::addTo($app, ['Lookup multiple values']);
 
 $form = Form::addTo($app, ['class.segment' => true]);
-\Atk4\Ui\Label::addTo($form, ['Input information here', 'top attached'], ['AboveControls']);
+\Atk4\Ui\Label::addTo($form, ['Input information here', 'class.top attached' => true], ['AboveControls']);
 
 $form->addControl('ends_with', [
     Form\Control\Dropdown::class,

--- a/demos/form-control/lookup-dep.php
+++ b/demos/form-control/lookup-dep.php
@@ -11,7 +11,7 @@ require_once __DIR__ . '/../init-app.php';
 
 \Atk4\Ui\Header::addTo($app, ['Lookup dependency']);
 
-$form = Form::addTo($app, ['segment']);
+$form = Form::addTo($app, ['class.segment' => true]);
 \Atk4\Ui\Label::addTo($form, ['Input information here', 'top attached'], ['AboveControls']);
 
 $form->addControl('starts_with', [
@@ -52,7 +52,7 @@ $form->onSubmit(function (Form $form) {
 
 \Atk4\Ui\Header::addTo($app, ['Lookup multiple values']);
 
-$form = Form::addTo($app, ['segment']);
+$form = Form::addTo($app, ['class.segment' => true]);
 \Atk4\Ui\Label::addTo($form, ['Input information here', 'top attached'], ['AboveControls']);
 
 $form->addControl('ends_with', [

--- a/demos/form-control/lookup.php
+++ b/demos/form-control/lookup.php
@@ -17,7 +17,7 @@ Form\Control\Lookup::addTo($app, ['placeholder' => 'Search country', 'label' => 
 
 // create form
 $form = Form::addTo($app, ['class.segment' => true]);
-\Atk4\Ui\Label::addTo($form, ['Lookup countries', 'top attached'], ['AboveControls']);
+\Atk4\Ui\Label::addTo($form, ['Lookup countries', 'class.top attached' => true], ['AboveControls']);
 
 $model = new \Atk4\Data\Model($app->db, ['table' => 'test']);
 

--- a/demos/form-control/lookup.php
+++ b/demos/form-control/lookup.php
@@ -60,12 +60,12 @@ Form\Control\Lookup::addTo($app, ['placeholder' => 'Search country', 'label' => 
     ->setModel(new Country($app->db));
 
 // through constructor
-Form\Control\Lookup::addTo($app, ['placeholder' => 'Weight', 'labelRight' => new \Atk4\Ui\Label(['kg', 'basic'])]);
-Form\Control\Lookup::addTo($app, ['label' => '$', 'labelRight' => new \Atk4\Ui\Label(['.00', 'basic'])]);
+Form\Control\Lookup::addTo($app, ['placeholder' => 'Weight', 'labelRight' => new \Atk4\Ui\Label(['kg', 'class.basic' => true])]);
+Form\Control\Lookup::addTo($app, ['label' => '$', 'labelRight' => new \Atk4\Ui\Label(['.00', 'class.basic' => true])]);
 
 Form\Control\Lookup::addTo($app, [
     'iconLeft' => 'tags',
-    'labelRight' => new \Atk4\Ui\Label(['Add Tag', 'tag']),
+    'labelRight' => new \Atk4\Ui\Label(['Add Tag', 'class.tag' => true]),
 ]);
 
 // left/right corner is not supported, but here is work-around:

--- a/demos/form-control/lookup.php
+++ b/demos/form-control/lookup.php
@@ -16,7 +16,7 @@ Form\Control\Lookup::addTo($app, ['placeholder' => 'Search country', 'label' => 
     ->setModel(new Country($app->db));
 
 // create form
-$form = Form::addTo($app, ['segment']);
+$form = Form::addTo($app, ['class.segment' => true]);
 \Atk4\Ui\Label::addTo($form, ['Lookup countries', 'top attached'], ['AboveControls']);
 
 $model = new \Atk4\Data\Model($app->db, ['table' => 'test']);

--- a/demos/form/form-section-accordion.php
+++ b/demos/form/form-section-accordion.php
@@ -9,7 +9,7 @@ use Atk4\Ui\Form;
 /** @var \Atk4\Ui\App $app */
 require_once __DIR__ . '/../init-app.php';
 
-\Atk4\Ui\Button::addTo($app, ['Form Sections', 'small left floated basic blue', 'icon' => 'left arrow'])
+\Atk4\Ui\Button::addTo($app, ['Form Sections', 'class.small left floated basic blue' => true, 'icon' => 'left arrow'])
     ->link(['form-section']);
 \Atk4\Ui\View::addTo($app, ['ui' => 'ui clearing divider']);
 

--- a/demos/form/form-section-accordion.php
+++ b/demos/form/form-section-accordion.php
@@ -58,7 +58,7 @@ $section2 = $sublayoutAccordion->addSection('Delivery address');
 $section2->addControl('delivery_address', []);
 
 // Terms field
-$form->addControl('term', [Form\Control\Checkbox::class, 'caption' => 'Accept terms and conditions', null, 'slider']);
+$form->addControl('term', [Form\Control\Checkbox::class, 'caption' => 'Accept terms and conditions', 'class.slider' => true]);
 
 $accordionLayout->activate($contactSection);
 

--- a/demos/form/form-section.php
+++ b/demos/form/form-section.php
@@ -9,7 +9,7 @@ use Atk4\Ui\Form;
 /** @var \Atk4\Ui\App $app */
 require_once __DIR__ . '/../init-app.php';
 
-\Atk4\Ui\Button::addTo($app, ['Accordion in Form', 'small right floated basic blue', 'iconRight' => 'right arrow'])
+\Atk4\Ui\Button::addTo($app, ['Accordion in Form', 'class.small right floated basic blue' => true, 'iconRight' => 'right arrow'])
     ->link(['form-section-accordion']);
 \Atk4\Ui\View::addTo($app, ['ui' => 'ui clearing divider']);
 

--- a/demos/form/form.php
+++ b/demos/form/form.php
@@ -201,7 +201,7 @@ $tab = $tabs->addTab('Layout Control');
 
 \Atk4\Ui\Header::addTo($tab, ['Shows example of grouping and multiple errors']);
 
-$form = Form::addTo($tab, ['segment']);
+$form = Form::addTo($tab, ['class.segment' => true]);
 $form->setModel((new \Atk4\Data\Model())->createEntity());
 
 $form->addHeader('Example fields added one-by-one');

--- a/demos/form/form.php
+++ b/demos/form/form.php
@@ -157,7 +157,7 @@ $form->onSubmit(function (Form $form) {
     return 'somehow it did not crash';
 });
 
-\Atk4\Ui\Button::addTo($form, ['Modal Test', 'secondary'])->on('click', \Atk4\Ui\Modal::addTo($form)
+\Atk4\Ui\Button::addTo($form, ['Modal Test', 'class.secondary' => true])->on('click', \Atk4\Ui\Modal::addTo($form)
     ->set(function ($p) {
         $form = Form::addTo($p);
         $form->addControl('email');

--- a/demos/form/form2.php
+++ b/demos/form/form2.php
@@ -18,9 +18,9 @@ require_once __DIR__ . '/../init-app.php';
 // create form
 $form = Form::addTo($app, ['class.segment' => true]);
 // $form = Form::addTo($app, ['class.segment' => true, 'buttonSave' => false]);
-// $form = Form::addTo($app, ['class.segment' => true, 'buttonSave' => new \Atk4\Ui\Button(['Import', 'secondary', 'iconRight' => 'list'])]);
-// $form = Form::addTo($app, ['class.segment' => true, 'buttonSave' => [null, 'Import', 'secondary', 'iconRight' => 'list']]);
-\Atk4\Ui\Label::addTo($form, ['Input new country information here', 'top attached'], ['AboveControls']);
+// $form = Form::addTo($app, ['class.segment' => true, 'buttonSave' => new \Atk4\Ui\Button(['Import', 'class.secondary' => true, 'iconRight' => 'list'])]);
+// $form = Form::addTo($app, ['class.segment' => true, 'buttonSave' => [null, 'Import', 'class.secondary' => true, 'iconRight' => 'list']]);
+\Atk4\Ui\Label::addTo($form, ['Input new country information here', 'class.top attached' => true], ['AboveControls']);
 
 $form->setModel((new Country($app->db))->createEntity(), []);
 

--- a/demos/form/form2.php
+++ b/demos/form/form2.php
@@ -16,10 +16,10 @@ require_once __DIR__ . '/../init-app.php';
 \Atk4\Ui\Header::addTo($app, ['Database-driven form with an enjoyable layout']);
 
 // create form
-$form = Form::addTo($app, ['segment']);
-// $form = Form::addTo($app, ['segment', 'buttonSave' => false]);
-// $form = Form::addTo($app, ['segment', 'buttonSave' => new \Atk4\Ui\Button(['Import', 'secondary', 'iconRight' => 'list'])]);
-// $form = Form::addTo($app, ['segment', 'buttonSave' => [null, 'Import', 'secondary', 'iconRight' => 'list']]);
+$form = Form::addTo($app, ['class.segment' => true]);
+// $form = Form::addTo($app, ['class.segment' => true, 'buttonSave' => false]);
+// $form = Form::addTo($app, ['class.segment' => true, 'buttonSave' => new \Atk4\Ui\Button(['Import', 'secondary', 'iconRight' => 'list'])]);
+// $form = Form::addTo($app, ['class.segment' => true, 'buttonSave' => [null, 'Import', 'secondary', 'iconRight' => 'list']]);
 \Atk4\Ui\Label::addTo($form, ['Input new country information here', 'top attached'], ['AboveControls']);
 
 $form->setModel((new Country($app->db))->createEntity(), []);

--- a/demos/form/jscondform.php
+++ b/demos/form/jscondform.php
@@ -14,7 +14,7 @@ require_once __DIR__ . '/../init-app.php';
 \Atk4\Ui\Header::addTo($app, ['Phone', 'size' => 2]);
 
 $formPhone = Form::addTo($app, ['class.segment' => true]);
-\Atk4\Ui\Label::addTo($formPhone, ['Add other phone field input. Note: phone1 required a number of at least 5 char.', 'top attached'], ['AboveControls']);
+\Atk4\Ui\Label::addTo($formPhone, ['Add other phone field input. Note: phone1 required a number of at least 5 char.', 'class.top attached' => true], ['AboveControls']);
 
 $formPhone->addControl('phone1');
 $formPhone->addControl('phone2');
@@ -36,7 +36,7 @@ $formSubscribe = Form::addTo($app, ['class.segment' => true]);
 \Atk4\Ui\Label::addTo($formSubscribe, ['Click on subscribe and add email to receive your gift.', 'top attached'], ['AboveControls']);
 
 $formSubscribe->addControl('name');
-$formSubscribe->addControl('subscribe', [Form\Control\Checkbox::class, 'Subscribe to weekly newsletter', 'toggle']);
+$formSubscribe->addControl('subscribe', [Form\Control\Checkbox::class, 'Subscribe to weekly newsletter', 'class.toggle' => true]);
 $formSubscribe->addControl('email');
 $formSubscribe->addControl('gender', [Form\Control\Radio::class], ['enum' => ['Female', 'Male']])->set('Female');
 $formSubscribe->addControl('m_gift', [Form\Control\Dropdown::class, 'caption' => 'Gift for Men', 'values' => ['Beer Glass', 'Swiss Knife']]);

--- a/demos/form/jscondform.php
+++ b/demos/form/jscondform.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/../init-app.php';
 
 \Atk4\Ui\Header::addTo($app, ['Phone', 'size' => 2]);
 
-$formPhone = Form::addTo($app, ['segment']);
+$formPhone = Form::addTo($app, ['class.segment' => true]);
 \Atk4\Ui\Label::addTo($formPhone, ['Add other phone field input. Note: phone1 required a number of at least 5 char.', 'top attached'], ['AboveControls']);
 
 $formPhone->addControl('phone1');
@@ -32,7 +32,7 @@ $formPhone->setControlsDisplayRules([
 
 \Atk4\Ui\Header::addTo($app, ['Optional subscription', 'size' => 2]);
 
-$formSubscribe = Form::addTo($app, ['segment']);
+$formSubscribe = Form::addTo($app, ['class.segment' => true]);
 \Atk4\Ui\Label::addTo($formSubscribe, ['Click on subscribe and add email to receive your gift.', 'top attached'], ['AboveControls']);
 
 $formSubscribe->addControl('name');
@@ -56,7 +56,7 @@ $formSubscribe->setControlsDisplayRules([
 
 \Atk4\Ui\Header::addTo($app, ['Dog registration', 'size' => 2]);
 
-$formDog = Form::addTo($app, ['segment']);
+$formDog = Form::addTo($app, ['class.segment' => true]);
 \Atk4\Ui\Label::addTo($formDog, ['You can select type of hair cut only with race that contains "poodle" AND age no more than 5 year OR your dog race equals "bichon".', 'top attached'], ['AboveControls']);
 $formDog->addControl('race', [Form\Control\Line::class]);
 $formDog->addControl('age');
@@ -73,7 +73,7 @@ $formDog->setControlsDisplayRules([
 
 \Atk4\Ui\Header::addTo($app, ['Hide or show group', 'size' => 2]);
 
-$formGroup = Form::addTo($app, ['segment']);
+$formGroup = Form::addTo($app, ['class.segment' => true]);
 \Atk4\Ui\Label::addTo($formGroup, ['Work on form group too.', 'top attached'], ['AboveControls']);
 
 $groupBasic = $formGroup->addGroup(['Basic Information']);
@@ -103,7 +103,7 @@ $formGroup->setGroupDisplayRules(['php' => ['dev' => 'checked'], 'language' => [
 /*
 \Atk4\Ui\Header::addTo($app, ['Hide or show accordion section', 'size' => 2]);
 
-$f_acc = Form::addTo($app, ['segment']);
+$f_acc = Form::addTo($app, ['class.segment' => true]);
 \Atk4\Ui\Label::addTo($f_acc, ['Work on section layouts too.', 'top attached'], ['AboveControls']);
 
 // Accordion

--- a/demos/form/jscondform.php
+++ b/demos/form/jscondform.php
@@ -33,7 +33,7 @@ $formPhone->setControlsDisplayRules([
 \Atk4\Ui\Header::addTo($app, ['Optional subscription', 'size' => 2]);
 
 $formSubscribe = Form::addTo($app, ['class.segment' => true]);
-\Atk4\Ui\Label::addTo($formSubscribe, ['Click on subscribe and add email to receive your gift.', 'top attached'], ['AboveControls']);
+\Atk4\Ui\Label::addTo($formSubscribe, ['Click on subscribe and add email to receive your gift.', 'class.top attached' => true], ['AboveControls']);
 
 $formSubscribe->addControl('name');
 $formSubscribe->addControl('subscribe', [Form\Control\Checkbox::class, 'Subscribe to weekly newsletter', 'class.toggle' => true]);
@@ -57,7 +57,7 @@ $formSubscribe->setControlsDisplayRules([
 \Atk4\Ui\Header::addTo($app, ['Dog registration', 'size' => 2]);
 
 $formDog = Form::addTo($app, ['class.segment' => true]);
-\Atk4\Ui\Label::addTo($formDog, ['You can select type of hair cut only with race that contains "poodle" AND age no more than 5 year OR your dog race equals "bichon".', 'top attached'], ['AboveControls']);
+\Atk4\Ui\Label::addTo($formDog, ['You can select type of hair cut only with race that contains "poodle" AND age no more than 5 year OR your dog race equals "bichon".', 'class.top attached' => true], ['AboveControls']);
 $formDog->addControl('race', [Form\Control\Line::class]);
 $formDog->addControl('age');
 $formDog->addControl('hair_cut', [Form\Control\Dropdown::class, 'values' => ['Short', 'Long']]);
@@ -74,7 +74,7 @@ $formDog->setControlsDisplayRules([
 \Atk4\Ui\Header::addTo($app, ['Hide or show group', 'size' => 2]);
 
 $formGroup = Form::addTo($app, ['class.segment' => true]);
-\Atk4\Ui\Label::addTo($formGroup, ['Work on form group too.', 'top attached'], ['AboveControls']);
+\Atk4\Ui\Label::addTo($formGroup, ['Work on form group too.', 'class.top attached' => true], ['AboveControls']);
 
 $groupBasic = $formGroup->addGroup(['Basic Information']);
 $groupBasic->addControl('first_name', ['width' => 'eight']);
@@ -104,7 +104,7 @@ $formGroup->setGroupDisplayRules(['php' => ['dev' => 'checked'], 'language' => [
 \Atk4\Ui\Header::addTo($app, ['Hide or show accordion section', 'size' => 2]);
 
 $f_acc = Form::addTo($app, ['class.segment' => true]);
-\Atk4\Ui\Label::addTo($f_acc, ['Work on section layouts too.', 'top attached'], ['AboveControls']);
+\Atk4\Ui\Label::addTo($f_acc, ['Work on section layouts too.', 'class.top attached' => true], ['AboveControls']);
 
 // Accordion
 $accordion_layout = $f_acc->layout->addSubLayout([Form\Layout\Section\Accordion::class, 'type' => ['styled', 'fluid'], 'settings' => ['exclusive' => false]]);

--- a/demos/index.php
+++ b/demos/index.php
@@ -9,16 +9,16 @@ require_once __DIR__ . '/init-app.php';
 
 \Atk4\Ui\Header::addTo($app)->set('Welcome to Agile Toolkit Demo!!');
 
-$t = \Atk4\Ui\Text::addTo(\Atk4\Ui\View::addTo($app, [false, 'green', 'ui' => 'segment']));
+$t = \Atk4\Ui\Text::addTo(\Atk4\Ui\View::addTo($app, [false, 'class.green' => true, 'ui' => 'segment']));
 $t->addParagraph('Take a quick stroll through some of the amazing features of Agile Toolkit.');
 
-\Atk4\Ui\Button::addTo($app, ['Begin the demo..', 'huge primary fluid', 'iconRight' => 'right arrow'])
+\Atk4\Ui\Button::addTo($app, ['Begin the demo..', 'class.huge primary fluid' => true, 'iconRight' => 'right arrow'])
     ->link('tutorial/intro.php');
 
 \Atk4\Ui\Header::addTo($app)->set('What is new in Agile Toolkit 2.0');
 
-$t = \Atk4\Ui\Text::addTo(\Atk4\Ui\View::addTo($app, [false, 'green', 'ui' => 'segment']));
+$t = \Atk4\Ui\Text::addTo(\Atk4\Ui\View::addTo($app, [false, 'class.green' => true, 'ui' => 'segment']));
 $t->addParagraph('In this version of Agile Toolkit we introduce "User Actions"!');
 
-\Atk4\Ui\Button::addTo($app, ['Learn about User Actions', 'huge basic primary fluid', 'iconRight' => 'right arrow'])
+\Atk4\Ui\Button::addTo($app, ['Learn about User Actions', 'class.huge basic primary fluid' => true, 'iconRight' => 'right arrow'])
     ->link('tutorial/actions.php');

--- a/demos/init-app.php
+++ b/demos/init-app.php
@@ -177,7 +177,7 @@ if ($layout instanceof \Atk4\Ui\Layout\NavigableInterface) {
     $layout->addMenuItem('Recursive Views', [$path . 'recursive'], $menu);
 
     // view demo source page on Github
-    \Atk4\Ui\Button::addTo($layout->menu->addItem()->addClass('aligned right'), ['View Source', 'teal', 'icon' => 'github'])
+    \Atk4\Ui\Button::addTo($layout->menu->addItem()->addClass('aligned right'), ['View Source', 'class.teal' => true, 'icon' => 'github'])
         ->on('click', $app->jsRedirect('https://github.com/atk4/ui/blob/develop/' . $relUrl, true));
 }
 unset($layout, $rootUrl, $relUrl, $demosUrl, $path, $menu);

--- a/demos/interactive/accordion-nested.php
+++ b/demos/interactive/accordion-nested.php
@@ -8,7 +8,7 @@ namespace Atk4\Ui\Demos;
 require_once __DIR__ . '/../init-app.php';
 
 /*
-\Atk4\Ui\Button::addTo($app, ['View Form input split in Accordion section', 'small right floated basic blue', 'iconRight' => 'right arrow'])
+\Atk4\Ui\Button::addTo($app, ['View Form input split in Accordion section', 'class.small right floated basic blue' => true, 'iconRight' => 'right arrow'])
     ->link(['accordion-in-form']);
 \Atk4\Ui\View::addTo($app, ['ui' => 'clearing divider']);
 */

--- a/demos/interactive/accordion.php
+++ b/demos/interactive/accordion.php
@@ -9,7 +9,7 @@ use Atk4\Ui\Form;
 /** @var \Atk4\Ui\App $app */
 require_once __DIR__ . '/../init-app.php';
 
-\Atk4\Ui\Button::addTo($app, ['Nested accordions', 'small right floated basic blue', 'iconRight' => 'right arrow'])
+\Atk4\Ui\Button::addTo($app, ['Nested accordions', 'class.small right floated basic blue' => true, 'iconRight' => 'right arrow'])
     ->link(['accordion-nested']);
 \Atk4\Ui\View::addTo($app, ['ui' => 'clearing divider']);
 

--- a/demos/interactive/card-action.php
+++ b/demos/interactive/card-action.php
@@ -10,7 +10,7 @@ use Atk4\Ui\Button;
 /** @var \Atk4\Ui\App $app */
 require_once __DIR__ . '/../init-app.php';
 
-\Atk4\Ui\Button::addTo($app, ['Card', 'small left floated basic blue', 'icon' => 'left arrow'])
+\Atk4\Ui\Button::addTo($app, ['Card', 'class.small left floated basic blue' => true, 'icon' => 'left arrow'])
     ->link(['card']);
 \Atk4\Ui\View::addTo($app, ['ui' => 'ui clearing divider']);
 

--- a/demos/interactive/card.php
+++ b/demos/interactive/card.php
@@ -7,7 +7,7 @@ namespace Atk4\Ui\Demos;
 /** @var \Atk4\Ui\App $app */
 require_once __DIR__ . '/../init-app.php';
 
-\Atk4\Ui\Button::addTo($app, ['Card Model', 'small right floated basic blue', 'iconRight' => 'right arrow'])
+\Atk4\Ui\Button::addTo($app, ['Card Model', 'class.small right floated basic blue' => true, 'iconRight' => 'right arrow'])
     ->link(['card-action']);
 \Atk4\Ui\View::addTo($app, ['ui' => 'ui clearing divider']);
 

--- a/demos/interactive/console.php
+++ b/demos/interactive/console.php
@@ -90,7 +90,7 @@ $tab = $tabs->addTab('composer update', function ($tab) {
     $message = \Atk4\Ui\Message::addTo($tab, ['This demo may not work', 'type' => 'warning']);
     $message->text->addParagraph('This demo requires you to have "bash" and "composer" installed and may display error if the process running PHP does not have write access to the "vendor" folder and "composer.*".');
 
-    $button = \Atk4\Ui\Button::addTo($message, ['I understand, proceed anyway', 'primary big']);
+    $button = \Atk4\Ui\Button::addTo($message, ['I understand, proceed anyway', 'class.primary big' => true]);
 
     $console = \Atk4\Ui\Console::addTo($tab, ['event' => false]);
     $console->exec('bash', ['-c', 'cd ../..; echo "Running \'composer update\' in `pwd`"; composer --no-ansi update; echo "Self-updated. OK to refresh now!"']);

--- a/demos/interactive/console.php
+++ b/demos/interactive/console.php
@@ -60,7 +60,7 @@ $tab = $tabs->addTab('exec() single', function ($tab) {
         'Command execution',
         'subHeader' => 'it is easy to run server-side commands and stream output through console',
     ]);
-    $message = \Atk4\Ui\Message::addTo($tab, ['This demo may not work', 'warning']);
+    $message = \Atk4\Ui\Message::addTo($tab, ['This demo may not work', 'type' => 'warning']);
     $message->text->addParagraph('This demo requires Linux OS and will display error otherwise.');
     \Atk4\Ui\Console::addTo($tab)->exec('/bin/pwd');
 });
@@ -71,7 +71,7 @@ $tab = $tabs->addTab('exec() chain', function ($tab) {
         'Command execution',
         'subHeader' => 'it is easy to run server-side commands and stream output through console',
     ]);
-    $message = \Atk4\Ui\Message::addTo($tab, ['This demo may not work', 'warning']);
+    $message = \Atk4\Ui\Message::addTo($tab, ['This demo may not work', 'type' => 'warning']);
     $message->text->addParagraph('This demo requires Linux OS and will display error otherwise.');
     \Atk4\Ui\Console::addTo($tab)->set(function ($console) {
         $console->exec('/sbin/ping', ['-c', '5', '-i', '1', '192.168.0.1']);
@@ -87,7 +87,7 @@ $tab = $tabs->addTab('composer update', function ($tab) {
         'subHeader' => 'it is easy to run server-side commands and stream output through console',
     ]);
 
-    $message = \Atk4\Ui\Message::addTo($tab, ['This demo may not work', 'warning']);
+    $message = \Atk4\Ui\Message::addTo($tab, ['This demo may not work', 'type' => 'warning']);
     $message->text->addParagraph('This demo requires you to have "bash" and "composer" installed and may display error if the process running PHP does not have write access to the "vendor" folder and "composer.*".');
 
     $button = \Atk4\Ui\Button::addTo($message, ['I understand, proceed anyway', 'primary big']);

--- a/demos/interactive/loader.php
+++ b/demos/interactive/loader.php
@@ -7,7 +7,7 @@ namespace Atk4\Ui\Demos;
 /** @var \Atk4\Ui\App $app */
 require_once __DIR__ . '/../init-app.php';
 
-\Atk4\Ui\Button::addTo($app, ['Loader Examples - Page 2', 'small right floated basic blue', 'iconRight' => 'right arrow'])
+\Atk4\Ui\Button::addTo($app, ['Loader Examples - Page 2', 'class.small right floated basic blue' => true, 'iconRight' => 'right arrow'])
     ->link(['loader2']);
 
 \Atk4\Ui\View::addTo($app, ['ui' => 'clearing divider']);
@@ -44,8 +44,8 @@ ViewTester::addTo($app);
     });
 
     // button may contain load event.
-    \Atk4\Ui\Button::addTo($p, ['Load Segment Manually (2s)', 'red'])->js('click', $loader->jsLoad(['color' => 'red']));
-    \Atk4\Ui\Button::addTo($p, ['Load Segment Manually (2s)', 'blue'])->js('click', $loader->jsLoad(['color' => 'blue']));
+    \Atk4\Ui\Button::addTo($p, ['Load Segment Manually (2s)', 'class.red' => true])->js('click', $loader->jsLoad(['color' => 'red']));
+    \Atk4\Ui\Button::addTo($p, ['Load Segment Manually (2s)', 'class.blue' => true])->js('click', $loader->jsLoad(['color' => 'blue']));
 });
 
 // Example 2 - Loader with custom body.
@@ -54,7 +54,7 @@ ViewTester::addTo($app);
     'shim' => [   // shim is displayed while content is leaded
         \Atk4\Ui\Message::class,
         'Generating LoremIpsum, please wait...',
-        'red',
+        'class.red' => true,
     ],
 ])->set(function ($p) {
     usleep(500_000);

--- a/demos/interactive/loader2.php
+++ b/demos/interactive/loader2.php
@@ -7,7 +7,7 @@ namespace Atk4\Ui\Demos;
 /** @var \Atk4\Ui\App $app */
 require_once __DIR__ . '/../init-app.php';
 
-\Atk4\Ui\Button::addTo($app, ['Loader Example - page 1', 'small left floated basic blue', 'icon' => 'left arrow'])
+\Atk4\Ui\Button::addTo($app, ['Loader Example - page 1', 'class.small left floated basic blue' => true, 'icon' => 'left arrow'])
     ->link(['loader']);
 \Atk4\Ui\View::addTo($app, ['ui' => 'ui clearing divider']);
 

--- a/demos/interactive/modal.php
+++ b/demos/interactive/modal.php
@@ -185,7 +185,7 @@ $stepModal->set(function ($modal) use ($stepModal, $session, $prevAction, $nextA
         $modelRegister = new \Atk4\Data\Model(new Persistence\Array_());
         $modelRegister->addField('name', ['caption' => 'Please enter your name (John)']);
 
-        $form = \Atk4\Ui\Form::addTo($modal, ['segment' => true]);
+        $form = \Atk4\Ui\Form::addTo($modal, ['class.segment' => true]);
         $form->setModel($modelRegister->createEntity());
 
         $form->onSubmit(function (\Atk4\Ui\Form $form) use ($nextAction, $session) {

--- a/demos/interactive/modal.php
+++ b/demos/interactive/modal.php
@@ -186,7 +186,7 @@ $stepModal->set(function ($modal) use ($stepModal, $session, $prevAction, $nextA
         $modelRegister->addField('name', ['caption' => 'Please enter your name (John)']);
 
         $form = \Atk4\Ui\Form::addTo($modal, ['segment' => true]);
-        $form->setModel($modelRegister);
+        $form->setModel($modelRegister->createEntity());
 
         $form->onSubmit(function (\Atk4\Ui\Form $form) use ($nextAction, $session) {
             if ($form->model->get('name') !== 'John') {

--- a/demos/interactive/modal.php
+++ b/demos/interactive/modal.php
@@ -149,7 +149,7 @@ $stepModal->setOption('observeChanges', true);
 
 // Add buttons to modal for next and previous actions.
 $action = new \Atk4\Ui\View(['ui' => 'buttons']);
-$prevAction = new \Atk4\Ui\Button(['Prev', 'labeled', 'icon' => 'left arrow']);
+$prevAction = new \Atk4\Ui\Button(['Prev', 'class.labeled' => true, 'icon' => 'left arrow']);
 $nextAction = new \Atk4\Ui\Button(['Next', 'iconRight' => 'right arrow']);
 
 $action->add($prevAction);

--- a/demos/interactive/popup.php
+++ b/demos/interactive/popup.php
@@ -181,7 +181,7 @@ $cart->destroy();
 
 // Label now can be added referencing Cart's items. Init() was colled when I added it into app, so the
 // item property is populated.
-$cartOutterLabel = \Atk4\Ui\Label::addTo($cartItem, [count($cart->items), 'floating red ']);
+$cartOutterLabel = \Atk4\Ui\Label::addTo($cartItem, [count($cart->items), 'class.floating red' => true]);
 if (!$cart->items) {
     $cartOutterLabel->addStyle('display', 'none');
 }
@@ -195,7 +195,7 @@ $cartPopup->set(function ($popup) use ($cart) {
 
     $cartInnerLabel->detail = count($cart->items);
     \Atk4\Ui\Item::addTo($popup)->setElement('hr');
-    \Atk4\Ui\Button::addTo($popup, ['Checkout', 'primary small']);
+    \Atk4\Ui\Button::addTo($popup, ['Checkout', 'class.primary small' => true]);
 });
 
 // Add item shelf below menu and link it with the cart
@@ -231,7 +231,7 @@ $signup->set(function ($pop) {
     // contetn of the popup will be different depending on this condition.
     if (isset($_GET['logged'])) {
         \Atk4\Ui\Message::addTo($pop, ['You are already logged in as ' . $_GET['logged']]);
-        \Atk4\Ui\Button::addTo($pop, ['Logout', 'primary', 'icon' => 'sign out'])
+        \Atk4\Ui\Button::addTo($pop, ['Logout', 'class.primary' => true, 'icon' => 'sign out'])
             ->link($pop->getApp()->url());
     } else {
         $form = Form::addTo($pop);
@@ -257,7 +257,7 @@ $signup->set(function ($pop) {
 
 \Atk4\Ui\Header::addTo($app)->set('Specifying trigger');
 
-$button = \Atk4\Ui\Button::addTo($app, ['Click Me', 'primary']);
+$button = \Atk4\Ui\Button::addTo($app, ['Click Me', 'class.primary' => true]);
 
 $buttonPopup = Popup::addTo($app, [$button]);
 

--- a/demos/interactive/popup.php
+++ b/demos/interactive/popup.php
@@ -272,4 +272,4 @@ View::addTo($inputPopup)->set('You can use this field to search data.');
 $button = \Atk4\Ui\Button::addTo($app, [null, 'icon' => 'volume down']);
 $buttonPopup = Popup::addTo($app, [$button, 'triggerOn' => 'hover'])->setHoverable();
 
-Form\Control\Checkbox::addTo($buttonPopup, ['Just On/Off', 'slider'])->on('change', $button->js()->find('.icon')->toggleClass('up down'));
+Form\Control\Checkbox::addTo($buttonPopup, ['Just On/Off', 'class.slider' => true])->on('change', $button->js()->find('.icon')->toggleClass('up down'));

--- a/demos/interactive/progress.php
+++ b/demos/interactive/progress.php
@@ -12,6 +12,6 @@ require_once __DIR__ . '/../init-app.php';
 
 $p = \Atk4\Ui\ProgressBar::addTo($app, [20]);
 
-$p = \Atk4\Ui\ProgressBar::addTo($app, [60, 'indicating progress', 'indicating']);
+$p = \Atk4\Ui\ProgressBar::addTo($app, [60, 'indicating progress', 'class.indicating' => true]);
 \Atk4\Ui\Button::addTo($app, ['increment'])->on('click', $p->jsIncrement());
 \Atk4\Ui\Button::addTo($app, ['set'])->on('click', $p->jsValue(20));

--- a/demos/interactive/scroll-container.php
+++ b/demos/interactive/scroll-container.php
@@ -9,9 +9,9 @@ use Atk4\Ui\HtmlTemplate;
 /** @var \Atk4\Ui\App $app */
 require_once __DIR__ . '/../init-app.php';
 
-\Atk4\Ui\Button::addTo($app, ['Dynamic scroll in Table', 'small left floated basic blue', 'icon' => 'left arrow'])
+\Atk4\Ui\Button::addTo($app, ['Dynamic scroll in Table', 'class.small left floated basic blue' => true, 'icon' => 'left arrow'])
     ->link(['scroll-table']);
-\Atk4\Ui\Button::addTo($app, ['Dynamic scroll in Grid', 'small right floated basic blue', 'iconRight' => 'right arrow'])
+\Atk4\Ui\Button::addTo($app, ['Dynamic scroll in Grid', 'class.small right floated basic blue' => true, 'iconRight' => 'right arrow'])
     ->link(['scroll-grid']);
 \Atk4\Ui\View::addTo($app, ['ui' => 'ui clearing divider']);
 

--- a/demos/interactive/scroll-grid-container.php
+++ b/demos/interactive/scroll-grid-container.php
@@ -22,7 +22,7 @@ $g1->setModel($m1);
 $g1->addQuickSearch([Country::hinting()->fieldName()->name, Country::hinting()->fieldName()->iso]);
 
 // demo for additional action buttons in Crud + JsPaginator
-$g1->addModalAction(['icon' => [\Atk4\Ui\Icon::class, 'cogs']], 'Details', function ($p, $id) use ($g1) {
+$g1->addModalAction(['icon' => 'cogs'], 'Details', function ($p, $id) use ($g1) {
     \Atk4\Ui\Card::addTo($p)->setModel($g1->model->load($id));
 });
 $g1->addActionButton('red', function ($js) {

--- a/demos/interactive/scroll-grid-container.php
+++ b/demos/interactive/scroll-grid-container.php
@@ -7,7 +7,7 @@ namespace Atk4\Ui\Demos;
 /** @var \Atk4\Ui\App $app */
 require_once __DIR__ . '/../init-app.php';
 
-\Atk4\Ui\Button::addTo($app, ['Dynamic scroll in Crud and Grid', 'small left floated basic blue', 'icon' => 'left arrow'])
+\Atk4\Ui\Button::addTo($app, ['Dynamic scroll in Crud and Grid', 'class.small left floated basic blue' => true, 'icon' => 'left arrow'])
     ->link(['scroll-grid']);
 \Atk4\Ui\View::addTo($app, ['ui' => 'ui clearing divider']);
 

--- a/demos/interactive/scroll-grid.php
+++ b/demos/interactive/scroll-grid.php
@@ -7,9 +7,9 @@ namespace Atk4\Ui\Demos;
 /** @var \Atk4\Ui\App $app */
 require_once __DIR__ . '/../init-app.php';
 
-\Atk4\Ui\Button::addTo($app, ['Dynamic scroll in Container', 'small left floated basic blue', 'icon' => 'left arrow'])
+\Atk4\Ui\Button::addTo($app, ['Dynamic scroll in Container', 'class.small left floated basic blue' => true, 'icon' => 'left arrow'])
     ->link(['scroll-container']);
-\Atk4\Ui\Button::addTo($app, ['Dynamic scroll in Grid using Container', 'small right floated basic blue', 'iconRight' => 'right arrow'])
+\Atk4\Ui\Button::addTo($app, ['Dynamic scroll in Grid using Container', 'class.small right floated basic blue' => true, 'iconRight' => 'right arrow'])
     ->link(['scroll-grid-container']);
 \Atk4\Ui\View::addTo($app, ['ui' => 'ui clearing divider']);
 

--- a/demos/interactive/scroll-lister.php
+++ b/demos/interactive/scroll-lister.php
@@ -9,7 +9,7 @@ use Atk4\Ui\HtmlTemplate;
 /** @var \Atk4\Ui\App $app */
 require_once __DIR__ . '/../init-app.php';
 
-\Atk4\Ui\Button::addTo($app, ['Dynamic scroll in Table', 'small right floated basic blue', 'iconRight' => 'right arrow'])
+\Atk4\Ui\Button::addTo($app, ['Dynamic scroll in Table', 'class.small right floated basic blue' => true, 'iconRight' => 'right arrow'])
     ->link(['scroll-table']);
 \Atk4\Ui\View::addTo($app, ['ui' => 'ui clearing divider']);
 

--- a/demos/interactive/scroll-table.php
+++ b/demos/interactive/scroll-table.php
@@ -7,9 +7,9 @@ namespace Atk4\Ui\Demos;
 /** @var \Atk4\Ui\App $app */
 require_once __DIR__ . '/../init-app.php';
 
-\Atk4\Ui\Button::addTo($app, ['Dynamic scroll in Lister', 'small left floated basic blue', 'icon' => 'left arrow'])
+\Atk4\Ui\Button::addTo($app, ['Dynamic scroll in Lister', 'class.small left floated basic blue' => true, 'icon' => 'left arrow'])
     ->link(['scroll-lister']);
-\Atk4\Ui\Button::addTo($app, ['Dynamic scroll in Container', 'small right floated basic blue', 'iconRight' => 'right arrow'])
+\Atk4\Ui\Button::addTo($app, ['Dynamic scroll in Container', 'class.small right floated basic blue' => true, 'iconRight' => 'right arrow'])
     ->link(['scroll-container']);
 \Atk4\Ui\View::addTo($app, ['ui' => 'ui clearing divider']);
 

--- a/demos/interactive/tabs.php
+++ b/demos/interactive/tabs.php
@@ -41,7 +41,7 @@ $tabs->addTab('Modal popup', function ($tab) {
 
 // dynamic tab
 $tabs->addTab('Dynamic Form', function ($tab) {
-    \Atk4\Ui\Message::addTo($tab, ['It takes 2 seconds for this tab to load', 'warning']);
+    \Atk4\Ui\Message::addTo($tab, ['It takes 2 seconds for this tab to load', 'type' => 'warning']);
     sleep(2);
     $modelRegister = new \Atk4\Data\Model(new Persistence\Array_());
     $modelRegister->addField('name', ['caption' => 'Please enter your name (John)']);

--- a/demos/interactive/tabs.php
+++ b/demos/interactive/tabs.php
@@ -46,7 +46,7 @@ $tabs->addTab('Dynamic Form', function ($tab) {
     $modelRegister = new \Atk4\Data\Model(new Persistence\Array_());
     $modelRegister->addField('name', ['caption' => 'Please enter your name (John)']);
 
-    $form = \Atk4\Ui\Form::addTo($tab, ['segment' => true]);
+    $form = \Atk4\Ui\Form::addTo($tab, ['class.segment' => true]);
     $form->setModel($modelRegister->createEntity());
     $form->onSubmit(function (\Atk4\Ui\Form $form) {
         if ($form->model->get('name') !== 'John') {

--- a/demos/interactive/wizard.php
+++ b/demos/interactive/wizard.php
@@ -51,7 +51,7 @@ $wizard->addStep(['Select Model', 'description' => '"Country" or "Stat"', 'icon'
     $columns = \Atk4\Ui\Columns::addTo($wizard);
 
     $grid = \Atk4\Ui\Grid::addTo($columns->addColumn(), ['paginator' => false, 'menu' => false]);
-    \Atk4\Ui\Message::addTo($columns->addColumn(), ['Information', 'info'])->text
+    \Atk4\Ui\Message::addTo($columns->addColumn(), ['Information', 'type' => 'info'])->text
         ->addParagraph('Selecting which model you would like to import into your DSN. If corresponding table already exist, we might add extra fields into it. No tables, columns or rows will be deleted.');
 
     $grid->setSource(['Country', 'Stat']);
@@ -92,5 +92,5 @@ $wizard->addStep(['Migration', 'description' => 'Create or update table', 'icon'
 // because you shouldn't be able to navigate wizard back without restarting it.
 // Only one finish can be added.
 $wizard->addFinish(function (Wizard $wizard) {
-    \Atk4\Ui\Header::addTo($wizard, ['You are DONE', 'huge centered']);
+    \Atk4\Ui\Header::addTo($wizard, ['You are DONE', 'class.huge centered' => true]);
 });

--- a/demos/layout/layouts_admin.php
+++ b/demos/layout/layouts_admin.php
@@ -36,7 +36,7 @@ $layout->template->set('Footer', 'ATK is awesome');
 
 \Atk4\Ui\Header::addTo($layout, ['Basic Form Example']);
 
-$form = \Atk4\Ui\Form::addTo($layout, ['segment']);
+$form = \Atk4\Ui\Form::addTo($layout, ['class.segment' => true]);
 $form->setModel((new \Atk4\Data\Model())->createEntity());
 
 $formGroup = $form->addGroup('Name');

--- a/demos/layout/layouts_admin.php
+++ b/demos/layout/layouts_admin.php
@@ -14,7 +14,7 @@ $menu->addItem(\Atk4\Ui\Layout\Centered::class);
 $menu->addItem(\Atk4\Ui\Layout\Admin::class);
 
 $menuRight = $layout->menuRight;
-$menuRight->addItem(['Warning', 'red', 'icon' => 'red warning']);
+$menuRight->addItem(['Warning', 'class.red' => true, 'icon' => 'red warning']);
 $menuUser = $menuRight->addMenu('John Smith');
 $menuUser->addItem('Profile');
 $menuUser->addDivider();

--- a/demos/obsolete/notify.php
+++ b/demos/obsolete/notify.php
@@ -7,7 +7,7 @@ namespace Atk4\Ui\Demos;
 /** @var \Atk4\Ui\App $app */
 require_once __DIR__ . '/../init-app.php';
 
-\Atk4\Ui\Button::addTo($app, ['Notify Examples - Page 2', 'small right floated basic blue', 'iconRight' => 'right arrow'])
+\Atk4\Ui\Button::addTo($app, ['Notify Examples - Page 2', 'class.small right floated basic blue' => true, 'iconRight' => 'right arrow'])
     ->link(['notify2']);
 
 \Atk4\Ui\Button::addTo($app, ['Test'])->on('click', (new \Atk4\Ui\JsNotify('Not yet implemented'))->setColor('red'));

--- a/demos/obsolete/notify2.php
+++ b/demos/obsolete/notify2.php
@@ -28,7 +28,7 @@ $notifierClass = AnonymousClassNameCache::get_class(fn () => new class() extends
  // Notification type form
 $head = \Atk4\Ui\Header::addTo($app, ['Notification Types']);
 
-$form = \Atk4\Ui\Form::addTo($app, ['segment']);
+$form = \Atk4\Ui\Form::addTo($app, ['class.segment' => true]);
 // Unit test only.
 $form->cb->setUrlTrigger('test_notify');
 

--- a/demos/obsolete/notify2.php
+++ b/demos/obsolete/notify2.php
@@ -32,7 +32,7 @@ $form = \Atk4\Ui\Form::addTo($app, ['class.segment' => true]);
 // Unit test only.
 $form->cb->setUrlTrigger('test_notify');
 
-\Atk4\Ui\Label::addTo($form, ['Some of notification options that can be set.', 'top attached'], ['AboveControls']);
+\Atk4\Ui\Label::addTo($form, ['Some of notification options that can be set.', 'class.top attached' => true], ['AboveControls']);
 $form->buttonSave->set('Show');
 $form->setModel((new $notifierClass($app->db))->createEntity(), []);
 

--- a/demos/others/recursive.php
+++ b/demos/others/recursive.php
@@ -13,7 +13,7 @@ $mySwitcherClass = AnonymousClassNameCache::get_class(fn () => new class() exten
     {
         parent::init();
 
-        \Atk4\Ui\Header::addTo($this, ['My name is ' . $this->name, 'red']);
+        \Atk4\Ui\Header::addTo($this, ['My name is ' . $this->name, 'class.red' => true]);
 
         $buttons = \Atk4\Ui\View::addTo($this, ['ui' => 'basic buttons']);
         \Atk4\Ui\Button::addTo($buttons, ['Yellow'])->setAttr('data-id', 'yellow');

--- a/demos/others/sticky2.php
+++ b/demos/others/sticky2.php
@@ -19,7 +19,7 @@ if (isset($_GET['name'])) {
     \Atk4\Ui\Label::addTo($frame, ['Name:', 'detail' => $_GET['name'], 'black'])->link($frame->url());
 
     // app still generates URL without localized sticky
-    \Atk4\Ui\Label::addTo($frame, ['Reset', 'iconRight' => 'close', 'black'])->link($app->url());
+    \Atk4\Ui\Label::addTo($frame, ['Reset', 'iconRight' => 'close', 'class.black' => true])->link($app->url());
     \Atk4\Ui\View::addTo($frame, ['ui' => 'hidden divider']);
 
     // nested interractive elemetns will respect lockal sticky get

--- a/demos/tutorial/actions.php
+++ b/demos/tutorial/actions.php
@@ -211,6 +211,6 @@ $wizard->addStep('Crud integration', function ($page) {
 
 $wizard->addFinish(function ($page) use ($wizard) {
     PromotionText::addTo($page);
-    \Atk4\Ui\Button::addTo($wizard, ['Exit demo', 'primary', 'icon' => 'left arrow'], ['Left'])
+    \Atk4\Ui\Button::addTo($wizard, ['Exit demo', 'class.primary' => true, 'icon' => 'left arrow'], ['Left'])
         ->link('/demos/index.php');
 });

--- a/demos/tutorial/intro.php
+++ b/demos/tutorial/intro.php
@@ -229,6 +229,6 @@ $wizard->addStep('Persistence', function ($page) {
 
 $wizard->addFinish(function ($page) use ($wizard) {
     PromotionText::addTo($page);
-    \Atk4\Ui\Button::addTo($wizard, ['Exit demo', 'primary', 'icon' => 'left arrow'], ['Left'])
+    \Atk4\Ui\Button::addTo($wizard, ['Exit demo', 'class.primary' => true, 'icon' => 'left arrow'], ['Left'])
         ->link('/demos/index.php');
 });

--- a/docs/app.rst
+++ b/docs/app.rst
@@ -423,7 +423,7 @@ Populating the left menu object is simply a matter of adding the right menu item
 
 This is the top menu of the admin layout. You can add other item to the top menu using::
 
-    Button::addTo($layout->menu->addItem(), ['View Source', 'teal', 'icon' => 'github'])
+    Button::addTo($layout->menu->addItem(), ['View Source', 'class.teal' => true, 'icon' => 'github'])
         ->setAttr('target', '_blank')->on('click', new \Atk4\Ui\JsExpression('document.location=[];', [$url . $f]));
 
 .. php:attr:: menuRight

--- a/docs/app.rst
+++ b/docs/app.rst
@@ -92,8 +92,8 @@ active. (See :ref:`system_pattern`)::
             // Make sure user is valid
             if (!$this->user->isLoaded()) {
                 $this->initLayout([\Atk4\Ui\Layout\Centered::class]);
-                Message::addTo($this, ['Login Required', 'error']);
-                Button::addTo($this, ['Login', 'primary'])->link('index.php');
+                Message::addTo($this, ['Login Required', 'type' => 'error']);
+                Button::addTo($this, ['Login', 'class.primary' => true])->link('index.php');
                 exit;
             }
 

--- a/docs/autocomplete.rst
+++ b/docs/autocomplete.rst
@@ -68,7 +68,7 @@ use of Filters::
 
 
     $form = \Atk4\Ui\Form::addTo($app, ['class.segment' => true]);
-    \Atk4\Ui\Label::addTo($form, ['Add city', 'top attached'], ['AboveControls']);
+    \Atk4\Ui\Label::addTo($form, ['Add city', 'class.top attached' => true], ['AboveControls']);
 
     $l = $form->addControl('city',[\Atk4\Ui\Form\Control\Lookup::class]);
 

--- a/docs/autocomplete.rst
+++ b/docs/autocomplete.rst
@@ -67,7 +67,7 @@ In 1.6 we have introduced Lookup form control, which is identical to AutoComplet
 use of Filters::
 
 
-    $form = \Atk4\Ui\Form::addTo($app, ['segment']);
+    $form = \Atk4\Ui\Form::addTo($app, ['class.segment' => true]);
     \Atk4\Ui\Label::addTo($form, ['Add city', 'top attached'], ['AboveControls']);
 
     $l = $form->addControl('city',[\Atk4\Ui\Form\Control\Lookup::class]);

--- a/docs/button.rst
+++ b/docs/button.rst
@@ -37,11 +37,11 @@ Button Icon
 
 Property $icon will place icon on your button and can be specified in one of the following two ways::
 
-    $button = Button::addTo($app, ['Like', 'blue', 'icon' => 'thumbs up']);
+    $button = Button::addTo($app, ['Like', 'class.blue' => true, 'icon' => 'thumbs up']);
 
     // or
 
-    $button = Button::addTo($app, ['Like', 'blue', 'icon' => new Icon('thumbs up')]);
+    $button = Button::addTo($app, ['Like', 'class.blue' => true, 'icon' => new Icon('thumbs up')]);
 
 or if you prefer initializing objects::
 
@@ -120,7 +120,7 @@ Knowledge of the Fomantic UI button (https://fomantic-ui.com/elements/button.htm
 in creating more complex buttons::
 
     $forks = new Button(['labeled' => true]); // Button, not Buttons!
-    Icon::addTo(Button::addTo($forks, ['Forks', 'blue']), ['fork']);
-    Label::addTo($forks, ['1,048', 'basic blue left pointing']);
+    Icon::addTo(Button::addTo($forks, ['Forks', 'class.blue' => true]), ['fork']);
+    Label::addTo($forks, ['1,048', 'class.basic blue left pointing' => true]);
     $app->add($forks);
 

--- a/docs/dataexecutor.rst
+++ b/docs/dataexecutor.rst
@@ -233,8 +233,8 @@ Example of changing button for Card, Crud and Modal executor globally within you
     {
         protected static $actionTriggerSeed = [
             self::MODAL_BUTTON => [
-                'edit' => [Button::class, 'Save', 'green'],
-                'add' => [Button::class, 'Save', 'green'],
+                'edit' => [Button::class, 'Save', 'class.green' => true],
+                'add' => [Button::class, 'Save', 'class.green' => true],
             ],
             self::TABLE_BUTTON => [
                 'edit' => [Button::class, null, 'icon' => 'pencil'],

--- a/docs/form-control.rst
+++ b/docs/form-control.rst
@@ -228,7 +228,7 @@ Here are few ways to specify `icon` to an Input::
 
     // Type-hinting friendly
     $line = new \Atk4\Ui\Form\Control\Line();
-    $line->icon='search';
+    $line->icon = 'search';
     $page->add($line);
 
     // using class factory
@@ -239,7 +239,7 @@ be automatically substituted with `new Icon($icon)`. If you wish to be more spec
 and pass some arguments to the icon, there are two options::
 
     // compact
-    $line->icon=['search', 'big'];
+    $line->icon = ['search', 'big'];
 
     // Type-hinting friendly
     $line->icon = new Icon('search');

--- a/docs/form-control.rst
+++ b/docs/form-control.rst
@@ -239,13 +239,13 @@ be automatically substituted with `new Icon($icon)`. If you wish to be more spec
 and pass some arguments to the icon, there are two options::
 
     // compact
-    $line->icon = ['search', 'big'];
+    $line->icon = ['search', 'class.big' => true];
 
     // Type-hinting friendly
     $line->icon = new Icon('search');
     $line->icon->addClass('big');
 
-To see how Icon interprets `new Icon(['search', 'big'])`, refer to :php:class:`Icon`.
+To see how Icon interprets `new Icon(['search', 'class.big' => true])`, refer to :php:class:`Icon`.
 
 .. note::
 

--- a/docs/form.rst
+++ b/docs/form.rst
@@ -771,7 +771,7 @@ Here is a more advanced example::
 
     $f_sub = Form::addTo($app);
     $f_sub->addControl('name');
-    $f_sub->addControl('subscribe', [\Atk4\Ui\Form\Control\Checkbox::class, 'Subscribe to weekly newsletter', 'toggle']);
+    $f_sub->addControl('subscribe', [\Atk4\Ui\Form\Control\Checkbox::class, 'Subscribe to weekly newsletter', 'class.toggle' => true]);
     $f_sub->addControl('email');
     $f_sub->addControl('gender', [\Atk4\Ui\Form\Control\Radio::class], ['enum' => ['Female', 'Male']])->set('Female');
     $f_sub->addControl('m_gift', [\Atk4\Ui\Form\Control\Dropdown::class, 'caption' => 'Gift for Men', 'values' => ['Beer Glass', 'Swiss Knife']]);

--- a/docs/form.rst
+++ b/docs/form.rst
@@ -718,7 +718,7 @@ Fomantic UI Modifiers
 There are many other classes Fomantic UI allow you to use on a form. The next code will produce
 form inside a segment (outline) and will make form controls appear smaller::
 
-    $form = new \Atk4\Ui\Form(['small segment']));
+    $form = new \Atk4\Ui\Form(['class.small segment' => true]));
 
 For further styling see documentation on :php:class:`View`.
 
@@ -809,7 +809,7 @@ Hiding / Showing group of field
 
 Instead of defining rules for form controls individually you can hide/show entire group::
 
-    $f_group = Form::addTo($app, ['segment']);
+    $f_group = Form::addTo($app, ['class.segment' => true]);
     Label::addTo($f_group, ['Work on form group too.', 'top attached'], ['AboveControls']);
 
     $g_basic = $f_group->addGroup(['Basic Information']);

--- a/docs/form.rst
+++ b/docs/form.rst
@@ -65,7 +65,7 @@ Even if model not explicitly set (see section below) each form has an underlying
 
 	// or multiple fields
 	$form->model->set([
-		'name'	=> 'John',
+		'name' => 'John',
 		'email' => 'some@email.com',
 	]);
 
@@ -810,7 +810,7 @@ Hiding / Showing group of field
 Instead of defining rules for form controls individually you can hide/show entire group::
 
     $f_group = Form::addTo($app, ['class.segment' => true]);
-    Label::addTo($f_group, ['Work on form group too.', 'top attached'], ['AboveControls']);
+    Label::addTo($f_group, ['Work on form group too.', 'class.top attached' => true], ['AboveControls']);
 
     $g_basic = $f_group->addGroup(['Basic Information']);
     $g_basic->addControl('first_name', ['width' => 'eight']);

--- a/docs/header.rst
+++ b/docs/header.rst
@@ -62,7 +62,7 @@ Here you can also specify seed for the image::
     Header::addTo($seg, [
         'Center-aligned header',
         'aligned' => 'center',
-        'image' => [$img, 'disabled'],
+        'image' => [$img, 'class.disabled' => true],
         'subHeader' => 'header with image',
     ]);
 

--- a/docs/icon.rst
+++ b/docs/icon.rst
@@ -34,9 +34,9 @@ https://fomantic-ui.com/elements/icon.html
 
 You can also use States, Variations by passing classes to your button::
 
-    Button::addTo($app, ['Click Me', 'red', 'icon' => 'flipped big question']);
+    Button::addTo($app, ['Click Me', 'class.red' => true, 'icon' => 'flipped big question']);
 
-    Label::addTo($app, ['Battery Low', 'green', 'icon' => 'battery low']);
+    Label::addTo($app, ['Battery Low', 'class.green' => true, 'icon' => 'battery low']);
 
 .. _icon_other_comp:
 
@@ -47,15 +47,15 @@ You can use icon on the following components: :php:class:`Button`, :php:class:`L
 :php:class:`Message`, :php:class:`Menu` and possibly some others. Here are some examples::
 
 
-    Header::addTo($app, ['Header', 'red', 'icon' => 'flipped question']);
-    Button::addTo($app, ['Button', 'red', 'icon' => 'flipped question']);
+    Header::addTo($app, ['Header', 'class.red' => true, 'icon' => 'flipped question']);
+    Button::addTo($app, ['Button', 'class.red' => true, 'icon' => 'flipped question']);
 
     $menu = Menu::addTo($app);
     $menu->addItem(['Menu Item', 'icon' => 'flipped question']);
     $sub_menu = $menu->addMenu(['Sub-menu', 'icon' => 'flipped question']);
     $sub_menu->addItem(['Sub Item', 'icon' => 'flipped question']);
 
-    Label::addTo($app, ['Label', 'right ribbon red', 'icon' => 'flipped question']);
+    Label::addTo($app, ['Label', 'class.right ribbon red' => true, 'icon' => 'flipped question']);
 
 
 
@@ -95,7 +95,7 @@ Composing
 
 Composing offers you another way to deal with Group icons::
 
-    $no_users = new \Atk4\Ui\View([null, 'huge icons', 'element' => 'i']);
+    $no_users = new \Atk4\Ui\View(['class.huge icons' => true, 'element' => 'i']);
     Icon::addTo($no_users, ['big red dont']);
     Icon::addTo($no_users, ['black user icon']);
 

--- a/docs/image.rst
+++ b/docs/image.rst
@@ -26,5 +26,5 @@ Specify classes
 You can pass additional classes to an image::
 
     $img = $app->cdn['atk'] . '/logo.png';
-    $icon = Image::addTo($app, [$img, 'disabled']);
+    $icon = Image::addTo($app, [$img, 'class.disabled' => true]);
 

--- a/docs/label.rst
+++ b/docs/label.rst
@@ -80,9 +80,9 @@ Groups
 Label can be part of the group, but you would need to either use custom HTML template or
 composition::
 
-    $group = View::addTo($app, [false, 'blue tag', 'ui' => 'labels']);
+    $group = View::addTo($app, [false, 'class.blue tag' => true, 'ui' => 'labels']);
     Label::addTo($group, ['$9.99']);
-    Label::addTo($group, ['$19.99', 'red tag']);
+    Label::addTo($group, ['$19.99', 'class.red tag' => true]);
     Label::addTo($group, ['$24.99']);
 
 Combining classes
@@ -96,10 +96,10 @@ Based on Fomantic UI documentation, you can add more classes to your labels::
     $col = View::addTo($c, ['ui' => 'raised segment']);
 
     // attach label to the top of left column
-    Label::addTo($col, ['Left Column', 'top attached', 'icon' => 'book']);
+    Label::addTo($col, ['Left Column', 'class.top attached' => true, 'icon' => 'book']);
 
     // ribbon around left column
-    Label::addTo($col, ['Lorem', 'red ribbon', 'icon' => 'cut']);
+    Label::addTo($col, ['Lorem', 'class.red ribbon' => true, 'icon' => 'cut']);
 
     // add some content inside column
     LoremIpsum::addTo($col, ['size' => 1]);
@@ -108,13 +108,13 @@ Based on Fomantic UI documentation, you can add more classes to your labels::
     $col = View::addTo($c, ['ui' => 'raised segment']);
 
     // attach label to the top of right column
-    Label::addTo($col, ['Right Column', 'top attached', 'icon' => 'book']);
+    Label::addTo($col, ['Right Column', 'class.top attached' => true, 'icon' => 'book']);
 
     // some content
     LoremIpsum::addTo($col, ['size' => 1]);
 
     // right bottom corner label
-    Label::addTo($col, ['Ipsum', 'orange bottom right attached', 'icon' => 'cut']);
+    Label::addTo($col, ['Ipsum', 'class.orange bottom right attached' => true, 'icon' => 'cut']);
 
 Added labels into Table
 =======================

--- a/docs/message.rst
+++ b/docs/message.rst
@@ -23,12 +23,12 @@ Implements basic image::
 
 Although typically you would want to specify what type of message is that::
 
-    $message = new \Atk4\Ui\Message(['Warning Message Title', 'warning']);
+    $message = new \Atk4\Ui\Message(['Warning Message Title', 'type' => 'warning']);
     $app->add($message);
 
 Here is the alternative syntax::
 
-    $message = Message::addTo($app, ['Warning Message Title', 'warning']);
+    $message = Message::addTo($app, ['Warning Message Title', 'type' => 'warning']);
 
 Adding message text
 ===================
@@ -53,7 +53,7 @@ You can specify icon also::
 
     $message = Message::addTo($app, [
         'Battery low',
-        'red',
+        'class.red' => true,
         'icon' => 'battery low',
     ])->text->addParagraph('Your battery is getting low. Re-charge your Web App');
 

--- a/docs/misc.rst
+++ b/docs/misc.rst
@@ -31,23 +31,23 @@ columns. This seem like a limitation of Fomantic UI::
 
     $c = Columns::addTo($page, ['width' => 4]);
     Box::addTo($c->addColumn(), ['red']);
-    Box::addTo($c->addColumn([null, 'right floated']), ['blue']);
+    Box::addTo($c->addColumn(['class.right floated' => true]), ['blue']);
 
 Rows
 ----
 
 When you add columns for a total width which is more than permitted, columns will stack below and form a second
-row. To improve and controll the flow of rows better, you can specify addRow()::
+row. To improve and control the flow of rows better, you can specify addRow()::
 
-    $c = Columns::addTo($page, ['internally celled']);
+    $c = Columns::addTo($page, ['class.internally celled' => true]);
 
     $r = $c->addRow();
-    Icon::addTo($r->addColumn([2, 'right aligned']), ['huge home']);
+    Icon::addTo($r->addColumn([2, 'class.right aligned' => true]), ['huge home']);
     LoremIpsum::addTo($r->addColumn(12), [1]);
     Icon::addTo($r->addColumn(2), ['huge trash']);
 
     $r = $c->addRow();
-    Icon::addTo($r->addColumn([2, 'right aligned']), ['huge home']);
+    Icon::addTo($r->addColumn([2, 'class.right aligned' => true]), ['huge home']);
     LoremIpsum::addTo($r->addColumn(12), [1]);
     Icon::addTo($r->addColumn(2), ['huge trash']);
 

--- a/docs/render.rst
+++ b/docs/render.rst
@@ -124,7 +124,7 @@ name. Ultimately, you can create a View that uses it's name to store some inform
             parent::init();
 
             if ($_GET[$this->name]) {
-                \Atk4\Ui\Label::addTo($this, ['Secret info is', 'big red', 'detail' => $_GET[$this->name]]);
+                \Atk4\Ui\Label::addTo($this, ['Secret info is', 'class.big red' => true, 'detail' => $_GET[$this->name]]);
             }
 
             \Atk4\Ui\Button::addTo($this, ['Send info to ourselves'])

--- a/docs/seed.rst
+++ b/docs/seed.rst
@@ -57,7 +57,7 @@ For more information about seeds, merging seeds, factories and namespaces, see h
 
 The most important points of a seed such as this one::
 
-    $seed = [Button::class, 'hello', 'big red', 'icon' => ['book', 'red']];
+    $seed = [Button::class, 'hello', 'class.big red' => true, 'icon' => ['book', 'red']];
 
 are:
 
@@ -71,13 +71,13 @@ Alternative ways to use Seed
 Some constructors may accept array as the first argument. It is also treated as a seed
 but without class (because class is already set)::
 
-    $button = new Button(['hello', 'big red', 'icon' => ['book', 'red']]);
+    $button = new Button(['hello', 'class.big red' => true, 'icon' => ['book', 'class.red' => true]]);
 
 It is alternatively possible to pass object as index 0 of the seed. In this case
 constructor is already invoked, so passing numeric values is not possible, but
 you still can pass some property values::
 
-    $seed = [new Button('hello', 'big red'), 'icon' => ['book', 'red']];
+    $seed = [new Button('hello', 'class.big red' => true), 'icon' => ['book', 'class.red' => true]];
 
 Additional cases
 ----------------

--- a/docs/table.rst
+++ b/docs/table.rst
@@ -217,7 +217,7 @@ As a final note in this section - you can re-use column objects multiple times::
     $table->addColumn($c_gap);
     $table->setModel(new Order($db), ['name', 'price', 'amount']);
     $table->addColumn($c_gap);
-    $table->addColumns(['total','status'])
+    $table->addColumns(['total', 'status'])
     $table->addColumn($c_gap);
 
 This will result in 3 gap columns rendered to the left, middle and right of your Table.

--- a/docs/tablecolumn.rst
+++ b/docs/tablecolumn.rst
@@ -194,7 +194,10 @@ If your column "status" can be one of the following "pending", "declined", "arch
 to use different icons and colors to emphasise status::
 
 
-    $states = [ 'positive' => ['paid', 'archived'], 'negative' => ['declined'] ];
+    $states = [
+        'positive' => ['paid', 'archived'],
+        'negative' => ['declined'],
+    ];
 
     $table->addColumn('status', new \Atk4\Ui\Table\Column\Status($states));
 

--- a/docs/tablecolumn.rst
+++ b/docs/tablecolumn.rst
@@ -116,7 +116,7 @@ is responsible for rendering of the TH box. If you are adding column manually, :
 will return it. When using model, use :php:meth:`Atk4\\Ui\\Table::getColumnDecorators`::
 
 
-    $table = Table::addTo($app, ['celled' => true]);
+    $table = Table::addTo($app, ['class.celled' => true]);
     $table->setModel(new Country($app->db));
 
     $name_column = $table->getColumnDecorators('name');
@@ -127,7 +127,7 @@ will return it. When using model, use :php:meth:`Atk4\\Ui\\Table::getColumnDecor
 You may also use :php:meth:`Atk4\\Ui\\Popup::set` method to dynamically load the content::
 
 
-    $table = Table::addTo($app, ['celled' => true]);
+    $table = Table::addTo($app, ['class.celled' => true]);
     $table->setModel(new Country($app->db));
 
     $name_column = $table->getColumnDecorators('name');

--- a/docs/tabs.rst
+++ b/docs/tabs.rst
@@ -66,7 +66,7 @@ Note that tab contents are refreshed including any values you put on the form::
         $m_register = new \Atk4\Data\Model(new \Atk4\Data\Persistence\Array_($a));
         $m_register->addField('name', ['caption' => 'Please enter your name (John)']);
 
-        $form = Form::addTo($tab, ['segment' => true]);
+        $form = Form::addTo($tab, ['class.segment' => true]);
         $form->setModel($m_register);
         $form->onSubmit(function (Form $form) {
             if ($form->model->get('name') !== 'John') {

--- a/docs/view.rst
+++ b/docs/view.rst
@@ -19,8 +19,8 @@ Agile UI is a component framework, which follows a software patterns known as
 
 View object is recursive. You can take one view and add another View inside of it::
 
-    $v = new \Atk4\Ui\View(['ui' => 'segment', 'inverted']);
-    Button::addTo($v, ['Orange', 'inverted orange']);
+    $v = new \Atk4\Ui\View(['ui' => 'segment', 'class.inverted' => true]);
+    Button::addTo($v, ['Orange', 'class.inverted orange' => true]);
 
 The above code will produce the following HTML block:
 
@@ -72,9 +72,9 @@ in any way you wish, before they will actuallized.
 In the next example I'll be creating 3 views, but it at the time their __constructor
 is executed it will be impossible to determine each view's position inside render tree::
 
-    $middle = new \Atk4\Ui\View(['ui' => 'segment', 'red']);
+    $middle = new \Atk4\Ui\View(['ui' => 'segment', 'class.red' => true]);
     $top = new \Atk4\Ui\View(['ui' => 'segments']);
-    $bottom = new \Atk4\Ui\Button(['Hello World', 'orange']);
+    $bottom = new \Atk4\Ui\Button(['Hello World', 'class.orange' => true]);
 
     // not arranged into render-tree yet
 
@@ -96,18 +96,18 @@ App class first and then continue with Layout initialization::
     $app = new \Atk4\Ui\App('My App');
     $top = $app->initLayout(new \Atk4\Ui\View(['ui' => 'segments']));
 
-    $middle = View::addTo($top, ['ui' => 'segment', 'red']);
+    $middle = View::addTo($top, ['ui' => 'segment', 'class.red' => true]);
 
-    $bottom = Button::addTo($middle, ['Hello World', 'orange']);
+    $bottom = Button::addTo($middle, ['Hello World', 'class.orange' => true]);
 
 Finally, if you prefer a more consise code, you can also use the following format::
 
     $app = new \Atk4\Ui\App('My App');
     $top = $app->initLayout([\Atk4\Ui\View::class, 'ui' => 'segments']);
 
-    $middle = View::addTo($top, ['ui' => 'segment', 'red']);
+    $middle = View::addTo($top, ['ui' => 'segment', 'class.red' => true]);
 
-    $bottom = Button::addTo($middle, ['Hello World', 'orange']);
+    $bottom = Button::addTo($middle, ['Hello World', 'class.orange' => true]);
 
 The rest of documentation will use this concise code to keep things readable, however if
 you value type-hinting of your IDE, you can keep using "new" keyword. I must also
@@ -221,7 +221,7 @@ which syntax you are using.
 If you are don't specify key for the properties, they will be considered an
 extra class for a view::
 
-    $view = View::addTo($app, ['inverted', 'orange', 'ui' => 'segment']);
+    $view = View::addTo($app, ['inverted', 'class.orange' => true, 'ui' => 'segment']);
     $view->name = 'test-id';
 
 You can either specify multiple classes one-by-one or as a single string

--- a/docs/virtualpage.rst
+++ b/docs/virtualpage.rst
@@ -159,7 +159,7 @@ Loader needs to occupy some space.
 By default it will display a white segment with 7em height, but you can specify any other view thorugh $shim
 property::
 
-    $loader = \Atk4\Ui\Loader::addTo($app, ['shim' => ['Message', 'Please wait until we load LoremIpsum...', 'red']]);
+    $loader = \Atk4\Ui\Loader::addTo($app, ['shim' => [\Atk4\Ui\Message::class, 'Please wait until we load LoremIpsum...', 'class.red' => true]]);
     $loader->set(function($p) {
 
         // Simulate slow-loading component

--- a/docs/wizard.rst
+++ b/docs/wizard.rst
@@ -54,7 +54,7 @@ which is described below. You can also provide first argument to addStep as a se
 You may also specify a single Finish callback, which will be used when wizard is complete::
 
     $wizard->addFinish(function ($wizard) {
-        Header::addTo($wizard, ['You are DONE', 'huge centered']);
+        Header::addTo($wizard, ['You are DONE', 'class.huge centered' => true]);
     });
 
 Properties

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1882,9 +1882,6 @@ parameters:
             message: '~^Property Atk4\\Ui\\Table\\Column\\Link::\$args has no type specified\.$~'
         -
             path: 'src/Table/Column/Link.php'
-            message: '~^Method Atk4\\Ui\\Table\\Column\\Link::__construct\(\) has parameter \$args with no type specified\.$~'
-        -
-            path: 'src/Table/Column/Link.php'
             message: '~^Method Atk4\\Ui\\Table\\Column\\Link::__construct\(\) has parameter \$page with no type specified\.$~'
         -
             path: 'src/Table/Column/Money.php'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1875,15 +1875,6 @@ parameters:
             path: 'src/Table/Column/KeyValue.php'
             message: '~^Property Atk4\\Ui\\Table\\Column\\KeyValue::\$values has no type specified\.$~'
         -
-            path: 'src/Table/Column/Link.php'
-            message: '~^Property Atk4\\Ui\\Table\\Column\\Link::\$page has no type specified\.$~'
-        -
-            path: 'src/Table/Column/Link.php'
-            message: '~^Property Atk4\\Ui\\Table\\Column\\Link::\$args has no type specified\.$~'
-        -
-            path: 'src/Table/Column/Link.php'
-            message: '~^Method Atk4\\Ui\\Table\\Column\\Link::__construct\(\) has parameter \$page with no type specified\.$~'
-        -
             path: 'src/Table/Column/Money.php'
             message: '~^Method Atk4\\Ui\\Table\\Column\\Money::getTagAttributes\(\) has parameter \$position with no type specified\.$~'
         -

--- a/src/AbstractView.php
+++ b/src/AbstractView.php
@@ -46,9 +46,6 @@ abstract class AbstractView
 
     /** @var bool will be set to true after rendered. This is so that we don't render view twice. */
     protected $_rendered = false;
-    // }}}
-
-    // {{{ Default init() method and add() logic
 
     /**
      * For the absence of the application, we would add a very

--- a/src/Accordion.php
+++ b/src/Accordion.php
@@ -16,7 +16,7 @@ class Accordion extends View
 
     public $ui = 'accordion';
 
-    /** @var array|string|null The css class for Fomantic-ui accordion type. */
+    /** @var array|string|null The CSS class for Fomantic-ui accordion type. */
     public $type;
 
     /** @var array Settings as per Fomantic-ui accordion settings. */

--- a/src/Card.php
+++ b/src/Card.php
@@ -64,9 +64,6 @@ class Card extends View
     /** @var View|null The button Container for Button */
     public $btnContainer;
 
-    /** @var string Table css class */
-    // public $tableClass = 'ui fixed small';
-
     /** @var bool Display model field as table inside card holder content */
     public $useTable = false;
 

--- a/src/Card.php
+++ b/src/Card.php
@@ -190,7 +190,7 @@ class Card extends View
 
         $this->setDataId($this->model->getId());
 
-        View::addTo($this->getSection(), [$model->getTitle(), ['class' => 'header']]);
+        View::addTo($this->getSection(), [$model->getTitle(), 'class.header' => true]);
         $this->getSection()->addFields($model, $fields, $this->useLabel, $this->useTable);
     }
 
@@ -240,7 +240,7 @@ class Card extends View
     {
         $section = CardSection::addToWithCl($this, [$this->cardSection, 'card' => $this], ['Section']);
         if ($title) {
-            View::addTo($section, [$title, ['class' => 'header']]);
+            View::addTo($section, [$title, 'class.header' => true]);
         }
 
         if ($model && $fields) {

--- a/src/Card.php
+++ b/src/Card.php
@@ -318,7 +318,7 @@ class Card extends View
             $this->addExtraContent(new View([$extra, 'ui' => 'ui basic fitted segment']));
         } else {
             foreach ($fields as $field) {
-                $this->addExtraContent(new View([$model->get($field), 'ui basic fitted segment']));
+                $this->addExtraContent(new View([$model->get($field), 'class.ui basic fitted segment' => true]));
             }
         }
     }

--- a/src/Columns.php
+++ b/src/Columns.php
@@ -39,7 +39,7 @@ class Columns extends View
             $defaults = [$defaults];
         }
 
-        $size = $defaults[0];
+        $size = $defaults[0] ?? null;
         unset($defaults[0]);
 
         $column = Factory::factory([\Atk4\Ui\View::class], $defaults);

--- a/src/Form.php
+++ b/src/Form.php
@@ -77,7 +77,7 @@ class Form extends View
      *
      * @var Button|array|false Button object, seed or false to not show button at all
      */
-    public $buttonSave = [Button::class, 'Save', 'primary'];
+    public $buttonSave = [Button::class, 'Save', 'class.primary' => true];
 
     /**
      * When form is submitted successfully, this template is used by method
@@ -135,6 +135,10 @@ class Form extends View
 
     public function __construct(array $defaults = [])
     {
+        if (func_num_args() > 1) { // prevent bad usage
+            throw new \Error('Too many method arguments');
+        }
+
         parent::__construct($defaults); // TODO remove once parent::__construct() accepts only array
     }
 

--- a/src/Form.php
+++ b/src/Form.php
@@ -27,8 +27,6 @@ class Form extends View
     /** @const string Executed when self::loadPost() method is called. */
     public const HOOK_LOAD_POST = self::class . '@loadPost';
 
-    // {{{ Properties
-
     public $ui = 'form';
     public $defaultTemplate = 'form.html';
 
@@ -129,18 +127,7 @@ class Form extends View
     /** @var array Use this formConfig variable to pass settings to Semantic UI in .from(). */
     public $formConfig = [];
 
-    // }}}
-
     // {{{ Base Methods
-
-    public function __construct(array $defaults = [])
-    {
-        if (func_num_args() > 1) { // prevent bad usage
-            throw new \Error('Too many method arguments');
-        }
-
-        parent::__construct($defaults); // TODO remove once parent::__construct() accepts only array
-    }
 
     protected function init(): void
     {

--- a/src/Form.php
+++ b/src/Form.php
@@ -133,24 +133,9 @@ class Form extends View
 
     // {{{ Base Methods
 
-    /**
-     * @param mixed $defaults CSS class or seed array
-     *
-     * @todo this should also call parent::__construct, but we have to refactor View::__construct method parameters too
-     */
-    public function __construct($defaults = [])
+    public function __construct(array $defaults = [])
     {
-        if (!is_array($defaults)) {
-            $defaults = [$defaults];
-        }
-
-        // CSS class
-        if (array_key_exists(0, $defaults)) {
-            $this->addClass($defaults[0]);
-            unset($defaults[0]);
-        }
-
-        $this->setDefaults($defaults);
+        parent::__construct($defaults); // TODO remove once parent::__construct() accepts only array
     }
 
     protected function init(): void

--- a/src/Form/Control/Checkbox.php
+++ b/src/Form/Control/Checkbox.php
@@ -24,13 +24,13 @@ class Checkbox extends Form\Control
      */
     public $label;
 
-    /**
-     * @param string|array $label
-     * @param string|array $class
-     */
-    public function __construct($label = null, $class = null)
+    public function __construct($label = [])
     {
-        parent::__construct($label, $class);
+        if (func_num_args() > 1) { // prevent bad usage
+            throw new \Error('Too many method arguments');
+        }
+
+        parent::__construct($label);
 
         $this->label = $this->content;
         $this->content = null;

--- a/src/Form/Layout.php
+++ b/src/Form/Layout.php
@@ -74,7 +74,7 @@ class Layout extends AbstractLayout
      */
     public function addHeader($label)
     {
-        \Atk4\Ui\Header::addTo($this, [$label, 'dividing', 'element' => 'h4']);
+        \Atk4\Ui\Header::addTo($this, [$label, 'class.dividing' => true, 'element' => 'h4']);
 
         return $this;
     }

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -132,7 +132,7 @@ class Grid extends View
     protected function initTable(): Table
     {
         /** @var Table */
-        $table = $this->container->add(Factory::factory([Table::class, 'very compact very basic striped single line', 'reload' => $this->container], $this->table), 'Table');
+        $table = $this->container->add(Factory::factory([Table::class, 'class.very compact very basic striped single line' => true, 'reload' => $this->container], $this->table), 'Table');
 
         return $table;
     }

--- a/src/JsConditionalForm.php
+++ b/src/JsConditionalForm.php
@@ -13,8 +13,6 @@ class JsConditionalForm implements JsExpressionable
 {
     use DiContainerTrait;
 
-    // {{{ Properties
-
     /** @var Form The form where rules should apply. */
     public $form;
 
@@ -23,10 +21,6 @@ class JsConditionalForm implements JsExpressionable
 
     /** @var string The html class name parent for input. */
     public $selector;
-
-    // }}}
-
-    // {{{ Base Methods
 
     public function __construct(Form $form, $rules = null, $selector = '.field')
     {
@@ -55,6 +49,4 @@ class JsConditionalForm implements JsExpressionable
 
         return $chain->jsRender();
     }
-
-    // }}}
 }

--- a/src/JsSortable.php
+++ b/src/JsSortable.php
@@ -26,7 +26,7 @@ class JsSortable extends JsCallback
 
     /**
      * The css class name of the handle element for dragging purpose.
-     *   if null, the entire element become the dragging handle.
+     * If null, the entire element become the dragging handle.
      *
      * @var string|null
      */

--- a/src/Message.php
+++ b/src/Message.php
@@ -17,7 +17,7 @@ namespace Atk4\Ui;
  */
 class Message extends View
 {
-    /** @var string Set to info | warning | error | success | positie | negative. */
+    /** @var string Set to info | warning | error | success | positive | negative. */
     public $type;
 
     /** @var Text|false Contains a text to be included below. */

--- a/src/Message.php
+++ b/src/Message.php
@@ -17,7 +17,7 @@ namespace Atk4\Ui;
  */
 class Message extends View
 {
-    /** @var string Set to info | warning | error | success | positive | negative. */
+    /** @var 'info'|'warning'|'success'|'error'|null */
     public $type;
 
     /** @var Text|false Contains a text to be included below. */

--- a/src/ProgressBar.php
+++ b/src/ProgressBar.php
@@ -29,11 +29,11 @@ class ProgressBar extends View
     /** @var int Indicates a maximum value of a progress bar. */
     public $max = 100;
 
-    public function __construct($value = 0, $label = null, $class = null)
+    public function __construct($value = 0, $label = [])
     {
         $this->value = $value;
 
-        parent::__construct($label, $class);
+        parent::__construct($label);
     }
 
     protected function renderView(): void

--- a/src/Table.php
+++ b/src/Table.php
@@ -105,14 +105,9 @@ class Table extends Lister
      */
     public $hasCollapsingCssActionColumn = true;
 
-    /**
-     * @param string|null $class CSS class to add
-     */
-    public function __construct($class = null)
+    public function __construct(array $defaults = [])
     {
-        if ($class) {
-            $this->addClass($class);
-        }
+        parent::__construct($defaults); // TODO remove once parent::__construct() accepts only array
     }
 
     /**

--- a/src/Table.php
+++ b/src/Table.php
@@ -107,6 +107,10 @@ class Table extends Lister
 
     public function __construct(array $defaults = [])
     {
+        if (func_num_args() > 1) { // prevent bad usage
+            throw new \Error('Too many method arguments');
+        }
+
         parent::__construct($defaults); // TODO remove once parent::__construct() accepts only array
     }
 

--- a/src/Table.php
+++ b/src/Table.php
@@ -105,15 +105,6 @@ class Table extends Lister
      */
     public $hasCollapsingCssActionColumn = true;
 
-    public function __construct(array $defaults = [])
-    {
-        if (func_num_args() > 1) { // prevent bad usage
-            throw new \Error('Too many method arguments');
-        }
-
-        parent::__construct($defaults); // TODO remove once parent::__construct() accepts only array
-    }
-
     /**
      * initChunks method will create one column object that will be used to render
      * all columns in the table unless you have specified a different

--- a/src/Table/Column.php
+++ b/src/Table/Column.php
@@ -52,6 +52,10 @@ class Column
 
     public function __construct(array $defaults = [])
     {
+        if (func_num_args() > 1) { // prevent bad usage
+            throw new \Error('Too many method arguments');
+        }
+
         $this->setDefaults($defaults);
     }
 

--- a/src/Table/Column.php
+++ b/src/Table/Column.php
@@ -50,10 +50,7 @@ class Column
     /** @var array|null The tag value required for getTag when using an header action. */
     public $headerActionTag;
 
-    /**
-     * @param array $defaults
-     */
-    public function __construct($defaults = [])
+    public function __construct(array $defaults = [])
     {
         $this->setDefaults($defaults);
     }

--- a/src/Table/Column/FilterPopup.php
+++ b/src/Table/Column/FilterPopup.php
@@ -65,7 +65,7 @@ class FilterPopup extends Popup
             return new jsReload($this->reload);
         });
 
-        \Atk4\Ui\Button::addTo($this->form, ['Clear', 'clear '])->on('click', function ($f) use ($model) {
+        \Atk4\Ui\Button::addTo($this->form, ['Clear', 'class.clear' => true])->on('click', function ($f) use ($model) {
             $model->clearData();
 
             return [

--- a/src/Table/Column/KeyValue.php
+++ b/src/Table/Column/KeyValue.php
@@ -60,11 +60,7 @@ class KeyValue extends Table\Column
     {
         $values = $field->values;
 
-        if (!is_array($values)) {
-            throw new Exception('KeyValues Column need values in field definition');
-        }
-
-        if (count($values) === 0) {
+        if (!is_array($values) || count($values) === 0) {
             throw new Exception('KeyValues Column values must have elements');
         }
 

--- a/src/Table/Column/Link.php
+++ b/src/Table/Column/Link.php
@@ -98,18 +98,6 @@ class Link extends Table\Column
         parent::__construct(array_replace($defaults, $page));
     }
 
-    public function setDefaults(array $properties, bool $passively = false)
-    {
-        if (isset($properties[0])) {
-            $this->page = array_shift($properties);
-        }
-        if (isset($properties[0])) {
-            $this->args = array_shift($properties);
-        }
-
-        return parent::setDefaults($properties);
-    }
-
     protected function init(): void
     {
         parent::init();

--- a/src/Table/Column/Link.php
+++ b/src/Table/Column/Link.php
@@ -76,16 +76,18 @@ class Link extends Table\Column
     /** @var bool add download in the tag to force download from the url. */
     public $force_download = false;
 
-    public function __construct($page = [], $args = [], $defaults = [])
+    public function __construct($page = [], array $args = [], array $defaults = [])
     {
         if (is_array($page)) {
             $page = ['page' => $page];
         } elseif (is_string($page)) {
             $page = ['url' => $page];
         }
+
         if ($args) {
             $page['args'] = $args;
         }
+
         parent::__construct(array_replace($defaults, $page));
     }
 

--- a/src/Table/Column/Link.php
+++ b/src/Table/Column/Link.php
@@ -17,7 +17,7 @@ use Atk4\Ui\Table;
  * or
  *   new Link(['order', 'id' ]);
  * or
- *   new Link([['order', 'x' => $myval], 'id' ]);.
+ *   new Link([['order', 'x' => $myval], 'id']);.
  */
 class Link extends Table\Column
 {

--- a/src/Table/Column/Link.php
+++ b/src/Table/Column/Link.php
@@ -37,6 +37,8 @@ class Link extends Table\Column
      * $url = $app->url(['example', 'type' => '123']);
      *
      * In addition to abpove "args" refer to values picked up from a current row.
+     *
+     * @var string|array
      */
     public $page;
 
@@ -53,6 +55,8 @@ class Link extends Table\Column
      *
      * You can also pass non-key arguments ['id', 'title'] and they will be added up
      * as ?id=4&title=John%20Smith
+     *
+     * @var array
      */
     public $args = [];
 
@@ -76,6 +80,9 @@ class Link extends Table\Column
     /** @var bool add download in the tag to force download from the url. */
     public $force_download = false;
 
+    /**
+     * @param string|array $page
+     */
     public function __construct($page = [], array $args = [], array $defaults = [])
     {
         if (is_array($page)) {

--- a/src/Table/Column/Status.php
+++ b/src/Table/Column/Status.php
@@ -18,7 +18,7 @@ class Status extends Table\Column
     /**
      * Pass argument with possible states like this:.
      *
-     *  [ 'positive' => ['Paid', 'Archived'], 'negative' => ['Overdue'] ]
+     *  ['positive' => ['Paid', 'Archived'], 'negative' => ['Overdue']]
      *
      * @param array $states List of status => [value, value, value]
      */

--- a/src/UserAction/ConfirmationExecutor.php
+++ b/src/UserAction/ConfirmationExecutor.php
@@ -63,7 +63,7 @@ class ConfirmationExecutor extends Modal implements JsExecutorInterface
     {
         // Add buttons to modal for next and previous.
         $btns = (new View())->addStyle(['min-height' => '24px']);
-        $this->ok = Button::addTo($btns, ['Ok', 'blue']);
+        $this->ok = Button::addTo($btns, ['Ok', 'class.blue' => true]);
         $this->cancel = Button::addTo($btns, ['Cancel']);
         $this->add($btns, 'actions');
         $this->showActions = true;

--- a/src/UserAction/ExecutorFactory.php
+++ b/src/UserAction/ExecutorFactory.php
@@ -208,16 +208,16 @@ class ExecutorFactory
             case self::MODAL_BUTTON:
                 $seed = [Button::class, $this->getActionCaption($action, $type)];
                 if ($type === self::MODAL_BUTTON || $type === self::CARD_BUTTON) {
-                    $seed[] = static::BUTTON_PRIMARY_COLOR;
+                    $seed['class.' . static::BUTTON_PRIMARY_COLOR] = true;
                 }
 
                 break;
             case self::MENU_ITEM:
-                $seed = [Item::class, $this->getActionCaption($action, $type), ['class' => 'item']];
+                $seed = [Item::class, $this->getActionCaption($action, $type), 'class.item' => true];
 
                 break;
             case self::TABLE_MENU_ITEM:
-                $seed = [Item::class, $this->getActionCaption($action, $type), 'name' => false, ['class' => 'item']];
+                $seed = [Item::class, $this->getActionCaption($action, $type), 'name' => false, 'class.item' => true];
 
                 break;
             default:

--- a/src/UserAction/StepExecutorTrait.php
+++ b/src/UserAction/StepExecutorTrait.php
@@ -350,7 +350,7 @@ trait StepExecutorTrait
     {
         $this->btns = (new View())->addStyle(['min-height' => '24px']);
         $this->prevStepBtn = Button::addTo($this->btns, ['Prev'])->addStyle(['float' => 'left !important']);
-        $this->nextStepBtn = Button::addTo($this->btns, ['Next', 'blue']);
+        $this->nextStepBtn = Button::addTo($this->btns, ['Next', 'class.blue' => true]);
         $this->execActionBtn = $this->getExecutorFactory()->createTrigger($action, ExecutorFactory::MODAL_BUTTON);
         $this->btns->add($this->execActionBtn);
 

--- a/src/UserAction/StepExecutorTrait.php
+++ b/src/UserAction/StepExecutorTrait.php
@@ -470,7 +470,7 @@ trait StepExecutorTrait
         } catch (ValidationException $e) {
             throw $e;
         } catch (\Throwable $e) {
-            $msg = new Message('Error executing ' . $this->action->caption, 'red');
+            $msg = new Message(['Error executing ' . $this->action->caption, 'type' => 'error', 'class.red' => true]);
             $msg->invokeInit();
             $msg->text->content = $this->getApp()->renderExceptionHtml($e);
 

--- a/src/UserAction/VpExecutor.php
+++ b/src/UserAction/VpExecutor.php
@@ -42,7 +42,7 @@ class VpExecutor extends View implements JsExecutorInterface
     public $stepListItems = ['args' => 'Fill argument(s)', 'fields' => 'Edit Record(s)', 'preview' => 'Preview', 'final' => 'Complete'];
 
     /** @var array */
-    public $cancelBtnSeed = [Button::class, ['Cancel', 'small left floated basic blue', 'icon' => 'left arrow']];
+    public $cancelBtnSeed = [Button::class, ['Cancel', 'class.small left floated basic blue' => true, 'icon' => 'left arrow']];
 
     protected function init(): void
     {

--- a/src/View.php
+++ b/src/View.php
@@ -91,9 +91,6 @@ class View extends AbstractView implements JsExpressionable
     public function __construct($label = [])
     {
         if (func_num_args() > 1) { // prevent bad usage
-            var_dump(func_get_args());
-            debug_print_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS);
-
             throw new \Error('Too many method arguments');
         }
 

--- a/src/View.php
+++ b/src/View.php
@@ -391,21 +391,8 @@ class View extends AbstractView implements JsExpressionable
      */
     public function addClass($class)
     {
-        if (is_array($class)) {
-            $class = implode(' ', $class);
-        }
-
-        if (!$this->class) {
-            $this->class = [];
-        }
-
-        if (is_string($this->class)) {
-            throw (new Exception('Property $class should always be array'))
-                ->addMoreInfo('object', $this)
-                ->addMoreInfo('class', $this->class);
-        }
-
-        $this->class = array_merge($this->class, explode(' ', $class));
+        $classArr = explode(' ', is_array($class) ? implode(' ', $class) : $class);
+        $this->class = array_merge($this->class, $classArr);
 
         return $this;
     }
@@ -413,18 +400,14 @@ class View extends AbstractView implements JsExpressionable
     /**
      * Remove one or several CSS classes from the element.
      *
-     * @param array|string $class CSS class name or array of class names
+     * @param string|array $class CSS class name or array of class names
      *
      * @return $this
      */
     public function removeClass($class)
     {
-        if (is_array($class)) {
-            $class = implode(' ', $class);
-        }
-
-        $class = explode(' ', $class);
-        $this->class = array_diff($this->class, $class);
+        $classArr = explode(' ', is_array($class) ? implode(' ', $class) : $class);
+        $this->class = array_diff($this->class, $classArr);
 
         return $this;
     }

--- a/src/View.php
+++ b/src/View.php
@@ -87,33 +87,25 @@ class View extends AbstractView implements JsExpressionable
 
     /**
      * @param array|string $label
-     * @param array|string $class
      */
-    public function __construct($label = null, $class = null)
+    public function __construct($label = [])
     {
-        if (is_array($label)) {
-            $defaults = $label;
-            if (isset($defaults[0])) {
-                $label = $defaults[0];
-                unset($defaults[0]);
-            } else {
-                $label = null;
-            }
+        $defaults = is_array($label) ? $label : [$label];
+        unset($label);
 
-            if (isset($defaults[1])) {
-                $class = $defaults[1];
-                unset($defaults[1]);
-            }
-            $this->setDefaults($defaults);
+        if (array_key_exists(0, $defaults)) {
+            $defaults['content'] = $defaults[0];
+            unset($defaults[0]);
         }
 
-        if ($label !== null) {
-            $this->content = $label;
+        // @TODO func_num_args() > 1!!!!
+        if (func_num_args() > 2 || count(array_filter($defaults, 'is_int', \ARRAY_FILTER_USE_KEY)) > 0) { // prevent bad usage
+            var_dump(func_get_args());
+
+            throw new \Error('Too many method arguments');
         }
 
-        if ($class) {
-            $this->addClass($class);
-        }
+        $this->setDefaults($defaults);
     }
 
     /**

--- a/src/View.php
+++ b/src/View.php
@@ -91,6 +91,9 @@ class View extends AbstractView implements JsExpressionable
     public function __construct($label = [])
     {
         if (func_num_args() > 1) { // prevent bad usage
+            var_dump(func_get_args());
+            debug_print_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS);
+
             throw new \Error('Too many method arguments');
         }
 

--- a/src/View.php
+++ b/src/View.php
@@ -90,19 +90,16 @@ class View extends AbstractView implements JsExpressionable
      */
     public function __construct($label = [])
     {
+        if (func_num_args() > 1) { // prevent bad usage
+            throw new \Error('Too many method arguments');
+        }
+
         $defaults = is_array($label) ? $label : [$label];
         unset($label);
 
         if (array_key_exists(0, $defaults)) {
             $defaults['content'] = $defaults[0];
             unset($defaults[0]);
-        }
-
-        // @TODO func_num_args() > 1!!!!
-        if (func_num_args() > 2 || count(array_filter($defaults, 'is_int', \ARRAY_FILTER_USE_KEY)) > 0) { // prevent bad usage
-            var_dump(func_get_args());
-
-            throw new \Error('Too many method arguments');
         }
 
         $this->setDefaults($defaults);

--- a/src/View.php
+++ b/src/View.php
@@ -86,16 +86,12 @@ class View extends AbstractView implements JsExpressionable
     // {{{ Setting Things up
 
     /**
-     * May accept properties of a class, but if property is not defined, it will
-     * be used as a HTML class instead.
-     *
      * @param array|string $label
      * @param array|string $class
      */
     public function __construct($label = null, $class = null)
     {
         if (is_array($label)) {
-            // backwards mode
             $defaults = $label;
             if (isset($defaults[0])) {
                 $label = $defaults[0];

--- a/src/Wizard.php
+++ b/src/Wizard.php
@@ -60,7 +60,7 @@ class Wizard extends View
 
         // add buttons
         if ($this->currentStep) {
-            $this->buttonPrev = Button::addTo($this, ['Back', 'basic'], ['Left']);
+            $this->buttonPrev = Button::addTo($this, ['Back', 'class.basic' => true], ['Left']);
             $this->buttonPrev->link($this->getUrl($this->currentStep - 1));
         }
 

--- a/src/Wizard.php
+++ b/src/Wizard.php
@@ -64,8 +64,8 @@ class Wizard extends View
             $this->buttonPrev->link($this->getUrl($this->currentStep - 1));
         }
 
-        $this->buttonNext = Button::addTo($this, ['Next', 'primary'], ['Right']);
-        $this->buttonFinish = Button::addTo($this, ['Finish', 'primary'], ['Right']);
+        $this->buttonNext = Button::addTo($this, ['Next', 'class.primary' => true], ['Right']);
+        $this->buttonFinish = Button::addTo($this, ['Finish', 'class.primary' => true], ['Right']);
 
         $this->buttonNext->link($this->getUrl($this->currentStep + 1));
     }


### PR DESCRIPTION
in favor of `class.xxx` seed syntax introduced in https://github.com/atk4/ui/pull/1770

this change intends to make the code more readable and error proof

to find most places to update, use `\[\s*+[^\[\]]+(?<!=> )'(\w| )+'(?! =>)` regex