### PR TITLE
Fix DropdownCascade /w custom row render callback

### DIFF
--- a/src/Form/Control/DropdownCascade.php
+++ b/src/Form/Control/DropdownCascade.php
@@ -85,7 +85,7 @@ class DropdownCascade extends Dropdown
         foreach ($model as $k => $row) {
             if ($this->renderRowFunction) {
                 $res = ($this->renderRowFunction)($row, $k);
-                $values[] = ['value' => $res['value'], 'text' => $row->get('name'), 'name' => $res['title']];
+                $values[] = ['value' => $res['value'], 'text' => $res['title'], 'name' => $res['title']];
             } else {
                 $values[] = ['value' => $row->getId(), 'text' => $row->get($model->titleField), 'name' => $row->get($model->titleField)];
             }


### PR DESCRIPTION
This is a very small bug fix -- the getNewValues method should not use the hard-coded 'name' field if a renderRowFunction exists