### PR TITLE
Validation exception can be rendered only if a form field exists

### DIFF
--- a/demos/form-control/lookup.php
+++ b/demos/form-control/lookup.php
@@ -48,16 +48,13 @@ $form->addControl('country3', [
 ]);
 
 $form->onSubmit(function (Form $form) {
-    $str = $form->model->ref('country1')->get(Country::hinting()->fieldName()->name)
-        . '; '
-        . $form->model->ref('country2')->get(Country::hinting()->fieldName()->name)
-        . '; '
-        . (new Country($form->getApp()->db))->load($form->model->get('country3'))
-            ->get(Country::hinting()->fieldName()->name);
-
     $view = new Message('Select:'); // need in behat test.
     $view->invokeInit();
-    $view->text->addParagraph($str);
+    $view->text->addParagraph($form->model->ref('country1')->get(Country::hinting()->fieldName()->name) ?? 'null');
+    $view->text->addParagraph($form->model->ref('country2')->get(Country::hinting()->fieldName()->name) ?? 'null');
+    $view->text->addParagraph($form->model->get('country3') !== '' // related with https://github.com/atk4/ui/pull/1805
+        ? (new Country($form->getApp()->db))->load($form->model->get('country3'))->get(Country::hinting()->fieldName()->name)
+        : 'null');
 
     return $view;
 });

--- a/src/Form.php
+++ b/src/Form.php
@@ -259,6 +259,10 @@ class Form extends View
             } catch (ValidationException $e) {
                 $response = [];
                 foreach ($e->errors as $field => $error) {
+                    if (!isset($this->controls[$field])) {
+                        throw $e;
+                    }
+
                     $response[] = $this->error($field, $error);
                 }
 

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -9,6 +9,7 @@ use Atk4\Data\Model;
 use Atk4\Ui\App;
 use Atk4\Ui\Callback;
 use Atk4\Ui\Exception;
+use Atk4\Ui\Exception\UnhandledCallbackExceptionError;
 use Atk4\Ui\Form;
 use Mvorisek\Atk4\Hintable\Phpstan\PhpstanUtil;
 
@@ -115,11 +116,6 @@ class FormTest extends TestCase
         });
     }
 
-    public function assertSubmitError(array $post, \Closure $checkExpectedErrorsFx): void
-    {
-        $this->assertSubmit($post, null, $checkExpectedErrorsFx);
-    }
-
     public function assertFormControlError(string $field, string $error): void
     {
         $n = preg_match_all('~form\("add prompt", "([^"]*)", "([^"]*)"\)~', $this->formError, $matchesAll, \PREG_SET_ORDER);
@@ -162,7 +158,7 @@ class FormTest extends TestCase
         $m = $m->createEntity();
         $this->form->setModel($m);
 
-        $this->assertSubmitError(['opt1' => '2', 'opt3_z' => '0', 'opt4' => '', 'opt4_z' => '0'], function (string $formError) {
+        $this->assertSubmit(['opt1' => '2', 'opt3_z' => '0', 'opt4' => '', 'opt4_z' => '0'], null, function (string $formError) {
             // dropdown validates to make sure option is proper
             $this->assertFormControlError('opt1', 'not one of the allowed values');
 
@@ -174,6 +170,21 @@ class FormTest extends TestCase
             $this->assertFromControlNoErrors('opt3_z');
             $this->assertFormControlError('opt4', 'Must not be empty');
             $this->assertFormControlError('opt4_z', 'Must not be empty');
+        });
+    }
+
+    public function testSubmitNonFormFieldError(): void
+    {
+        $m = new Model();
+        $m->addField('foo', ['nullable' => false]);
+        $m->addField('bar', ['nullable' => false]);
+
+        $m = $m->createEntity();
+        $this->form->setModel($m, ['foo']);
+
+        $this->expectException(UnhandledCallbackExceptionError::class);
+        $this->assertSubmit(['foo' => 'x'], function (Model $model) {
+            $model->set('bar', null);
         });
     }
 }

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -6,6 +6,7 @@ namespace Atk4\Ui\Tests;
 
 use Atk4\Core\Phpunit\TestCase;
 use Atk4\Data\Model;
+use Atk4\Data\ValidationException;
 use Atk4\Ui\App;
 use Atk4\Ui\Callback;
 use Atk4\Ui\Exception;
@@ -182,10 +183,19 @@ class FormTest extends TestCase
         $m = $m->createEntity();
         $this->form->setModel($m, ['foo']);
 
-        $this->expectException(UnhandledCallbackExceptionError::class);
-        $this->assertSubmit(['foo' => 'x'], function (Model $model) {
-            $model->set('bar', null);
-        });
+        try {
+            $this->assertSubmit(['foo' => 'x'], function (Model $model) {
+                $model->set('bar', null);
+            });
+
+            static::assertFalse(true);
+        } catch (UnhandledCallbackExceptionError $e) {
+            $this->expectException(ValidationException::class);
+            $this->expectExceptionMessage('Must not be null');
+            static::assertSame('bar', $e->getPrevious()->getParams()['field']->shortName);
+
+            throw $e->getPrevious();
+        }
     }
 }
 


### PR DESCRIPTION
fix #1817