### PR TITLE
Mark all parent accordions/tabs if validation exception of control inside

### DIFF
--- a/demos/form/form.php
+++ b/demos/form/form.php
@@ -38,6 +38,7 @@ $tab = $tabs->addTab('Basic Use');
 Header::addTo($tab, ['Very simple form']);
 
 $form = Form::addTo($tab);
+
 $form->addControl('email');
 $form->onSubmit(function (Form $form) {
     // implement subscribe here
@@ -56,13 +57,16 @@ $group->addControl('name');
 $group->addControl('surname');
 $group->addControl('gender', [Form\Control\Dropdown::class, 'values' => ['Female', 'Male']]);
 
+$accordionLayout = $form->layout->addSubLayout([\Atk4\Ui\Form\Layout\Section\Accordion::class]);
+$details = $accordionLayout->addSection('Validating Field in Accordion');
+
 // testing 0 value
 $values = [0 => 'noob', 1 => 'pro', 2 => 'dev'];
 $form->addControl('description', [Form\Control\Textarea::class])->set(0);
 $form->addControl('no_description', [Form\Control\Textarea::class])->set(null);
 $form->addControl('status_optional', [Form\Control\Dropdown::class, 'values' => $values]);
-$form->addControl('status_string_not-nullable', [Form\Control\Dropdown::class], ['type' => 'string', 'values' => $values, 'nullable' => false]);
-$form->addControl('status_integer_not-nullable', [Form\Control\Dropdown::class], ['type' => 'integer', 'values' => $values, 'nullable' => false]);
+$details->addControl('status_string_not-nullable', [Form\Control\Dropdown::class], ['type' => 'string', 'values' => $values, 'nullable' => false]);
+$details->addControl('status_integer_not-nullable', [Form\Control\Dropdown::class], ['type' => 'integer', 'values' => $values, 'nullable' => false]);
 $form->addControl('status_string_required', [Form\Control\Dropdown::class], ['type' => 'string', 'values' => $values, 'required' => true]);
 $form->addControl('status_integer_required', [Form\Control\Dropdown::class], ['type' => 'integer', 'values' => $values, 'required' => true]);
 

--- a/demos/form/form.php
+++ b/demos/form/form.php
@@ -38,7 +38,6 @@ $tab = $tabs->addTab('Basic Use');
 Header::addTo($tab, ['Very simple form']);
 
 $form = Form::addTo($tab);
-
 $form->addControl('email');
 $form->onSubmit(function (Form $form) {
     // implement subscribe here
@@ -57,7 +56,7 @@ $group->addControl('name');
 $group->addControl('surname');
 $group->addControl('gender', [Form\Control\Dropdown::class, 'values' => ['Female', 'Male']]);
 
-$accordionLayout = $form->layout->addSubLayout([\Atk4\Ui\Form\Layout\Section\Accordion::class]);
+$accordionLayout = $form->layout->addSubLayout([Form\Layout\Section\Accordion::class]);
 $details = $accordionLayout->addSection('Validating Field in Accordion');
 
 // testing 0 value

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -88,6 +88,9 @@ parameters:
             path: 'demos/form/form.php'
             message: '~^Call to an undefined method Atk4\\Ui\\JsChain::checkbox\(\)\.$~'
         -
+            path: 'demos/form/form.php'
+            message: '~^Call to an undefined method Atk4\Ui\Form\Layout::addSection\(\)\.$~'
+        -
             path: 'demos/form/form2.php'
             message: '~^Call to an undefined method Atk4\\Ui\\Form\\Control::addAction\(\)\.$~'
         -

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -89,7 +89,7 @@ parameters:
             message: '~^Call to an undefined method Atk4\\Ui\\JsChain::checkbox\(\)\.$~'
         -
             path: 'demos/form/form.php'
-            message: '~^Call to an undefined method Atk4\Ui\Form\Layout::addSection\(\)\.$~'
+            message: '~^Call to an undefined method Atk4\\Ui\\Form\\Layout::addSection\(\)\.$~'
         -
             path: 'demos/form/form2.php'
             message: '~^Call to an undefined method Atk4\\Ui\\Form\\Control::addAction\(\)\.$~'

--- a/src/AccordionSection.php
+++ b/src/AccordionSection.php
@@ -22,11 +22,16 @@ class AccordionSection extends View
     /** @var string */
     public $icon = 'dropdown';
 
+    /** @var string */
+    public $warningIcon = 'exclamation circle';
+
     protected function renderView(): void
     {
         parent::renderView();
 
         $this->template->set('icon', $this->icon);
+
+        $this->template->set('warningIcon', $this->warningIcon);
 
         if ($this->title) {
             $this->template->set('title', $this->title);

--- a/src/Form.php
+++ b/src/Form.php
@@ -261,12 +261,14 @@ class Form extends View
                 $openFirstSectionOnError = false;
 
                 foreach ($e->errors as $field => $error) {
+                    $response[] = $this->error($field, $error);
+
+                    // If field inside Accordion section does not validate, open first AccordionSection
                     if (!$openFirstSectionOnError && $this->getControl($field)->getOwner()->getOwner() instanceof \Atk4\Ui\AccordionSection) {
                         $response[] = $this->getControl($field)->getOwner()->getOwner()->getOwner()->jsOpen($this->getControl($field)->getOwner()->getOwner());
                         $openFirstSectionOnError = true;
                     }
 
-                    $response[] = $this->error($field, $error);
                 }
 
                 return $response;

--- a/src/Form.php
+++ b/src/Form.php
@@ -258,15 +258,12 @@ class Form extends View
                 return $response;
             } catch (ValidationException $e) {
                 $response = [];
-                $openFirstSectionOnError = false;
-
                 foreach ($e->errors as $field => $error) {
                     $response[] = $this->error($field, $error);
 
                     // If field inside Accordion section does not validate, open first AccordionSection
-                    if (!$openFirstSectionOnError && $this->getControl($field)->getOwner()->getOwner() instanceof \Atk4\Ui\AccordionSection) {
-                        $response[] = $this->getControl($field)->getOwner()->getOwner()->getOwner()->jsOpen($this->getControl($field)->getOwner()->getOwner());
-                        $openFirstSectionOnError = true;
+                    if ($this->getControl($field)->getOwner()->getOwner() instanceof \Atk4\Ui\AccordionSection) {
+                        $response[] = $this->getControl($field)->getOwner()->getOwner()->getOwner()->js(true)->find('i.icon.atk-panel-warning.exclamation.circle')->addClass('atk-visible');
                     }
                 }
 

--- a/src/Form.php
+++ b/src/Form.php
@@ -258,7 +258,14 @@ class Form extends View
                 return $response;
             } catch (ValidationException $e) {
                 $response = [];
+                $openFirstSectionOnError = false;
+
                 foreach ($e->errors as $field => $error) {
+                    if (!$openFirstSectionOnError && $this->getControl($field)->getOwner()->getOwner() instanceof \Atk4\Ui\AccordionSection) {
+                        $response[] = $this->getControl($field)->getOwner()->getOwner()->getOwner()->jsOpen($this->getControl($field)->getOwner()->getOwner());
+                        $openFirstSectionOnError = true;
+                    }
+
                     $response[] = $this->error($field, $error);
                 }
 

--- a/src/Form.php
+++ b/src/Form.php
@@ -268,7 +268,6 @@ class Form extends View
                         $response[] = $this->getControl($field)->getOwner()->getOwner()->getOwner()->jsOpen($this->getControl($field)->getOwner()->getOwner());
                         $openFirstSectionOnError = true;
                     }
-
                 }
 
                 return $response;

--- a/template/accordion-section.html
+++ b/template/accordion-section.html
@@ -1,5 +1,5 @@
 
-<div class="title" id="{$_id}"><i class="{$icon} icon"></i>{title}Title{/}</div>
+<div class="title" id="{$_id}"><i class="{$icon} icon"></i><i class="atk-panel-warning {$warningIcon} icon"></i>{title}Title{/}</div>
 <div class="content ui basic segment" data-path="{$path}" style="min-height: 60px">
   <div id="{$itemId}">{$Content}</div>
 </div>

--- a/template/accordion-section.pug
+++ b/template/accordion-section.pug
@@ -1,5 +1,6 @@
 div(id="{$_id}" class="title")
     i(class="{$icon} icon")
+    i(class="atk-panel-warning {$warningIcon} icon")
     | {title}Title{/}
 div(class="content ui basic segment", data-path="{$path}", style="min-height: 60px")
     div(id="{$itemId}")


### PR DESCRIPTION
Introduces  #1728 

Demo can be seen by opening `demos/form/form.php` demo, pressing save on the second form ("but very flexibly"). The field `status integer not nullable` will then not validate and you can see that the Accordion is automatically opened.

https://github.com/atk4/ui/blob/621d33fb35e563e3154a067d4fb2f1ec997131f2/demos/form/form.php#L60
