### PR TITLE
Fix public path resolution with symlinks

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -634,6 +634,9 @@ class App
 
     protected function createRequestPathFromLocalPath(string $localPath): string
     {
+        // $localPath does not need realpath() as the path is expected to be built using __DIR__
+        // which has symlinks resolved
+
         static $requestUrlPath = null;
         static $requestLocalPath = null;
         if ($requestUrlPath === null) {
@@ -645,7 +648,7 @@ class App
             } else {
                 $request = \Symfony\Component\HttpFoundation\Request::createFromGlobals();
                 $requestUrlPath = $request->getBasePath();
-                $requestLocalPath = $request->server->get('SCRIPT_FILENAME');
+                $requestLocalPath = realpath($request->server->get('SCRIPT_FILENAME'));
             }
         }
         $fs = new \Symfony\Component\Filesystem\Filesystem();


### PR DESCRIPTION
see https://github.com/atk4/ui/issues/1727#issuecomment-1308607494 discussion and analysis there

```
RUN mkdir /mount && mkdir /mount/html && chmod 0777 /mount/html
RUN ln -s /mount/html /var/www/ht # /var/www/html directory cannot be removed because of Docker

RUN cd /var/www/ht/ && pwd && php -r 'var_dump(getcwd());' && php demos/test.php
```
and `test.php`:
```
<?php var_dump(__FILE__); var_dump(__DIR__);
```
demo shows calling `realpath` on `__DIR__` is redundant, so the proposed solution should imply no performance drop, realpath is called only once per app/request for entry php script file