### PR TITLE
Unimplement JsExpressionable from JsCallback

### DIFF
--- a/demos/_unit-test/sse.php
+++ b/demos/_unit-test/sse.php
@@ -19,7 +19,7 @@ $sse = JsSse::addTo($app);
 $sse->setUrlTrigger('see_test');
 
 $v->js(true, $sse->set(function () use ($sse) {
-    for ($i = 0; $i < 4; $i++) {
+    for ($i = 0; $i < 4; ++$i) {
         $sse->send(new JsExpression('console.log([])', ['test ' . $i]));
     }
 

--- a/demos/_unit-test/sse.php
+++ b/demos/_unit-test/sse.php
@@ -19,11 +19,10 @@ $sse = JsSse::addTo($app);
 $sse->setUrlTrigger('see_test');
 
 $v->js(true, $sse->set(function () use ($sse) {
-    $sse->send(new JsExpression('console.log(\'test\')'));
-    $sse->send(new JsExpression('console.log(\'test\')'));
-    $sse->send(new JsExpression('console.log(\'test\')'));
-    $sse->send(new JsExpression('console.log(\'test\')'));
+    for ($i = 0; $i < 4; $i++) {
+        $sse->send(new JsExpression('console.log([])', ['test ' . $i]));
+    }
 
     // non-SSE way
     return new JsToast('SSE sent, see browser console log');
-}));
+})->jsExecute());

--- a/demos/form-control/multiline.php
+++ b/demos/form-control/multiline.php
@@ -18,7 +18,7 @@ Header::addTo($app, ['Multiline form control', 'icon' => 'database', 'subHeader'
 $inventory = new MultilineItem($app->db);
 $inventory->getField($inventory->fieldName()->item)->ui['multiline'] = [Form\Control\Multiline::TABLE_CELL => ['width' => 2]];
 $inventory->getField($inventory->fieldName()->inv_date)->ui['multiline'] = [Form\Control\Multiline::TABLE_CELL => ['width' => 2]];
-$inventory->getField($inventory->fieldName()->inv_date)->ui['multiline'] = [Form\Control\Multiline::TABLE_CELL => ['width' => 2]];
+$inventory->getField($inventory->fieldName()->inv_time)->ui['multiline'] = [Form\Control\Multiline::TABLE_CELL => ['width' => 2]];
 $inventory->getField($inventory->fieldName()->country_id)->ui['multiline'] = [Form\Control\Multiline::TABLE_CELL => ['width' => 3]];
 $inventory->getField($inventory->fieldName()->qty)->ui['multiline'] = [Form\Control\Multiline::TABLE_CELL => ['width' => 2]];
 $inventory->getField($inventory->fieldName()->box)->ui['multiline'] = [Form\Control\Multiline::TABLE_CELL => ['width' => 2]];

--- a/docs/callbacks.rst
+++ b/docs/callbacks.rst
@@ -210,7 +210,7 @@ When you trigger callback, you'll see the output::
     {"success": true, "message": "Success", "eval": "alert(\"ok\")"}
 
 This is how JsCallback renders actions and sends them back to the browser. In order to retrieve and execute actions,
-you'll need a JavaScript routine. Luckily JsCallback also implements JsExpressionable, so it, in itself is an action.
+you'll need a JavaScript routine. Luckily JsCallback can be passed to :php:meth:`View::on()` as a JS action.
 
 Let me try this again. JsCallback is an :ref:`js_action` which will execute request towards a callback-URL that will
 execute PHP method returning one or more :ref:`js_action` which will be received and executed by the original action.

--- a/src/CardDeck.php
+++ b/src/CardDeck.php
@@ -218,9 +218,9 @@ class CardDeck extends View
      * Return proper js statement for afterExecute hook on action executor
      * depending on return type, model loaded and action scope.
      *
-     * @param string|array|JsExpressionable|Model|null $return
+     * @param string|JsExpressionable|array<int, JsExpressionable>|Model|null $return
      *
-     * @return array|object
+     * @return JsExpressionable|array<int, JsExpressionable>
      */
     protected function jsExecute($return, Model\UserAction $action)
     {
@@ -242,10 +242,9 @@ class CardDeck extends View
     }
 
     /**
-     * Return jsNotifier object.
      * Override this method for setting notifier based on action or model value.
      */
-    protected function getNotifier(Model\UserAction $action, string $msg = null): object
+    protected function getNotifier(Model\UserAction $action, string $msg = null): JsExpressionable
     {
         $notifier = Factory::factory($this->notifyDefault);
         if ($msg) {
@@ -257,6 +256,8 @@ class CardDeck extends View
 
     /**
      * Js expression return when action afterHook executor return a Model.
+     *
+     * @return array<int, JsExpressionable>
      */
     protected function jsModelReturn(Model\UserAction $action, string $msg = 'Done!'): array
     {

--- a/src/Console.php
+++ b/src/Console.php
@@ -131,14 +131,9 @@ class Console extends View implements \Psr\Log\LoggerInterface
         return $this;
     }
 
-    /**
-     * Return JavaScript expression to execute console.
-     *
-     * @return JsExpressionable
-     */
-    public function jsExecute()
+    public function jsExecute(): JsExpressionable
     {
-        return $this->sse;
+        return $this->sse->jsExecute();
     }
 
     private function escapeOutputHtml(string $message): string

--- a/src/Crud.php
+++ b/src/Crud.php
@@ -157,6 +157,8 @@ class Crud extends Grid
      * depending on return type, model loaded and action scope.
      *
      * @param string|null $return
+     *
+     * @return array<int, JsExpressionable>
      */
     protected function jsExecute($return, Model\UserAction $action): array
     {

--- a/src/JsCallback.php
+++ b/src/JsCallback.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Atk4\Ui;
 
-class JsCallback extends Callback implements JsExpressionable
+class JsCallback extends Callback
 {
     /** @var array Holds information about arguments passed in to the callback. */
     public $args = [];
@@ -47,7 +47,7 @@ class JsCallback extends Callback implements JsExpressionable
         return $res;
     }
 
-    public function jsRender(): string
+    public function jsExecute(): JsExpression
     {
         $this->getApp(); // assert has App
 
@@ -57,7 +57,7 @@ class JsCallback extends Callback implements JsExpressionable
             'confirm' => $this->confirm,
             'apiConfig' => $this->apiConfig,
             'storeName' => $this->storeName,
-        ])->jsRender();
+        ]);
     }
 
     /**

--- a/src/JsExpression.php
+++ b/src/JsExpression.php
@@ -51,7 +51,7 @@ class JsExpression implements JsExpressionable
                 $value = $this->args[$identifier];
 
                 // no escaping for "{}"
-                if ($matches[0][0] === '{') {
+                if ($matches[0][0] === '{' && is_string($value)) {
                     return $value;
                 }
 
@@ -74,15 +74,10 @@ class JsExpression implements JsExpressionable
      */
     protected function _jsEncode($arg): string
     {
-        if (is_object($arg)) {
-            if ($arg instanceof JsExpressionable) {
-                $result = $arg->jsRender();
+        if (is_object($arg) && $arg instanceof JsExpressionable) {
+            $result = $arg->jsRender();
 
-                return $result;
-            }
-
-            throw (new Exception('Not sure how to represent this object in JSON'))
-                ->addMoreInfo('obj', $arg);
+            return $result;
         } elseif (is_array($arg)) {
             $array = [];
             $assoc = !array_is_list($arg);
@@ -115,7 +110,7 @@ class JsExpression implements JsExpressionable
         } elseif ($arg === null) {
             $string = 'null';
         } else {
-            throw (new Exception('Unsupported argument type'))
+            throw (new Exception('Argument is not renderable to JS'))
                 ->addMoreInfo('arg', $arg);
         }
 

--- a/src/JsExpression.php
+++ b/src/JsExpression.php
@@ -34,7 +34,7 @@ class JsExpression implements JsExpressionable
         $namelessCount = 0;
         $res = preg_replace_callback(
             '~\[[\w]*\]|{[\w]*}~',
-            function ($matches) use (&$namelessCount) {
+            function ($matches) use (&$namelessCount): string {
                 $identifier = substr($matches[0], 1, -1);
 
                 // Allow template to contain []

--- a/src/JsSse.php
+++ b/src/JsSse.php
@@ -41,7 +41,7 @@ class JsSse extends JsCallback
         }
     }
 
-    public function jsRender(): string
+    public function jsExecute(): JsExpression
     {
         $this->getApp(); // assert has App
 
@@ -53,7 +53,7 @@ class JsSse extends JsCallback
             $options['closeBeforeUnload'] = $this->closeBeforeUnload;
         }
 
-        return (new Jquery($this->getOwner() /* TODO element and loader element should be passed explicitly */))->atkServerEvent($options)->jsRender();
+        return (new Jquery($this->getOwner() /* TODO element and loader element should be passed explicitly */))->atkServerEvent($options);
     }
 
     /**

--- a/src/UserAction/ConfirmationExecutor.php
+++ b/src/UserAction/ConfirmationExecutor.php
@@ -85,9 +85,6 @@ class ConfirmationExecutor extends Modal implements JsExecutorInterface
         ];
     }
 
-    /**
-     * Return js expression that will trigger action executor.
-     */
     public function jsExecute(array $urlArgs = []): array
     {
         if (!$this->action) {

--- a/src/UserAction/JsExecutorInterface.php
+++ b/src/UserAction/JsExecutorInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Atk4\Ui\UserAction;
 
+use Atk4\Ui\JsExpressionable;
+
 /**
  * Add js trigger for executing an action.
  */
@@ -11,6 +13,8 @@ interface JsExecutorInterface extends ExecutorInterface
 {
     /**
      * Return js expression that will trigger action executor.
+     *
+     * @return array<int, JsExpressionable>
      */
     public function jsExecute(array $urlArgs): array;
 }

--- a/src/UserAction/ModalExecutor.php
+++ b/src/UserAction/ModalExecutor.php
@@ -136,9 +136,6 @@ class ModalExecutor extends Modal implements JsExecutorInterface
         return $this;
     }
 
-    /**
-     * Generate js for triggering action.
-     */
     public function jsExecute(array $urlArgs = []): array
     {
         if (!$this->actionInitialized) {

--- a/src/View.php
+++ b/src/View.php
@@ -1021,7 +1021,9 @@ class View extends AbstractView implements JsExpressionable
                 return $action($chain, ...$args);
             }, $arguments);
 
-            $actions[] = $cb;
+            $actions[] = $cb->jsExecute();
+        } elseif ($action instanceof JsCallback) {
+            $actions[] = $action->jsExecute();
         } elseif ($action instanceof UserAction\ExecutorInterface || $action instanceof Model\UserAction) {
             // Setup UserAction executor.
             $ex = $action instanceof Model\UserAction ? $this->getExecutorFactory()->create($action, $this) : $action;
@@ -1044,7 +1046,7 @@ class View extends AbstractView implements JsExpressionable
                 if ($defaults['apiConfig'] ?? null) {
                     $ex->apiConfig = $defaults['apiConfig'];
                 }
-                $actions[] = $ex;
+                $actions[] = $ex->jsExecute();
                 $ex->executeModelAction($arguments);
             } else {
                 throw new Exception('Executor must be of type UserAction\JsCallbackExecutor or extend View and implement UserAction\JsExecutorInterface');

--- a/tests/JsIntegrationTest.php
+++ b/tests/JsIntegrationTest.php
@@ -6,6 +6,8 @@ namespace Atk4\Ui\Tests;
 
 use Atk4\Core\Phpunit\TestCase;
 use Atk4\Ui\Button;
+use Atk4\Ui\Exception;
+use Atk4\Ui\JsCallback;
 use Atk4\Ui\View;
 
 class JsIntegrationTest extends TestCase
@@ -116,5 +118,18 @@ class JsIntegrationTest extends TestCase
         static::assertNotNull($v->js(true, null)); // @phpstan-ignore-line
         static::assertNull($v->js(true, $js)); // @phpstan-ignore-line
         static::assertNull($v->on('click', $js)); // @phpstan-ignore-line
+    }
+
+    public function testChainUnsupportedTypeException(): void
+    {
+        $v = new View();
+        $v->invokeInit();
+
+        $js = $v->js();
+        $js->data(['url' => JsCallback::addTo($v)]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('not renderable to JS');
+        $js->jsRender();
     }
 }

--- a/tests/JsIntegrationTest.php
+++ b/tests/JsIntegrationTest.php
@@ -8,6 +8,7 @@ use Atk4\Core\Phpunit\TestCase;
 use Atk4\Ui\Button;
 use Atk4\Ui\Exception;
 use Atk4\Ui\JsCallback;
+use Atk4\Ui\JsExpression;
 use Atk4\Ui\View;
 
 class JsIntegrationTest extends TestCase
@@ -45,7 +46,7 @@ class JsIntegrationTest extends TestCase
     {
         $v = new Button(['name' => 'b']);
         $j = $v->js(true)->hide();
-        $v->getHtml();
+        $v->renderAll();
 
         static::assertSame('(function () {
     $(\'#b\').hide();
@@ -56,7 +57,7 @@ class JsIntegrationTest extends TestCase
     {
         $v = new Button(['name' => 'b']);
         $v->js('click')->hide();
-        $v->getHtml();
+        $v->renderAll();
 
         static::assertSame('(function () {
     $(\'#b\').on(\'click\', function (event) {
@@ -71,7 +72,7 @@ class JsIntegrationTest extends TestCase
     {
         $v = new Button(['name' => 'b']);
         $v->js('click', null);
-        $v->getHtml();
+        $v->renderAll();
 
         static::assertSame('(function () {
     $(\'#b\').on(\'click\', function (event) {
@@ -86,9 +87,9 @@ class JsIntegrationTest extends TestCase
 
     public function testChainNested(): void
     {
-        $bb = new View(['ui' => 'buttons']);
-        $b1 = Button::addTo($bb, ['name' => 'b1']);
-        $b2 = Button::addTo($bb, ['name' => 'b2']);
+        $v = new View(['ui' => 'buttons']);
+        $b1 = Button::addTo($v, ['name' => 'b1']);
+        $b2 = Button::addTo($v, ['name' => 'b2']);
 
         $b1->on('click', [
             'preventDefault' => false,
@@ -97,7 +98,7 @@ class JsIntegrationTest extends TestCase
             $b2->js()->hide(),
         ]);
         $b1->js(true)->data('x', 'y');
-        $bb->getHtml();
+        $v->renderAll();
 
         static::assertSame('(function () {
     $(\'#b1\').on(\'click\', function (event) {
@@ -107,7 +108,7 @@ class JsIntegrationTest extends TestCase
         $(\'#b2\').hide();
     });
     $(\'#b1\').data(\'x\', \'y\');
-})()', $bb->getJs());
+})()', $v->getJs());
     }
 
     public function testChainNullReturn(): void
@@ -131,5 +132,33 @@ class JsIntegrationTest extends TestCase
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('not renderable to JS');
         $js->jsRender();
+    }
+
+    public function testChainJsCallbackLazyExecuteRender(): void
+    {
+        $v = new View();
+        $v->invokeInit();
+        $b = Button::addTo($v);
+
+        $jsCallback = new class() extends JsCallback {
+            public int $counter = 0;
+
+            public function jsExecute(): JsExpression
+            {
+                ++$this->counter;
+
+                return parent::jsExecute();
+            }
+        };
+        $v->add($jsCallback);
+
+        $b->on('click', $jsCallback);
+        static::assertSame(0, $jsCallback->counter);
+
+        $v->renderAll();
+        static::assertSame(0, $jsCallback->counter);
+
+        $v->getJs();
+        static::assertSame(1, $jsCallback->counter);
     }
 }

--- a/tests/JsTest.php
+++ b/tests/JsTest.php
@@ -6,6 +6,7 @@ namespace Atk4\Ui\Tests;
 
 use Atk4\Core\Phpunit\TestCase;
 use Atk4\Ui\App;
+use Atk4\Ui\Exception;
 use Atk4\Ui\Jquery;
 use Atk4\Ui\JsChain;
 use Atk4\Ui\JsExpression;
@@ -129,5 +130,14 @@ class JsTest extends TestCase
                     $('.box1').height($('.box2').height());
                 })
             EOF, $fx->jsRender());
+    }
+
+    public function testUnsupportedTypeRenderException(): void
+    {
+        $js = new JsExpression('{}', [new \stdClass()]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('not renderable to JS');
+        $js->jsRender();
     }
 }


### PR DESCRIPTION
`View::jsRender()` renders jQuery with the view selector, overriding the meaning of the method is wrong and misleading.

fix #1953

related with #1872