### PR TITLE
Add support to add label to menu group

### DIFF
--- a/demos/init-app.php
+++ b/demos/init-app.php
@@ -153,10 +153,10 @@ if ($layout instanceof Layout\NavigableInterface) {
     $layout->addMenuItem(['Sliding Panel'], [$path . 'layout-panel'], $menu);
 
     $path = $demosUrl . 'basic/';
-    $menu = $layout->addMenuGroup(['Basics', 'icon' => 'cubes']);
+    $menu = $layout->addMenuGroup(['Basics', 'label' => ['10', 'class.red' => true]]);
     $layout->addMenuItem('View', [$path . 'view'], $menu);
-    $layout->addMenuItem('Button', [$path . 'button'], $menu);
-    $layout->addMenuItem('Header', [$path . 'header'], $menu);
+    $layout->addMenuItem(['Button', 'label' => ['10', 'class.red' => true]], [$path . 'button'], $menu);
+    $layout->addMenuItem(['Header', 'icon' => 'edit'], [$path . 'header'], $menu);
     $layout->addMenuItem('Message', [$path . 'message'], $menu);
     $layout->addMenuItem('Labels', [$path . 'label'], $menu);
     $layout->addMenuItem('Menu', [$path . 'menu'], $menu);
@@ -174,9 +174,11 @@ if ($layout instanceof Layout\NavigableInterface) {
     $layout->addMenuItem(['HTML Layout'], [$path . 'html-layout'], $menu);
     $layout->addMenuItem(['Conditional Fields'], [$path . 'jscondform'], $menu);
 
+    $layout->addMenuItem(['Chats', 'label' => ['10', 'class.red' => true]], [$path . '..']);
+
     $path = $demosUrl . 'form-control/';
     $menu = $layout->addMenuGroup(['Form Controls', 'icon' => 'keyboard outline']);
-    $layout->addMenuItem(['Input'], [$path . 'input2'], $menu);
+    $layout->addMenuItem(['Input', 'label' => ['10', 'class.red' => true]], [$path . 'input2'], $menu);
     $layout->addMenuItem('Input Decoration', [$path . 'input'], $menu);
     $layout->addMenuItem('Calendar', [$path . 'calendar'], $menu);
     $layout->addMenuItem(['Checkboxes'], [$path . 'checkbox'], $menu);

--- a/docs/app.md
+++ b/docs/app.md
@@ -447,8 +447,8 @@ $layout = $app->layout;
 $layout->menuLeft->addItem(['Welcome Page', 'icon' => 'gift'], ['index']);
 $layout->menuLeft->addItem(['Layouts', 'icon' => 'object group'], ['layouts']);
 
-$EditGroup = $layout->menuLeft->addGroup(['Edit', 'icon' => 'edit']);
-$EditGroup->addItem('Basics', ['edit/basic']);
+$editGroup = $layout->menuLeft->addGroup(['Edit', 'icon' => 'edit']);
+$editGroup->addItem('Basics', ['edit/basic']);
 ```
 
 :::{php:attr} menu

--- a/docs/app.md
+++ b/docs/app.md
@@ -449,6 +449,9 @@ $layout->menuLeft->addItem(['Layouts', 'icon' => 'object group'], ['layouts']);
 
 $editGroup = $layout->menuLeft->addGroup(['Edit', 'icon' => 'edit']);
 $editGroup->addItem('Basics', ['edit/basic']);
+
+$newsGroup = $layout->menuLeft->addGroup(['News', 'label' => ['28', 'class.red' => true]]);
+$newsGroup->addItem('Emails', ['news/emails']);
 ```
 
 :::{php:attr} menu

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -131,6 +131,8 @@ class Menu extends View
 
         if (isset($name['icon'])) {
             Icon::addTo($group, [$name['icon']], ['Icon'])->removeClass('item');
+        } elseif (isset($name['label'])) {
+            Label::addTo($group, [$name['label']], ['Icon'])->removeClass('item')->addClass('mini');
         }
 
         return $group;

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -132,7 +132,7 @@ class Menu extends View
         if (isset($name['icon'])) {
             Icon::addTo($group, [$name['icon']], ['Icon'])->removeClass('item');
         } elseif (isset($name['label'])) {
-            Label::addTo($group, [$name['label']], ['Icon'])->removeClass('item')->addClass('mini');
+            Label::addTo($group, [$name['label']], ['Icon'])->removeClass('item')->addClass('tiny');
         }
 
         return $group;

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -91,7 +91,7 @@ class Menu extends View
             $name = [$name];
         }
 
-        $label = $name['title'] ?? $name['text'] ?? $name['name'] ?? $name[0] ?? null;
+        $label = $name['title'] ?? $name[0] ?? null;
 
         if ($label !== null) {
             $subMenu->template->set('label', $label);
@@ -123,7 +123,7 @@ class Menu extends View
             $name = [$name];
         }
 
-        $title = $name['title'] ?? $name['text'] ?? $name['name'] ?? $name[0] ?? null;
+        $title = $name['title'] ?? $name[0] ?? null;
 
         if ($title !== null) {
             $group->template->set('title', $title);


### PR DESCRIPTION
Situation:
Today, only icons are supported for menu groups. Menu items however in Admin or Maestro layout can show either an icon or a label.

PR:
Introduce to add label also for menu groups.

Sample Usage:
`$layout->addMenuGroup(['Tickets', 'label' => ['1', 'class.red' => true]]);`

Look:
![image](https://user-images.githubusercontent.com/28671486/187750607-ac9bda69-8b1d-4c0b-949b-bddc8483c070.png)

Caveat: It would be better if the items were right-aligned (the icon or the label) - for menu items (see below), they are right aligned, so the label spreads out to the left. If anyone has a hint, how to set classes for that please contribute.