### PR TITLE
Fix `interactive/popup.php` cart demo

### DIFF
--- a/demos/interactive/popup.php
+++ b/demos/interactive/popup.php
@@ -178,6 +178,7 @@ $cart = $cartClass::addTo($app);
 // If i add unset($cart) afterwards, garbage collector will trigger destructor. Instead I'm passing $cart
 // into the callback and making it part of the pop-up render tree.
 $cart->destroy();
+$cart->setApp($app);
 
 // Label now can be added referencing Cart's items. Init() was colled when I added it into app, so the
 // item property is populated.


### PR DESCRIPTION
fixes https://github.com/atk4/ui/issues/1781

there is `destroy` method called which smells to me, introduced in https://github.com/atk4/ui/commit/ad0fe7e7e292d0f3090834f854d88ff8eaf143e6

Behat test should be added to assert the fixed state