### PR TITLE
Drop Form::addControls() method

### DIFF
--- a/demos/data-action/factory-view.php
+++ b/demos/data-action/factory-view.php
@@ -20,7 +20,7 @@ View::addTo($app, ['ui' => 'ui clearing divider']);
 
 // Overriding basic ExecutorFactory in order to change Card button.
 $myFactory = AnonymousClassNameCache::get_class(fn () => new class() extends ExecutorFactory {
-    public const BUTTON_PRIMARY_COLOR = 'green';
+    public $buttonPrimaryColor = 'green';
 
     protected array $actionIcon = [
         'callback' => 'sync',

--- a/demos/data-action/factory.php
+++ b/demos/data-action/factory.php
@@ -30,7 +30,7 @@ $msg->text->addParagraph('In this example, Crud and Card button was changed and 
 // Overriding basic ExecutorFactory in order to change Table and Modal button.
 // and also changing default add action label.
 $myFactory = AnonymousClassNameCache::get_class(fn () => new class() extends ExecutorFactory {
-    public const BUTTON_PRIMARY_COLOR = 'green';
+    public $buttonPrimaryColor = 'green';
 
     protected $triggerSeed = [
         self::TABLE_BUTTON => [

--- a/demos/data-action/jsactions-panel.php
+++ b/demos/data-action/jsactions-panel.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Atk4\Ui\Demos;
 
+use Atk4\Ui\UserAction\ExecutorFactory;
 use Atk4\Ui\UserAction\PanelExecutor;
 
 /** @var \Atk4\Ui\App $app */
 require_once __DIR__ . '/../init-app.php';
 
 $factory = $app->getExecutorFactory();
-$factory->registerTypeExecutor($factory::STEP_EXECUTOR, [PanelExecutor::class]);
+$factory->registerTypeExecutor(ExecutorFactory::STEP_EXECUTOR, [PanelExecutor::class]);
 
 require __DIR__ . '/jsactions2.php';

--- a/demos/data-action/jsactions-vp.php
+++ b/demos/data-action/jsactions-vp.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Atk4\Ui\Demos;
 
+use Atk4\Ui\UserAction\ExecutorFactory;
 use Atk4\Ui\UserAction\VpExecutor;
 
 /** @var \Atk4\Ui\App $app */
 require_once __DIR__ . '/../init-app.php';
 
 $factory = $app->getExecutorFactory();
-$factory->registerTypeExecutor($factory::STEP_EXECUTOR, [VpExecutor::class]);
+$factory->registerTypeExecutor(ExecutorFactory::STEP_EXECUTOR, [VpExecutor::class]);
 
 require_once 'jsactions2.php';

--- a/demos/form-control/dropdown-plus.php
+++ b/demos/form-control/dropdown-plus.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Atk4\Ui\Demos;
 
-use Atk4\Data\Model;
 use Atk4\Ui\Form;
 use Atk4\Ui\Header;
 use Atk4\Ui\Message;

--- a/demos/form/form.php
+++ b/demos/form/form.php
@@ -200,7 +200,7 @@ $form->onSubmit(function (Form $form) {
 
     return [
         $form->jsInput('email')->val('john@gmail.com'),
-        $form->jsControl('is_accept_terms')->checkbox('set checked'),
+        $form->getControl('is_accept_terms')->js()->checkbox('set checked'),
     ];
 });
 

--- a/demos/interactive/console.php
+++ b/demos/interactive/console.php
@@ -122,10 +122,8 @@ $tab = $tabs->addTab('Use after form submit', function (VirtualPage $vp) {
     session_start();
 
     $form = Form::addTo($vp);
-    $form->addControls([
-        ['foo'],
-        ['bar'],
-    ]);
+    $form->addControl('foo');
+    $form->addControl('bar');
 
     $console = Console::addTo($vp, ['event' => false]);
     $console->set(function (Console $console) {

--- a/demos/interactive/console.php
+++ b/demos/interactive/console.php
@@ -122,7 +122,10 @@ $tab = $tabs->addTab('Use after form submit', function (VirtualPage $vp) {
     session_start();
 
     $form = Form::addTo($vp);
-    $form->addControls([['foo'], ['bar']]);
+    $form->addControls([
+        ['foo'],
+        ['bar'],
+    ]);
 
     $console = Console::addTo($vp, ['event' => false]);
     $console->set(function (Console $console) {

--- a/docs/form.rst
+++ b/docs/form.rst
@@ -177,17 +177,6 @@ Form control does not have to be added directly into the form. You can use a sep
     $myview = View::addTo($form, ['defaultTemplate' => './mytemplate.html']);
     Form\Control\Dropdown::addTo($myview, ['form' => $form]);
 
-.. php:method:: addControls($fields)
-
-Similar to :php:meth:`Form::addControl()`, but allows to add multiple form controls in one method call::
-
-    $form = Form::addTo($app);
-    $form->addControls([
-        ['email'],
-        ['gender', [\Atk4\Ui\Form\Control\Dropdown::class, 'values' => ['Female', 'Male']]],
-        ['terms', null, ['type' => 'boolean', 'caption' => 'Agree to Terms & Conditions']],
-    ]);
-
 Adding new controls
 -------------------
 
@@ -651,18 +640,14 @@ My next example will add multiple controls on the same line::
 
     $form->setModel(new User($db), []); // will not populate any form controls automatically
 
-    $form->addControls([
-        ['name'],
-        ['surname'],
-    ]);
+    $group = $form->addGroup('Customer');
+    $group->addControl('name');
+    $group->addControl('surname');
 
     $group = $form->addGroup('Address');
-    // grouped form controls, will appear on the same line
-    $group->addControls([
-        ['address'],
-        ['city'],
-        ['country'],
-    ]);
+    $group->addControl('street');
+    $group->addControl('city');
+    $group->addControl('country');
 
 By default grouped form controls will appear with fixed width. To distribute space you can either specify
 proportions manually::
@@ -674,10 +659,8 @@ proportions manually::
 or you can divide space equally between form controls. Header is also omitted for this group::
 
     $group = $form->addGroup(['width' => 'two']);
-    $group->addControls([
-        ['city'],
-        ['country'],
-    ]);
+    $group->addControl('city');
+    $group->addControl('country');
 
 You can also use in-line form groups. Controls in such a group will display header on the left and
 the error messages appearing on the right from the control::

--- a/docs/form.rst
+++ b/docs/form.rst
@@ -420,7 +420,7 @@ it's always nicer to load values for the database. Given a ``User`` model this i
 you can create a form to change profile of a currently logged user::
 
     $user = new User($db);
-    $user->getControl('password')->neverPersist = true; // ignore password field
+    $user->getField('password')->neverPersist = true; // ignore password field
     $user = $user->load($current_user);
 
     // Display all fields (except password) and values

--- a/docs/form.rst
+++ b/docs/form.rst
@@ -183,7 +183,7 @@ Similar to :php:meth:`Form::addControl()`, but allows to add multiple form contr
 
     $form = Form::addTo($app);
     $form->addControls([
-        'email',
+        ['email'],
         ['gender', [\Atk4\Ui\Form\Control\Dropdown::class, 'values' => ['Female', 'Male']]],
         ['terms', null, ['type' => 'boolean', 'caption' => 'Agree to Terms & Conditions']],
     ]);
@@ -651,10 +651,18 @@ My next example will add multiple controls on the same line::
 
     $form->setModel(new User($db), []); // will not populate any form controls automatically
 
-    $form->addControls(['name', 'surname']);
+    $form->addControls([
+        ['name'],
+        ['surname'],
+    ]);
 
     $group = $form->addGroup('Address');
-    $group->addControls(['address', 'city', 'country']); // grouped form controls, will appear on the same line
+    // grouped form controls, will appear on the same line
+    $group->addControls([
+        ['address'],
+        ['city'],
+        ['country'],
+    ]);
 
 By default grouped form controls will appear with fixed width. To distribute space you can either specify
 proportions manually::
@@ -666,7 +674,10 @@ proportions manually::
 or you can divide space equally between form controls. Header is also omitted for this group::
 
     $group = $form->addGroup(['width' => 'two']);
-    $group->addControls(['city', 'country']);
+    $group->addControls([
+        ['city'],
+        ['country'],
+    ]);
 
 You can also use in-line form groups. Controls in such a group will display header on the left and
 the error messages appearing on the right from the control::

--- a/docs/js.rst
+++ b/docs/js.rst
@@ -74,10 +74,7 @@ events can be triggered by the user or by other JavaScript code. There are sever
 
 To execute actions instantly on page load, use `true` as first argument to :php:meth:`View::js()`::
 
-    $view->js(
-        true,
-        new JsExpression('alert([])', ['Hello world'])
-    );
+    $view->js(true, new JsExpression('alert([])', ['Hello world']));
 
 You can also combine both forms::
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -82,12 +82,6 @@ parameters:
             path: 'demos/form/form-section.php'
             message: '~^Call to an undefined method Atk4\\Ui\\Form\\Layout::addTab\(\)\.$~'
         -
-            path: 'demos/form/form.php'
-            message: '~^Call to an undefined method Atk4\\Ui\\JsChain::val\(\)\.$~'
-        -
-            path: 'demos/form/form.php'
-            message: '~^Call to an undefined method Atk4\\Ui\\JsChain::checkbox\(\)\.$~'
-        -
             path: 'demos/form/form2.php'
             message: '~^Call to an undefined method Atk4\\Ui\\Form\\Control::addAction\(\)\.$~'
         -

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -305,7 +305,7 @@ parameters:
             message: '~^Method Atk4\\Ui\\Form\\Layout::_addControl\(\) should return Atk4\\Ui\\Form\\Control but returns Atk4\\Ui\\View\.$~'
         -
             path: 'src/Form/Layout.php'
-            message: '~^Method Atk4\\Ui\\Form\\Layout::addSubLayout\(\) should return static\(Atk4\\Ui\\Form\\Layout\) but returns Atk4\\Ui\\AbstractView\.$~'
+            message: '~^Method Atk4\\Ui\\Form\\Layout::addSubLayout\(\) should return Atk4\\Ui\\Form\\Layout but returns Atk4\\Ui\\AbstractView\.$~'
         -
             path: 'src/Form/Layout/Custom.php'
             message: '~^Method Atk4\\Ui\\Form\\Layout\\Custom::addButton\(\) should return Atk4\\Ui\\Button but returns Atk4\\Ui\\AbstractView\.$~'

--- a/src/AbstractView.php
+++ b/src/AbstractView.php
@@ -42,7 +42,7 @@ abstract class AbstractView
      *
      * @var array<int, array{self, array}>
      */
-    protected $_addLater = [];
+    protected array $_addLater = [];
 
     /** Will be set to true after rendered. This is so that we don't render view twice. */
     protected bool $_rendered = false;

--- a/src/Accordion.php
+++ b/src/Accordion.php
@@ -68,7 +68,7 @@ class Accordion extends View
      *
      * @return JsChain
      */
-    public function jsRefresh($when = null)
+    public function jsRefresh($when = false)
     {
         return $this->jsBehavior('refresh', [], $when);
     }
@@ -79,7 +79,7 @@ class Accordion extends View
      *
      * @return JsChain
      */
-    public function jsOpen($section, $when = null)
+    public function jsOpen($section, $when = false)
     {
         return $this->jsBehavior('open', [$this->getSectionIdx($section)], $when);
     }
@@ -89,7 +89,7 @@ class Accordion extends View
      *
      * @return JsChain
      */
-    public function jsCloseOthers($when = null)
+    public function jsCloseOthers($when = false)
     {
         return $this->jsBehavior('close others', [], $when);
     }
@@ -100,7 +100,7 @@ class Accordion extends View
      *
      * @return JsChain
      */
-    public function jsClose($section, $when = null)
+    public function jsClose($section, $when = false)
     {
         return $this->jsBehavior('close', [$this->getSectionIdx($section)], $when);
     }
@@ -111,7 +111,7 @@ class Accordion extends View
      *
      * @return JsChain
      */
-    public function jsToggle($section, $when = null)
+    public function jsToggle($section, $when = false)
     {
         return $this->jsBehavior('toggle', [$this->getSectionIdx($section)], $when);
     }
@@ -127,7 +127,7 @@ class Accordion extends View
      *
      * @return JsChain
      */
-    public function jsBehavior($behavior, array $args, $when = null)
+    public function jsBehavior($behavior, array $args, $when = false)
     {
         return $this->js($when)->accordion($behavior, ...$args);
     }

--- a/src/App.php
+++ b/src/App.php
@@ -31,14 +31,9 @@ class App
         init as private _init;
     }
 
-    /** @const string */
     public const HOOK_BEFORE_EXIT = self::class . '@beforeExit';
-    /** @const string */
     public const HOOK_BEFORE_RENDER = self::class . '@beforeRender';
-    /** @const string not used, make it public if needed or drop it */
-    private const HOOK_BEFORE_OUTPUT = self::class . '@beforeOutput';
 
-    /** @const string */
     protected const HEADER_STATUS_CODE = 'atk4-status-code';
 
     /** @var array|false Location where to load JS/CSS files */
@@ -568,7 +563,6 @@ class App
             $isExitException = true;
         }
 
-        $this->hook(self::HOOK_BEFORE_OUTPUT);
         if (!$this->exitCalled) { // output already sent by terminate()
             if ($this->isJsUrlRequest()) {
                 $this->outputResponseJson($output);

--- a/src/Callback.php
+++ b/src/Callback.php
@@ -24,10 +24,7 @@ use Atk4\Ui\Exception\UnhandledCallbackExceptionError;
  */
 class Callback extends AbstractView
 {
-    /** @const string */
     public const URL_QUERY_TRIGGER_PREFIX = '__atk_cb_';
-
-    /** @const string */
     public const URL_QUERY_TARGET = '__atk_cbtarget';
 
     /** @var string Specify a custom GET trigger. */

--- a/src/Card.php
+++ b/src/Card.php
@@ -203,16 +203,6 @@ class Card extends View
     }
 
     /**
-     * Add actions from various model.
-     */
-    public function addModelsActions(array $models): void
-    {
-        foreach ($models as $model) {
-            $this->addModelActions($model);
-        }
-    }
-
-    /**
      * Add action from Model.
      */
     public function addModelActions(Model $model): void

--- a/src/Card.php
+++ b/src/Card.php
@@ -380,18 +380,4 @@ class Card extends View
 
         return $btn;
     }
-
-    /**
-     * Add a series of buttons to this card.
-     *
-     * @return View
-     */
-    public function addButtons(array $buttons)
-    {
-        foreach ($buttons as $btn) {
-            $btn = $this->addButton($btn);
-        }
-
-        return $this->getButtonContainer();
-    }
 }

--- a/src/Card.php
+++ b/src/Card.php
@@ -207,17 +207,16 @@ class Card extends View
      */
     public function addModelActions(Model $model): void
     {
-        if ($singleActions = $model->getUserActions(Model\UserAction::APPLIES_TO_SINGLE_RECORD)) {
-            $this->setModel($model);
-            foreach ($singleActions as $action) {
-                $this->addAction($action, $this->executor);
-            }
+        $this->setModel($model);
+
+        $actions = $model->getUserActions(Model\UserAction::APPLIES_TO_SINGLE_RECORD);
+        foreach ($actions as $action) {
+            $this->addAction($action, $this->executor);
         }
 
-        if ($noRecordAction = $model->getUserActions(Model\UserAction::APPLIES_TO_NO_RECORDS)) {
-            foreach ($noRecordAction as $action) {
-                $this->addAction($action, $this->executor);
-            }
+        $actions = $model->getUserActions(Model\UserAction::APPLIES_TO_NO_RECORDS);
+        foreach ($actions as $action) {
+            $this->addAction($action, $this->executor);
         }
     }
 

--- a/src/Columns.php
+++ b/src/Columns.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Atk4\Ui;
 
-use Atk4\Core\Factory;
-
 /**
  * Vertically distributed columns based on CSS Grid system.
  */

--- a/src/Columns.php
+++ b/src/Columns.php
@@ -37,7 +37,7 @@ class Columns extends View
      *
      * @return View
      */
-    public function addColumn($defaults = null)
+    public function addColumn($defaults = [])
     {
         if (!is_array($defaults)) {
             $defaults = [$defaults];
@@ -46,8 +46,7 @@ class Columns extends View
         $size = $defaults[0] ?? null;
         unset($defaults[0]);
 
-        $column = Factory::factory([View::class], $defaults);
-        $this->add($column);
+        $column = View::addTo($this, $defaults);
 
         if ($size && isset($this->sizes[$size])) {
             $column->addClass($this->sizes[$size] . ' wide');

--- a/src/Console.php
+++ b/src/Console.php
@@ -16,7 +16,7 @@ class Console extends View implements \Psr\Log\LoggerInterface
     public $ui = 'inverted black segment';
 
     /**
-     * Specify which event will trigger this console. Set to 'false'
+     * Specify which event will trigger this console. Set to false
      * to disable automatic triggering if you need to trigger it
      * manually.
      *
@@ -80,9 +80,7 @@ class Console extends View implements \Psr\Log\LoggerInterface
             throw new Exception('Please specify the $callback argument');
         }
 
-        if ($event !== null) {
-            $this->event = $event;
-        }
+        $this->event = $event ?? false;
 
         if (!$this->sse) {
             $this->sse = JsSse::addTo($this);

--- a/src/Form.php
+++ b/src/Form.php
@@ -382,7 +382,7 @@ class Form extends View
      *
      * @param string $name Name of control
      *
-     * @return JsChain
+     * @return Jquery
      */
     public function jsInput($name)
     {

--- a/src/Form.php
+++ b/src/Form.php
@@ -355,20 +355,6 @@ class Form extends View
     }
 
     /**
-     * @param array<int, array> $controls
-     *
-     * @return $this
-     */
-    public function addControls(array $controls)
-    {
-        foreach ($controls as $control) {
-            $this->addControl(...$control);
-        }
-
-        return $this;
-    }
-
-    /**
      * Add header into the form, which appears as a separator.
      *
      * @param string|array $title

--- a/src/Form.php
+++ b/src/Form.php
@@ -169,7 +169,7 @@ class Form extends View
         if ($this->buttonSave) {
             $this->buttonSave = $this->layout->addButton($this->buttonSave);
             $this->buttonSave->setAttr('tabindex', 0);
-            $this->buttonSave->on('click', $this->js(null, null, $this->formElement)->form('submit'));
+            $this->buttonSave->on('click', $this->js(false, null, $this->formElement)->form('submit'));
             $this->buttonSave->on('keypress', new JsExpression('if (event.keyCode === 13){ $([name]).form("submit"); }', ['name' => '#' . $this->formElement->name]));
         }
     }

--- a/src/Form.php
+++ b/src/Form.php
@@ -16,13 +16,13 @@ class Form extends View
 {
     use \Atk4\Core\HookTrait;
 
-    /** @const string Executed when form is submitted */
+    /** Executed when form is submitted */
     public const HOOK_SUBMIT = self::class . '@submit';
-    /** @const string Executed when form is submitted */
+    /** Executed when form is submitted */
     public const HOOK_DISPLAY_ERROR = self::class . '@displayError';
-    /** @const string Executed when form is submitted */
+    /** Executed when form is submitted */
     public const HOOK_DISPLAY_SUCCESS = self::class . '@displaySuccess';
-    /** @const string Executed when self::loadPost() method is called. */
+    /** Executed when self::loadPost() method is called. */
     public const HOOK_LOAD_POST = self::class . '@loadPost';
 
     public $ui = 'form';

--- a/src/Form.php
+++ b/src/Form.php
@@ -389,19 +389,6 @@ class Form extends View
         return $this->layout->getControl($name)->js()->find('input');
     }
 
-    /**
-     * Returns JS Chain that targets INPUT of a specified element. This method is handy
-     * if you wish to set a value to a certain field.
-     *
-     * @param string $name Name of control
-     *
-     * @return JsChain
-     */
-    public function jsControl($name)
-    {
-        return $this->layout->getControl($name)->js();
-    }
-
     // }}}
 
     // {{{ Internals

--- a/src/Form/AbstractLayout.php
+++ b/src/Form/AbstractLayout.php
@@ -65,20 +65,6 @@ abstract class AbstractLayout extends View
     }
 
     /**
-     * @param array<int, array> $controls
-     *
-     * @return $this
-     */
-    public function addControls(array $controls)
-    {
-        foreach ($controls as $control) {
-            $this->addControl(...$control);
-        }
-
-        return $this;
-    }
-
-    /**
      * Returns array of names of fields to automatically include them in form.
      * This includes all editable or visible fields of the model.
      *
@@ -104,19 +90,21 @@ abstract class AbstractLayout extends View
             $fields = $this->getModelFields($model);
         }
 
-        // prepare array of controls - check if fields are editable or read-only/disabled
-        $controls = [];
+        // add controls - check if fields are editable or read-only/disabled
         foreach ($fields as $fieldName) {
             $field = $model->getField($fieldName);
 
+            $controlSeed = null;
             if ($field->isEditable()) {
-                $controls[] = [$field->shortName];
+                $controlSeed = [];
             } elseif ($field->isVisible()) {
-                $controls[] = [$field->shortName, ['readOnly' => true]];
+                $controlSeed = ['readOnly' => true];
+            }
+
+            if ($controlSeed !== null) {
+                $this->addControl($field->shortName, $controlSeed);
             }
         }
-
-        $this->addControls($controls);
     }
 
     /**

--- a/src/Form/AbstractLayout.php
+++ b/src/Form/AbstractLayout.php
@@ -13,7 +13,7 @@ use Atk4\Ui\Form;
 use Atk4\Ui\View;
 
 /**
- * Custom Layout for a form (user-defined HTML).
+ * Custom Layout for a form.
  */
 abstract class AbstractLayout extends View
 {
@@ -108,8 +108,7 @@ abstract class AbstractLayout extends View
     }
 
     /**
-     * Return Field decorator associated with
-     * the form's field.
+     * Return Field decorator associated with the form's field.
      */
     public function getControl(string $name): Control
     {

--- a/src/Form/Control.php
+++ b/src/Form/Control.php
@@ -168,12 +168,12 @@ class Control extends View
      *
      * $field->jsInput(true)->val(123);
      *
-     * @param string|bool|null $when
+     * @param bool|string      $when
      * @param JsExpressionable $action
      *
      * @return Jquery
      */
-    public function jsInput($when = null, $action = null)
+    public function jsInput($when = false, $action = null)
     {
         return $this->js($when, $action, '#' . $this->name . '_input');
     }

--- a/src/Form/Control/Checkbox.php
+++ b/src/Form/Control/Checkbox.php
@@ -80,12 +80,12 @@ class Checkbox extends Form\Control
     /**
      * Will return jQuery expression to get checkbox checked state.
      *
-     * @param string|bool|null $when
+     * @param bool|string      $when
      * @param JsExpressionable $action
      *
      * @return Jquery
      */
-    public function jsChecked($when = null, $action = null)
+    public function jsChecked($when = false, $action = null)
     {
         return $this->jsInput($when, $action)->get(0)->checked;
     }

--- a/src/Form/Control/Input.php
+++ b/src/Form/Control/Input.php
@@ -249,7 +249,7 @@ class Input extends Form\Control
      */
     public function addAction(array $defaults = [])
     {
-        $this->action = Button::addTo($this, [$defaults], ['AfterInput']);
+        $this->action = Button::addTo($this, $defaults, ['AfterInput']);
         $this->addClass('action');
 
         return $this->action;

--- a/src/Form/Layout.php
+++ b/src/Form/Layout.php
@@ -111,7 +111,7 @@ class Layout extends AbstractLayout
      * @param mixed $seed
      * @param bool  $addDivider Should we add divider after this section
      *
-     * @return static
+     * @return self
      */
     public function addSubLayout($seed = [self::class], $addDivider = true)
     {

--- a/src/Form/Layout/Custom.php
+++ b/src/Form/Layout/Custom.php
@@ -9,9 +9,6 @@ use Atk4\Ui\Button;
 use Atk4\Ui\Exception;
 use Atk4\Ui\Form;
 
-/**
- * Custom Layout for a form (user-defined HTML).
- */
 class Custom extends Form\AbstractLayout
 {
     /** @var string */

--- a/src/Form/Layout/Section/Columns.php
+++ b/src/Form/Layout/Section/Columns.php
@@ -24,7 +24,7 @@ class Columns extends UiColumns
      *
      * @return Form\Layout
      */
-    public function addColumn($defaults = null)
+    public function addColumn($defaults = [])
     {
         $column = parent::addColumn($defaults);
 

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -440,16 +440,6 @@ class Grid extends View
     }
 
     /**
-     * Add action menu item using an array.
-     */
-    public function addActionMenuItems(array $actions = []): void
-    {
-        foreach ($actions as $action) {
-            $this->addActionMenuItem($action);
-        }
-    }
-
-    /**
      * Add action menu items using Model.
      * You may specify the scope of actions to be added.
      *

--- a/src/HtmlTemplate.php
+++ b/src/HtmlTemplate.php
@@ -18,7 +18,6 @@ class HtmlTemplate
     use AppScopeTrait;
     use WarnDynamicPropertyTrait;
 
-    /** @const string */
     public const TOP_TAG = '_top';
 
     /** @var array<string, string|false> */

--- a/src/JsSse.php
+++ b/src/JsSse.php
@@ -13,8 +13,8 @@ class JsSse extends JsCallback
 {
     use HookTrait;
 
-    /** @const string Executed when user aborted, or disconnect browser, when using this SSE. */
-    public const HOOK_ABORTED = self::class . '@connection_aborted';
+    /** Executed when user aborted, or disconnect browser, when using this SSE. */
+    public const HOOK_ABORTED = self::class . '@connectionAborted';
 
     /** @var bool Allows us to fall-back to standard functionality of JsCallback if browser does not support SSE. */
     public $browserSupport = false;

--- a/src/Lister.php
+++ b/src/Lister.php
@@ -11,9 +11,7 @@ class Lister extends View
 {
     use HookTrait;
 
-    /** @const string */
     public const HOOK_BEFORE_ROW = self::class . '@beforeRow';
-    /** @const string */
     public const HOOK_AFTER_ROW = self::class . '@afterRow';
 
     /**

--- a/src/Table/Column.php
+++ b/src/Table/Column.php
@@ -33,8 +33,8 @@ class Column
     /** @var Table Link back to the table, where column is used. */
     public $table;
 
-    /** @var array Contains any custom attributes that may be applied on head, body or foot. */
-    public $attr = [];
+    /** Contains any custom attributes that may be applied on head, body or foot. */
+    public array $attr = [];
 
     /** @var string|null If set, will override column header value. */
     public $caption;

--- a/src/Table/Column.php
+++ b/src/Table/Column.php
@@ -25,9 +25,7 @@ class Column
     use \Atk4\Core\NameTrait;
     use \Atk4\Core\TrackableTrait;
 
-    /** @const string */
     public const HOOK_GET_HTML_TAGS = self::class . '@getHtmlTags';
-    /** @const string */
     public const HOOK_GET_HEADER_CELL_HTML = self::class . '@getHeaderCellHtml';
 
     /** @var Table Link back to the table, where column is used. */

--- a/src/Table/Column/Checkbox.php
+++ b/src/Table/Column/Checkbox.php
@@ -26,7 +26,7 @@ class Checkbox extends Table\Column
      */
     public function jsChecked()
     {
-        return new JsExpression(' $(' . $this->table->jsRender() . ').find(\'.checked.' . $this->class . '\').closest(\'tr\').map(function() { '
+        return new JsExpression('$(' . $this->table->jsRender() . ').find(\'.checked.' . $this->class . '\').closest(\'tr\').map(function() { '
             . 'return $(this).data(\'id\'); }).get().join(\',\')');
     }
 

--- a/src/Table/Column/FilterPopup.php
+++ b/src/Table/Column/FilterPopup.php
@@ -73,7 +73,7 @@ class FilterPopup extends Popup
                 $model->clearData();
 
                 return [
-                    $this->form->js(null, null, $this->form->formElement)->form('reset'),
+                    $this->form->js(false, null, $this->form->formElement)->form('reset'),
                     new JsReload($this->reload),
                     (new Jquery($this->colTrigger))->trigger('click'),
                 ];

--- a/src/Table/Column/Image.php
+++ b/src/Table/Column/Image.php
@@ -12,8 +12,7 @@ use Atk4\Ui\Table;
  */
 class Image extends Table\Column
 {
-    /** @var array Overrides custom attributes that will be applied on head, body or foot. */
-    public $attr = ['all' => ['class' => ['center aligned single line']]];
+    public array $attr = ['all' => ['class' => ['center aligned single line']]];
 
     public function getDataCellTemplate(Field $field = null): string
     {

--- a/src/Table/Column/Money.php
+++ b/src/Table/Column/Money.php
@@ -14,7 +14,7 @@ use Atk4\Ui\Table;
  */
 class Money extends Table\Column
 {
-    public $attr = ['all' => ['class' => ['right aligned single line']]];
+    public array $attr = ['all' => ['class' => ['right aligned single line']]];
 
     /** @var bool Should we show zero values in cells? */
     public $showZeroValues = true;

--- a/src/Table/Column/Text.php
+++ b/src/Table/Column/Text.php
@@ -11,5 +11,5 @@ use Atk4\Ui\Table;
  */
 class Text extends Table\Column
 {
-    public $attr = ['all' => ['class' => ['atk-cell-expanded']]];
+    public array $attr = ['all' => ['class' => ['atk-cell-expanded']]];
 }

--- a/src/TabsSubview.php
+++ b/src/TabsSubview.php
@@ -9,7 +9,7 @@ namespace Atk4\Ui;
  */
 class TabsSubview extends View
 {
-    public $class = ['ui tab'];
+    public array $class = ['ui tab'];
 
     /** @var string */
     public $dataTabName;

--- a/src/UserAction/BasicExecutor.php
+++ b/src/UserAction/BasicExecutor.php
@@ -18,7 +18,6 @@ class BasicExecutor extends View implements ExecutorInterface
 {
     use HookTrait;
 
-    /** @const string */
     public const HOOK_AFTER_EXECUTE = self::class . '@afterExecute';
 
     /** @var Model\UserAction|null */

--- a/src/UserAction/ExecutorFactory.php
+++ b/src/UserAction/ExecutorFactory.php
@@ -28,8 +28,8 @@ class ExecutorFactory
     public const MENU_ITEM = self::class . '@menuItem';
     public const TABLE_MENU_ITEM = self::class . '@tableMenuItem';
 
-    // TODO this should be not a constant, as all constants should be final
-    public const BUTTON_PRIMARY_COLOR = 'primary';
+    /** @var string */
+    public $buttonPrimaryColor = 'primary';
 
     /**
      * Store basic type of executor to use for create method.
@@ -213,7 +213,7 @@ class ExecutorFactory
             case self::MODAL_BUTTON:
                 $seed = [Button::class, $this->getActionCaption($action, $type)];
                 if ($type === self::MODAL_BUTTON || $type === self::CARD_BUTTON) {
-                    $seed['class.' . static::BUTTON_PRIMARY_COLOR] = true;
+                    $seed['class.' . $this->buttonPrimaryColor] = true;
                 }
 
                 break;

--- a/src/UserAction/ExecutorFactory.php
+++ b/src/UserAction/ExecutorFactory.php
@@ -28,6 +28,7 @@ class ExecutorFactory
     public const MENU_ITEM = self::class . '@menuItem';
     public const TABLE_MENU_ITEM = self::class . '@tableMenuItem';
 
+    // TODO this should be not a constant, as all constants should be final
     public const BUTTON_PRIMARY_COLOR = 'primary';
 
     /**

--- a/src/UserAction/ModalExecutor.php
+++ b/src/UserAction/ModalExecutor.php
@@ -35,7 +35,6 @@ class ModalExecutor extends Modal implements JsExecutorInterface
     use HookTrait;
     use StepExecutorTrait;
 
-    /** @const string */
     public const HOOK_STEP = self::class . '@onStep';
 
     protected function init(): void

--- a/src/UserAction/PanelExecutor.php
+++ b/src/UserAction/PanelExecutor.php
@@ -21,7 +21,6 @@ class PanelExecutor extends Right implements JsExecutorInterface
     use HookTrait;
     use StepExecutorTrait;
 
-    /** @const string */
     public const HOOK_STEP = self::class . '@onStep';
 
     /** @var array No need for dynamic content. It is manage with step loader. */

--- a/src/UserAction/StepExecutorTrait.php
+++ b/src/UserAction/StepExecutorTrait.php
@@ -427,10 +427,10 @@ trait StepExecutorTrait
     protected function jsSetSubmitBtn(View $view, Form $form, string $step): void
     {
         if ($this->isLastStep($step)) {
-            $view->js(true, $this->execActionBtn->js()->on('click', new JsFunction([$form->js(null, null, $form->formElement)->form('submit')])));
+            $view->js(true, $this->execActionBtn->js()->on('click', new JsFunction([$form->js(false, null, $form->formElement)->form('submit')])));
         } else {
             // submit on next
-            $view->js(true, $this->nextStepBtn->js()->on('click', new JsFunction([$form->js(null, null, $form->formElement)->form('submit')])));
+            $view->js(true, $this->nextStepBtn->js()->on('click', new JsFunction([$form->js(false, null, $form->formElement)->form('submit')])));
         }
     }
 

--- a/src/UserAction/VpExecutor.php
+++ b/src/UserAction/VpExecutor.php
@@ -24,7 +24,6 @@ class VpExecutor extends View implements JsExecutorInterface
     use HookTrait;
     use StepExecutorTrait;
 
-    /** @const string */
     public const HOOK_STEP = self::class . '@onStep';
 
     /** @var VirtualPage */

--- a/src/View.php
+++ b/src/View.php
@@ -14,19 +14,16 @@ use Atk4\Ui\UserAction\ExecutorFactory;
 class View extends AbstractView implements JsExpressionable
 {
     /**
-     * When you call render() this will be populated with JavaScript
-     * chains.
+     * When you call render() this will be populated with JavaScript chains.
      *
      * @internal
      */
     protected array $_jsActions = [];
 
-    /** @var Model|null */
-    public $model;
+    public ?Model $model = null;
 
     /**
-     * Name of the region in the parent's template where this object
-     * will output itself.
+     * Name of the region in the parent's template where this object will output itself.
      */
     public ?string $region = null;
 
@@ -39,14 +36,14 @@ class View extends AbstractView implements JsExpressionable
      */
     public $ui = false;
 
-    /** @var array List of classes that needs to be added. */
-    public $class = [];
+    /** List of classes that needs to be added. */
+    public array $class = [];
 
-    /** @var array List of custom CSS attributes. */
-    public $style = [];
+    /** List of custom CSS attributes. */
+    public array $style = [];
 
-    /** @var array List of custom attributes. */
-    public $attr = [];
+    /** List of custom attributes. */
+    public array $attr = [];
 
     /**
      * Template object, that, for most Views will be rendered to
@@ -74,7 +71,7 @@ class View extends AbstractView implements JsExpressionable
     /** @var string Change this if you want to substitute default "div" for something else. */
     public $element;
 
-    /** @var ExecutorFactory|null Seed class name */
+    /** @var ExecutorFactory|null */
     protected $executorFactory;
 
     // {{{ Setting Things up

--- a/src/View.php
+++ b/src/View.php
@@ -9,7 +9,7 @@ use Atk4\Data\Persistence;
 use Atk4\Ui\UserAction\ExecutorFactory;
 
 /**
- * Base view of all other UI components.
+ * Base view of all UI components.
  */
 class View extends AbstractView implements JsExpressionable
 {
@@ -765,36 +765,29 @@ class View extends AbstractView implements JsExpressionable
      *
      * @see http://agile-ui.readthedocs.io/en/latest/js.html
      *
-     * @param string|bool|null $when     Event when chain will be executed
+     * @param bool|string      $when     Event when chain will be executed
      * @param JsExpressionable $action   JavaScript action
      * @param string|self|null $selector If you wish to override jQuery($selector)
      *
      * @return Jquery
      */
-    public function js($when = null, $action = null, $selector = null)
+    public function js($when = false, $action = null, $selector = null)
     {
         $chain = new Jquery($selector ?? $this);
 
-        // Substitute $when to make it better work as a array key
         if ($when === true) {
             $this->_jsActions[$when][] = $chain;
 
             if ($action) {
                 $this->_jsActions[$when][] = $action;
             }
+        } elseif ($when !== false) {
+            // binding on a specific event
+            $action = (new Jquery($this))
+                ->bind($when, new JsFunction([$chain, $action]));
 
-            return $chain;
+            $this->_jsActions[$when][] = $action;
         }
-
-        if ($when === false || $when === null) {
-            return $chain;
-        }
-
-        // next - binding on a specific event
-        $action = (new Jquery($this))
-            ->bind($when, new JsFunction([$chain, $action]));
-
-        $this->_jsActions[$when][] = $action;
 
         return $chain;
     }

--- a/tests/CallbackTest.php
+++ b/tests/CallbackTest.php
@@ -12,22 +12,11 @@ use Atk4\Ui\CallbackLater;
 use Atk4\Ui\Layout;
 use Atk4\Ui\View;
 use Atk4\Ui\VirtualPage;
-use Mvorisek\Atk4\Hintable\Phpstan\PhpstanUtil;
 
 class AppMock extends App
 {
-    /** @var bool */
-    public $terminated = false;
-
-    public function terminate($output = '', array $headers = []): void
-    {
-        $this->terminated = true;
-
-        PhpstanUtil::fakeNeverReturn();
-    }
-
     /**
-     * Overrided to allow multiple App::run() calls, prevent sending headers when headers are already sent.
+     * Overriden to allow multiple App::run() calls, prevent sending headers when headers are already sent.
      */
     protected function outputResponse(string $data, array $headers): void
     {

--- a/tests/Concerns/HandlesTableTrait.php
+++ b/tests/Concerns/HandlesTableTrait.php
@@ -6,7 +6,7 @@ namespace Atk4\Ui\Tests\Concerns;
 
 use Atk4\Ui\Table;
 
-trait HandlesTable
+trait HandlesTableTrait
 {
     /**
      * Extract only <tr> out from a Table given the <tr> data-id attribute value.

--- a/tests/DemosTest.php
+++ b/tests/DemosTest.php
@@ -26,9 +26,7 @@ use Psr\Http\Message\ResponseInterface;
  */
 class DemosTest extends TestCase
 {
-    /** @const string */
     protected const ROOT_DIR = __DIR__ . '/..';
-    /** @const string */
     protected const DEMOS_DIR = self::ROOT_DIR . '/demos';
 
     private static array $_serverSuperglobalBackup;

--- a/tests/ExecutorFactoryTest.php
+++ b/tests/ExecutorFactoryTest.php
@@ -13,6 +13,7 @@ use Atk4\Ui\Layout;
 use Atk4\Ui\MenuItem;
 use Atk4\Ui\UserAction\BasicExecutor;
 use Atk4\Ui\UserAction\ConfirmationExecutor;
+use Atk4\Ui\UserAction\ExecutorFactory;
 use Atk4\Ui\UserAction\JsCallbackExecutor;
 use Atk4\Ui\UserAction\ModalExecutor;
 use Atk4\Ui\View;
@@ -90,29 +91,29 @@ class ExecutorFactoryTest extends TestCase
         $editAction = $this->model->getUserAction('edit');
         $addAction = $this->model->getUserAction('add');
 
-        $modalButton = Button::assertInstanceOf($factory->createTrigger($editAction, $factory::MODAL_BUTTON));
-        static::assertSame($factory->getCaption($editAction, $factory::MODAL_BUTTON), $modalButton->content);
+        $modalButton = Button::assertInstanceOf($factory->createTrigger($editAction, ExecutorFactory::MODAL_BUTTON));
+        static::assertSame($factory->getCaption($editAction, ExecutorFactory::MODAL_BUTTON), $modalButton->content);
 
-        $cardButton = Button::assertInstanceOf($factory->createTrigger($editAction, $factory::CARD_BUTTON));
-        static::assertSame($factory->getCaption($editAction, $factory::CARD_BUTTON), $cardButton->content);
+        $cardButton = Button::assertInstanceOf($factory->createTrigger($editAction, ExecutorFactory::CARD_BUTTON));
+        static::assertSame($factory->getCaption($editAction, ExecutorFactory::CARD_BUTTON), $cardButton->content);
 
-        $tableButton = Button::assertInstanceOf($factory->createTrigger($editAction, $factory::TABLE_BUTTON));
+        $tableButton = Button::assertInstanceOf($factory->createTrigger($editAction, ExecutorFactory::TABLE_BUTTON));
         static::assertNull($tableButton->content);
         static::assertSame($tableButton->icon, 'edit');
 
-        $addMenuItem = MenuItem::assertInstanceOf($factory->createTrigger($addAction, $factory::MENU_ITEM));
+        $addMenuItem = MenuItem::assertInstanceOf($factory->createTrigger($addAction, ExecutorFactory::MENU_ITEM));
         static::assertSame($addMenuItem->content, 'Add Test');
         static::assertSame($addMenuItem->icon, 'plus');
 
-        $tableMenuItem = MenuItem::assertInstanceOf($factory->createTrigger($editAction, $factory::TABLE_MENU_ITEM));
-        static::assertSame($factory->getCaption($editAction, $factory::TABLE_MENU_ITEM), $tableMenuItem->content);
+        $tableMenuItem = MenuItem::assertInstanceOf($factory->createTrigger($editAction, ExecutorFactory::TABLE_MENU_ITEM));
+        static::assertSame($factory->getCaption($editAction, ExecutorFactory::TABLE_MENU_ITEM), $tableMenuItem->content);
     }
 
     public function testRegisterTrigger(): void
     {
         $factory = $this->app->getExecutorFactory();
-        $factory->useTriggerDefault($factory::TABLE_BUTTON);
-        $factory->useTriggerDefault($factory::MENU_ITEM);
+        $factory->useTriggerDefault(ExecutorFactory::TABLE_BUTTON);
+        $factory->useTriggerDefault(ExecutorFactory::MENU_ITEM);
 
         $editAction = $this->model->getUserAction('edit');
 
@@ -126,18 +127,18 @@ class ExecutorFactoryTest extends TestCase
         });
         $specialEditAction = (new $specialClass($p))->getUserAction('edit');
 
-        $factory->registerTrigger($factory::MENU_ITEM, [MenuItem::class, 'edit_item', 'icon' => 'pencil'], $editAction);
-        $editItem = MenuItem::assertInstanceOf($factory->createTrigger($editAction, $factory::MENU_ITEM));
+        $factory->registerTrigger(ExecutorFactory::MENU_ITEM, [MenuItem::class, 'edit_item', 'icon' => 'pencil'], $editAction);
+        $editItem = MenuItem::assertInstanceOf($factory->createTrigger($editAction, ExecutorFactory::MENU_ITEM));
 
         static::assertSame('edit_item', $editItem->content);
         static::assertSame('pencil', $editItem->icon);
 
-        $factory->registerTrigger($factory::TABLE_BUTTON, [Button::class, 'edit_button'], $editAction);
-        $factory->registerTrigger($factory::TABLE_BUTTON, [Button::class, 'specific_edit_button'], $specialEditAction, true);
+        $factory->registerTrigger(ExecutorFactory::TABLE_BUTTON, [Button::class, 'edit_button'], $editAction);
+        $factory->registerTrigger(ExecutorFactory::TABLE_BUTTON, [Button::class, 'specific_edit_button'], $specialEditAction, true);
 
-        $editButton = Button::assertInstanceOf($factory->createTrigger($editAction, $factory::TABLE_BUTTON));
-        $secondEditButon = Button::assertInstanceOf($factory->createTrigger($secondEditAction, $factory::TABLE_BUTTON));
-        $specialEditButton = Button::assertInstanceOf($factory->createTrigger($specialEditAction, $factory::TABLE_BUTTON));
+        $editButton = Button::assertInstanceOf($factory->createTrigger($editAction, ExecutorFactory::TABLE_BUTTON));
+        $secondEditButon = Button::assertInstanceOf($factory->createTrigger($secondEditAction, ExecutorFactory::TABLE_BUTTON));
+        $specialEditButton = Button::assertInstanceOf($factory->createTrigger($specialEditAction, ExecutorFactory::TABLE_BUTTON));
 
         static::assertSame('specific_edit_button', $specialEditButton->content);
         static::assertSame($editButton->content, $secondEditButon->content);

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -8,6 +8,7 @@ use Atk4\Core\Phpunit\TestCase;
 use Atk4\Data\Model;
 use Atk4\Ui\App;
 use Atk4\Ui\Callback;
+use Atk4\Ui\Exception;
 use Atk4\Ui\Form;
 use Mvorisek\Atk4\Hintable\Phpstan\PhpstanUtil;
 
@@ -140,7 +141,7 @@ class FormTest extends TestCase
         static::assertGreaterThan(0, $n);
         foreach ($matchesAll as $matches) {
             if ($matches[1] === $field) {
-                static::fail('Form control ' . $field . ' unexpected error: ' . $matches[2]);
+                throw new Exception('Form control ' . $field . ' unexpected error: ' . $matches[2]);
             }
         }
     }

--- a/tests/GridTest.php
+++ b/tests/GridTest.php
@@ -11,7 +11,7 @@ use Atk4\Ui\Table;
 
 class GridTest extends TestCase
 {
-    use Concerns\HandlesTable;
+    use Concerns\HandlesTableTrait;
 
     /** @var MyModel */
     public $m;

--- a/tests/GridTest.php
+++ b/tests/GridTest.php
@@ -11,7 +11,7 @@ use Atk4\Ui\Table;
 
 class GridTest extends TestCase
 {
-    use Concerns\HandlesTableTrait;
+    use TableTestTrait;
 
     /** @var MyModel */
     public $m;

--- a/tests/ListerTest.php
+++ b/tests/ListerTest.php
@@ -37,10 +37,10 @@ class ListerTest extends TestCase
 
     public function testAddAfterRender(): void
     {
-        $this->expectException(Exception::class);
         $v = new View();
         $v->invokeInit();
-        $l = Lister::addTo($v);
-        $l->setSource(['foo', 'bar']);
+
+        $this->expectException(Exception::class);
+        Lister::addTo($v);
     }
 }

--- a/tests/TableColumnColorRatingTest.php
+++ b/tests/TableColumnColorRatingTest.php
@@ -12,7 +12,7 @@ use Atk4\Ui\Table;
 
 class TableColumnColorRatingTest extends TestCase
 {
-    use Concerns\HandlesTableTrait;
+    use TableTestTrait;
 
     /** @var Table */
     public $table;

--- a/tests/TableColumnColorRatingTest.php
+++ b/tests/TableColumnColorRatingTest.php
@@ -12,7 +12,7 @@ use Atk4\Ui\Table;
 
 class TableColumnColorRatingTest extends TestCase
 {
-    use Concerns\HandlesTable;
+    use Concerns\HandlesTableTrait;
 
     /** @var Table */
     public $table;

--- a/tests/TableColumnLinkTest.php
+++ b/tests/TableColumnLinkTest.php
@@ -11,7 +11,7 @@ use Atk4\Ui\Table;
 
 class TableColumnLinkTest extends TestCase
 {
-    use Concerns\HandlesTable;
+    use Concerns\HandlesTableTrait;
 
     /** @var Table */
     public $table;

--- a/tests/TableColumnLinkTest.php
+++ b/tests/TableColumnLinkTest.php
@@ -11,7 +11,7 @@ use Atk4\Ui\Table;
 
 class TableColumnLinkTest extends TestCase
 {
-    use Concerns\HandlesTableTrait;
+    use TableTestTrait;
 
     /** @var Table */
     public $table;

--- a/tests/TableTestTrait.php
+++ b/tests/TableTestTrait.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Atk4\Ui\Tests\Concerns;
+namespace Atk4\Ui\Tests;
 
 use Atk4\Ui\Table;
 
-trait HandlesTableTrait
+trait TableTestTrait
 {
     /**
      * Extract only <tr> out from a Table given the <tr> data-id attribute value.


### PR DESCRIPTION
such method was confusing as the accepted input did not match `Model::addFields()` and nor implied form group

the removed methods were also never used nor covered