### PR TITLE
Fix SQL multiply of 2 bind params in multiline demo for PostgreSQL

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -399,7 +399,8 @@ jobs:
           php demos/_demo-data/create-db.php
           vendor/bin/behat -vv --config behat.yml.dist
 
-      - name: "Run tests: PostgreSQL"
+      - name: "Run tests: PostgreSQL (only for cron)"
+        if: (success() || failure()) && github.event_name == 'schedule'
         env:
           DB_DSN: "pgsql:host=postgres;dbname=atk4_test"
           DB_USER: atk4_test_user

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -399,8 +399,7 @@ jobs:
           php demos/_demo-data/create-db.php
           vendor/bin/behat -vv --config behat.yml.dist
 
-      - name: "Run tests: PostgreSQL (only for cron)"
-        if: (success() || failure()) && github.event_name == 'schedule'
+      - name: "Run tests: PostgreSQL"
         env:
           DB_DSN: "pgsql:host=postgres;dbname=atk4_test"
           DB_USER: atk4_test_user

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -312,7 +312,7 @@ jobs:
       - name: Lint JS files (only for Slow)
         if: matrix.type == 'Chrome Slow'
         run: |
-          (cd js && npm run lint ../public/external/\*.js)
+          (cd js && npm run lint)
 
       - name: Compile HTML files (only for Slow)
         if: matrix.type == 'Chrome Slow'

--- a/demos/_demo-data/create-db.php
+++ b/demos/_demo-data/create-db.php
@@ -1161,4 +1161,14 @@ $model->import([
     ['id' => 2, 'item' => 'DAP delivery', 'inv_date' => '2020-02-01', 'inv_time' => '8:33', 'country_id' => 223, 'qty' => 2, 'box' => 100],
 ]);
 
+$model = new ImportModelWithPrefixedFields($db, ['table' => 'multiline_delivery']);
+$model->addField('name', ['type' => 'string']);
+$model->addField('country', ['type' => 'json']);
+$model->addField('items', ['type' => 'json']);
+(new Migrator($model))->create();
+$model->import([
+    // TODO Model::containsXxx support
+    // https://github.com/atk4/ui/issues/1860
+]);
+
 echo 'import complete!' . "\n\n";

--- a/demos/form-control/multiline-containsmany.php
+++ b/demos/form-control/multiline-containsmany.php
@@ -5,52 +5,8 @@ declare(strict_types=1);
 namespace Atk4\Ui\Demos;
 
 use Atk4\Ui\Crud;
-use Atk4\Ui\Form;
 
 /** @var \Atk4\Ui\App $app */
 require_once __DIR__ . '/../init-app.php';
 
-// This demo require specific Database setup.
-
-if (!class_exists(Client::class)) {
-    class Client extends ModelWithPrefixedFields
-    {
-        public $table = 'client';
-        public $caption = 'Client';
-
-        protected function init(): void
-        {
-            parent::init();
-
-            $this->addField('name');
-            $this->containsMany('accounts', ['model' => [Account::class]]);
-        }
-    }
-
-    class Account extends ModelWithPrefixedFields
-    {
-        public $caption = ' ';
-
-        protected function init(): void
-        {
-            parent::init();
-
-            $this->addField('email', [
-                'required' => true,
-                'ui' => ['multiline' => [Form\Control\Multiline::INPUT => ['icon' => 'envelope', 'type' => 'email']]],
-            ]);
-            $this->addField('password', [
-                'required' => true,
-                'ui' => ['multiline' => [Form\Control\Multiline::INPUT => ['icon' => 'key', 'type' => 'password']]],
-            ]);
-            $this->addField('site', ['required' => true]);
-            $this->addField('type', [
-                'default' => 'user',
-                'values' => ['user' => 'Regular User', 'admin' => 'System Admin'],
-                'ui' => ['multiline' => [Form\Control\Multiline::TABLE_CELL => ['width' => 'four']]],
-            ]);
-        }
-    }
-}
-
-Crud::addTo($app)->setModel(new Client($app->db));
+Crud::addTo($app)->setModel(new MultilineDelivery($app->db));

--- a/demos/init-db.php
+++ b/demos/init-db.php
@@ -536,7 +536,7 @@ class MultilineItem extends ModelWithPrefixedFields
  * @property Country       $country @Atk4\RefOne()
  * @property MultilineItem $items   @Atk4\RefMany()
  */
-class MultiLineDelivery extends ModelWithPrefixedFields
+class MultilineDelivery extends ModelWithPrefixedFields
 {
     public $table = 'multiline_delivery';
 

--- a/demos/init-db.php
+++ b/demos/init-db.php
@@ -530,3 +530,22 @@ class MultilineItem extends ModelWithPrefixedFields
         ]);
     }
 }
+
+/**
+ * @property string        $name    @Atk4\Field()
+ * @property Country       $country @Atk4\RefOne()
+ * @property MultilineItem $items   @Atk4\RefMany()
+ */
+class MultiLineDelivery extends ModelWithPrefixedFields
+{
+    public $table = 'multiline_delivery';
+
+    protected function init(): void
+    {
+        parent::init();
+
+        $this->addField($this->fieldName()->name, ['required' => true]);
+        $this->containsOne($this->fieldName()->country, ['model' => [Country::class]]);
+        $this->containsMany($this->fieldName()->items, ['model' => [MultilineItem::class]]);
+    }
+}


### PR DESCRIPTION
```
Atk4\Data\Persistence\Sql\ExecuteException [code: 7]:
ERROR: operator is not unique: unknown * unknown
LINE 1: ..._box", $7 * $8 "atk_...
HINT:  Could not choose a best candidate operator. You might need to add explicit type casts.
query:
select (-1) "atk_fp_multiline_item__id",
    'Chocolate' "atk_fp_multiline_item__item",
    '2020-02-20' "atk_fp_multiline_item__inv_date",
    '07:20:00.000000' "atk_fp_multiline_item__inv_time",
    80 "atk_fp_multiline_item__country_id",
    0 "atk_fp_multiline_item__qty",
    5 "atk_fp_multiline_item__box",
    0 * 5 "atk_fp_multiline_item__total_sql",
    NULL "atk_fp_multiline_item__total_php"
from "multiline_item" limit 1 offset 0
```

related with https://github.com/atk4/data/pull/989

the problem is type info is not avaialbe before the SQL bind params are passed, but PostgreSQL needs the type info earlier