### PR TITLE
Fix Table\Column\Labels  for null fields

### DIFF
--- a/src/Table/Column/Labels.php
+++ b/src/Table/Column/Labels.php
@@ -24,7 +24,7 @@ class Labels extends Table\Column
         $values = $this->values ?? $field->values;
 
         $v = $field->get($row);
-        $v = explode(',', $v);
+        $v = explode(',', $v ?? '');
 
         $labels = [];
         foreach ($v as $id) {


### PR DESCRIPTION
Steps to reproduce:
- Adjust demo: https://dev.agiletoolkit.org/demos/collection/tablecolumns.php
- Set "interests" field for one of the records to null
- The interests field is configured to show content in table as Table\Column\Labels which will render an error, since explode(...) does not work with null strings.
