### PR TITLE
Fix Card with entity action, entity must not reload

### DIFF
--- a/demos/data-action/factory-view.php
+++ b/demos/data-action/factory-view.php
@@ -53,7 +53,8 @@ $myFactory = AnonymousClassNameCache::get_class(fn () => new class() extends Exe
 Header::addTo($app, ['Executor Factory set for this Card View only.']);
 
 DemoActionsUtil::setupDemoActions($country = new Country($app->db));
-$country = $country->loadAny();
+$country = $country->loadBy($country->fieldName()->iso, 'fr');
+$country->name .= ' NO RELOAD';
 
 $cardActions = Card::addTo($app, ['useLabel' => true, 'executorFactory' => new $myFactory()]);
 $cardActions->setModel($country);
@@ -68,10 +69,11 @@ foreach ($country->getModel()->getUserActions() as $action) {
 
 Header::addTo($app, ['Card View using global Executor Factory']);
 
-$model = new Country($app->db);
-$model = $model->loadAny();
+$country = new Country($app->db);
+$country = $country->loadBy($country->fieldName()->iso, 'cz');
+$country->name .= ' NO RELOAD';
 
 $card = Card::addTo($app, ['useLabel' => true]);
-$card->setModel($model);
-$card->addClickAction($model->getUserAction('edit'));
-$card->addClickAction($model->getUserAction('delete'));
+$card->setModel($country);
+$card->addClickAction($country->getUserAction('edit'));
+$card->addClickAction($country->getUserAction('delete'));

--- a/demos/data-action/factory-view.php
+++ b/demos/data-action/factory-view.php
@@ -52,7 +52,8 @@ $myFactory = AnonymousClassNameCache::get_class(fn () => new class() extends Exe
 
 Header::addTo($app, ['Executor Factory set for this Card View only.']);
 
-DemoActionsUtil::setupDemoActions($country = new Country($app->db));
+$country = new Country($app->db);
+DemoActionsUtil::setupDemoActions($country);
 $country = $country->loadBy($country->fieldName()->iso, 'fr');
 $country->name .= ' NO RELOAD';
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -118,9 +118,6 @@ parameters:
             path: 'demos/interactive/wizard.php'
             message: '~^Access to an undefined property Atk4\\Ui\\Form\\Control::\$placeholder\.$~'
         -
-            path: 'src/Card.php'
-            message: '~^Call to an undefined method Atk4\\Ui\\View::setAction\(\)\.$~'
-        -
             path: 'src/CardDeck.php'
             message: '~^Access to an undefined property Atk4\\Ui\\AbstractView::\$reload\.$~'
         -

--- a/src/Behat/Context.php
+++ b/src/Behat/Context.php
@@ -368,18 +368,18 @@ class Context extends RawMinkContext implements BehatContext
 
     /**
      * @Then Modal is open with text :arg1
-     * @Then Modal is open with text :arg1 in tag :arg2
+     * @Then Modal is open with text :arg1 in selector :arg2
      *
      * Check if text is present in modal or dynamic modal.
      */
-    public function modalIsOpenWithText(string $text, string $tag = 'div'): void
+    public function modalIsOpenWithText(string $text, string $selector = 'div'): void
     {
         $textEncoded = str_contains($text, '"')
             ? 'concat("' . str_replace('"', '", \'"\', "', $text) . '")'
             : '"' . $text . '"';
 
         $modal = $this->findElement(null, '.modal.visible.active.front');
-        $this->findElement($modal, 'xpath(//' . $tag . '[text()[normalize-space()=' . $textEncoded . ']])');
+        $this->findElement($modal, 'xpath(//' . $selector . '[text()[normalize-space()=' . $textEncoded . ']])');
     }
 
     /**
@@ -423,12 +423,12 @@ class Context extends RawMinkContext implements BehatContext
 
     /**
      * @Then Panel is open with text :arg1
-     * @Then Panel is open with text :arg1 in tag :arg2
+     * @Then Panel is open with text :arg1 in selector :arg2
      */
-    public function panelIsOpenWithText(string $text, string $tag = 'div'): void
+    public function panelIsOpenWithText(string $text, string $selector = 'div'): void
     {
         $panel = $this->findElement(null, '.atk-right-panel.atk-visible');
-        $this->findElement($panel, 'xpath(//' . $tag . '[text()[normalize-space()="' . $text . '"]])');
+        $this->findElement($panel, 'xpath(//' . $selector . '[text()[normalize-space()="' . $text . '"]])');
     }
 
     /**

--- a/src/Card.php
+++ b/src/Card.php
@@ -203,24 +203,6 @@ class Card extends View
     }
 
     /**
-     * Add action from Model.
-     */
-    public function addModelActions(Model $model): void
-    {
-        $this->setModel($model);
-
-        $actions = $model->getUserActions(Model\UserAction::APPLIES_TO_SINGLE_RECORD);
-        foreach ($actions as $action) {
-            $this->addAction($action, $this->executor);
-        }
-
-        $actions = $model->getUserActions(Model\UserAction::APPLIES_TO_NO_RECORDS);
-        foreach ($actions as $action) {
-            $this->addAction($action, $this->executor);
-        }
-    }
-
-    /**
      * Add a CardSection to this card.
      *
      * @return View
@@ -238,32 +220,6 @@ class Card extends View
         }
 
         return $section;
-    }
-
-    /**
-     * Add action executor to card.
-     *
-     * @param class-string<View&UserAction\ExecutorInterface> $executorClass
-     * @param Button|array                                    $button
-     */
-    public function addAction(Model\UserAction $action, $executorClass, $button = null): void
-    {
-        if (!$button) {
-            $button = new Button([$action->caption]);
-        }
-        $btn = $this->addButton($button);
-
-        $vp = VirtualPage::addTo($this)->set(function (View $page) use ($executorClass, $action) {
-            $id = $this->stickyGet($this->name);
-
-            $executor = $page->add(new $executorClass());
-
-            $action = $action->getActionForEntity($action->getModel()->load($id));
-
-            $executor->setAction($action);
-        });
-
-        $btn->on('click', new JsModal($action->caption, $vp, [$this->name => (new Jquery())->parents('.atk-card')->data('id')]));
     }
 
     /**

--- a/src/Card.php
+++ b/src/Card.php
@@ -169,8 +169,6 @@ class Card extends View
     }
 
     /**
-     * Set model.
-     *
      * If Fields are past with $model that field will be add
      * to the main section of this card.
      *
@@ -197,7 +195,7 @@ class Card extends View
      *
      * @param string $id
      */
-    public function setDataId($id): void
+    protected function setDataId($id): void
     {
         $this->template->trySet('dataId', $id);
     }

--- a/src/UserAction/CommonExecutorTrait.php
+++ b/src/UserAction/CommonExecutorTrait.php
@@ -18,7 +18,11 @@ trait CommonExecutorTrait
         );
 
         if ($id && $action->appliesTo === Model\UserAction::APPLIES_TO_SINGLE_RECORD) {
-            $action = $action->getActionForEntity($model->load($id));
+            if ($action->isOwnerEntity() && $action->getEntity()->getId()) {
+                $action->getEntity()->setId($id); // assert ID is the same
+            } else {
+                $action = $action->getActionForEntity($model->load($id));
+            }
         } elseif (!$action->isOwnerEntity() && in_array($action->appliesTo, [Model\UserAction::APPLIES_TO_NO_RECORDS, Model\UserAction::APPLIES_TO_SINGLE_RECORD], true)) {
             $action = $action->getActionForEntity($model->createEntity());
         }

--- a/src/UserAction/JsCallbackExecutor.php
+++ b/src/UserAction/JsCallbackExecutor.php
@@ -63,7 +63,11 @@ class JsCallbackExecutor extends JsCallback implements ExecutorInterface
                 $_POST['c0'] ?? $_POST['id'] ?? $_POST[$this->action->getModel()->idField] ?? null
             );
             if ($id && $this->action->appliesTo === Model\UserAction::APPLIES_TO_SINGLE_RECORD) {
-                $this->action = $this->action->getActionForEntity($this->action->getModel()->load($id));
+                if ($this->action->isOwnerEntity() && $this->action->getEntity()->getId()) {
+                    $this->action->getEntity()->setId($id); // assert ID is the same
+                } else {
+                    $this->action = $this->action->getActionForEntity($this->action->getModel()->load($id));
+                }
             } elseif (!$this->action->isOwnerEntity()
                 && in_array($this->action->appliesTo, [Model\UserAction::APPLIES_TO_NO_RECORDS, Model\UserAction::APPLIES_TO_SINGLE_RECORD], true)
             ) {

--- a/tests-behat/card.feature
+++ b/tests-behat/card.feature
@@ -1,7 +1,15 @@
 Feature: Card
 
-  Scenario: Card with entity action, entity must not reload
+  Scenario: Card with entity, entity must not reload
     Given I am on "data-action/factory-view.php"
+    Then I click using selector "i.eye.icon"
+    Then Modal is open with text "Display Preview prior to run the action"
+    # TODO fix
+    # Then Modal is open with text "Previewing country France NO RELOAD"
+    Then I press Modal button "Preview"
+    Then Toast display should contain text "Success: Done previewing France"
+
+  Scenario: Card with entity action, entity must not reload
     When I press button "Edit"
     Then Modal is open with text "Edit Country"
     Then I check if input value for ".modal.front input" match text "Czech Republic NO RELOAD"

--- a/tests-behat/card.feature
+++ b/tests-behat/card.feature
@@ -13,6 +13,13 @@ Feature: Card
     When I press button "Edit"
     Then Modal is open with text "Edit Country"
     Then I check if input value for ".modal.front input" match text "Czech Republic NO RELOAD"
+    Then I hide js modal
+
+  Scenario: Card with entity action, entity must not reload II exception is displayed
+    When I press button "Delete"
+    Then Modal is open with text "Please go ahead. Demo mode does not really delete data."
+    When I press Modal button "Ok"
+    Then Modal is open with text "Atk4\Data\Exception: Calling user action on a Model with dirty fields that are not allowed by this action"
 
   Scenario:
     Given I am on "interactive/card-action.php"

--- a/tests-behat/card.feature
+++ b/tests-behat/card.feature
@@ -9,13 +9,13 @@ Feature: Card
     Then I press Modal button "Preview"
     Then Toast display should contain text "Success: Done previewing France"
 
-  Scenario: Card with entity action, entity must not reload
+  Scenario: Card with entity action, entity must not reload - ModalExecutor
     When I press button "Edit"
     Then Modal is open with text "Edit Country"
     Then I check if input value for ".modal.front input" match text "Czech Republic NO RELOAD"
     Then I hide js modal
 
-  Scenario: Card with entity action, entity must not reload II exception is displayed
+  Scenario: Card with entity action, entity must not reload - JsCallbackExecutor
     When I press button "Delete"
     Then Modal is open with text "Please go ahead. Demo mode does not really delete data."
     When I press Modal button "Ok"

--- a/tests-behat/card.feature
+++ b/tests-behat/card.feature
@@ -1,9 +1,15 @@
 Feature: Card
 
+  Scenario: Card with entity action, entity must not reload
+    Given I am on "data-action/factory-view.php"
+    When I press button "Edit"
+    Then Modal is open with text "Edit Country"
+    Then I check if input value for ".modal.front input" match text "Czech Republic NO RELOAD"
+
   Scenario:
     Given I am on "interactive/card-action.php"
     When I press button "Send Note"
-    Then Modal is open with text "Note" in tag "label"
+    Then Modal is open with text "Note" in selector "label"
     When I fill in "note" with "This is a test note"
     Then I press Modal button "Notify"
     Then Toast display should contain text "This is a test note"

--- a/tests-behat/useraction.feature
+++ b/tests-behat/useraction.feature
@@ -7,7 +7,7 @@ Feature: UserAction executor and UserConfirmation modal
 
   Scenario:
     When I press button "Argument"
-    Then Modal is open with text "Age" in tag "label"
+    Then Modal is open with text "Age" in selector "label"
     When I fill Modal field "age" with "22"
     Then I press Modal button "Argument"
     Then Toast display should contain text "22 is old enough to visit"
@@ -19,7 +19,7 @@ Feature: UserAction executor and UserConfirmation modal
 
   Scenario:
     When I press button "Multi Step"
-    Then Modal is open with text "Age" in tag "label"
+    Then Modal is open with text "Age" in selector "label"
     When I fill Modal field "age" with "22"
     Then I press Modal button "Next"
     Then I press Modal button "Next"
@@ -52,14 +52,14 @@ Feature: UserAction executor and UserConfirmation modal
   Scenario: testing PanelExecutor
     Given I am on "data-action/jsactions-panel.php"
     When I press button "Argument"
-    Then Panel is open with text "Age" in tag "label"
+    Then Panel is open with text "Age" in selector "label"
     When I fill Panel field "age" with "22"
     Then I press Panel button "Argument"
     Then Toast display should contain text "22 is old enough to visit"
 
   Scenario: testing multi in panel
     When I press button "Multi Step"
-    Then Panel is open with text "Age" in tag "label"
+    Then Panel is open with text "Age" in selector "label"
     When I fill Panel field "age" with "22"
     Then I press Panel button "Next"
     Then I press Panel button "Next"


### PR DESCRIPTION
fix #1723

I am still not sure if we ever want to go with entity/model UA.

But (re)load should really be not done if a loaded entity is passed.