### PR TITLE
Fix template caching, allow app to be released

### DIFF
--- a/demos/init-db.php
+++ b/demos/init-db.php
@@ -9,6 +9,7 @@ use Atk4\Data\Field;
 use Atk4\Data\Model;
 use Atk4\Ui\Exception;
 use Atk4\Ui\Form;
+use Atk4\Ui\Table;
 use Mvorisek\Atk4\Hintable\Data\HintablePropertyDef;
 
 try {
@@ -269,6 +270,7 @@ class Stat extends ModelWithPrefixedFields
             'type' => 'string',
             'ui' => [
                 'form' => [Form\Control\Line::class],
+                'table' => [Table\Column\CountryFlag::class],
             ],
         ])
             ->addField($this->fieldName()->client_country, Country::hinting()->fieldName()->name);

--- a/src/HtmlTemplate.php
+++ b/src/HtmlTemplate.php
@@ -456,7 +456,13 @@ class HtmlTemplate
             $this->tagTrees = [];
             try {
                 $this->tagTrees[self::TOP_TAG] = $this->parseTemplateTree($inputReversed);
-                self::$_parseCache[$cKey] = $this->tagTrees;
+                $tagTrees = $this->tagTrees;
+                \Closure::bind(function () use ($tagTrees) {
+                    foreach ($tagTrees as $tagTree) {
+                        $tagTree->parentTemplate = null; // @phpstan-ignore-line
+                    }
+                }, null, TagTree::class)();
+                self::$_parseCache[$cKey] = $tagTrees;
             } finally {
                 $this->tagTrees = null; // @phpstan-ignore-line
             }

--- a/src/Table/Column/CountryFlag.php
+++ b/src/Table/Column/CountryFlag.php
@@ -11,14 +11,14 @@ use Atk4\Ui\Table;
 class CountryFlag extends Table\Column
 {
     /** Name of country code model field (in ISO 3166-1 alpha-2 format) */
-    public string $codeField;
+    public ?string $codeField = null;
 
     /** Optional name of model field which contains full country name. */
     public ?string $nameField = null;
 
     public function getHtmlTags(Model $row, ?Field $field): array
     {
-        $countryCode = $row->get($this->codeField);
+        $countryCode = $row->get($this->codeField ?? $field->shortName);
         $countryName = $this->nameField ? $row->get($this->nameField) : null;
 
         return [


### PR DESCRIPTION
bug that took me a lot of efford to find out, when a template is loaded, it is cached, and the first load was originally cached with parent template, which referenced an app, thus app was effectively never released (was released on request end)

memory for phpunit is also reduced from 60MB to 30 MB :)