### PR TITLE
Optimize realpath() for template loading

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -232,9 +232,6 @@ parameters:
         -
             path: 'src/View.php'
             message: '~^Call to an undefined method Atk4\\Ui\\Js\\JsChain::addJsonData\(\)\.$~'
-        -
-            path: 'src/View.php'
-            message: '~^Call to an undefined method Atk4\\Ui\\App::getViewJS\(\)\.$~'
 
         # TODO fix contravariance for View::set() method
         -

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -370,9 +370,6 @@ parameters:
             path: 'src/Table/Column/FilterModel/TypeEnum.php'
             message: '~^Property Atk4\\Ui\\Table\\Column\\FilterModel::\$op \(Atk4\\Data\\Field\) does not accept null\.$~'
         -
-            path: 'src/Text.php'
-            message: '~^Property Atk4\\Ui\\Text::\$defaultTemplate \(string\|null\) does not accept default value of type false\.$~'
-        -
             path: 'src/Wizard.php'
             message: '~^Property Atk4\\Ui\\Form::\$buttonSave \(array\|Atk4\\Ui\\Button\|false\) does not accept null\.$~'
 

--- a/src/AbstractView.php
+++ b/src/AbstractView.php
@@ -31,18 +31,15 @@ abstract class AbstractView
     use StaticAddToTrait;
     use TrackableTrait;
 
-    /** @var string Default name of the element. */
-    public $defaultName = 'atk';
-
     /**
      * If add() method is called, but current view is not part of render tree yet,
      * then arguments to add() are simply stored in this array. When the view is
      * initialized by calling init() or adding into App or another initialized View,
      * then add() will be re-invoked with the contents of this array.
      *
-     * @var array<int, array{self, array}>
+     * @var array<int, array{self, array}>|null
      */
-    protected array $_addLater = [];
+    protected ?array $_addLater = [];
 
     /** Will be set to true after rendered. This is so that we don't render view twice. */
     protected bool $_rendered = false;
@@ -72,16 +69,17 @@ abstract class AbstractView
         }
 
         if ($this->name === null) {
-            $this->name = $this->defaultName;
+            $this->name = 'atk';
         }
 
         $this->_init();
 
-        // add default objects
-        foreach ($this->_addLater as [$object, $args]) {
-            $this->add($object, $args);
+        if ($this->_addLater !== null) {
+            foreach ($this->_addLater as [$object, $args]) {
+                $this->add($object, $args);
+            }
+            $this->_addLater = null;
         }
-        $this->_addLater = [];
     }
 
     /**

--- a/src/App.php
+++ b/src/App.php
@@ -585,11 +585,9 @@ class App
     /**
      * Load template by template file name.
      *
-     * @param string $filename
-     *
      * @return HtmlTemplate
      */
-    public function loadTemplate($filename)
+    public function loadTemplate(string $filename)
     {
         $template = new $this->templateClass();
         $template->setApp($this);

--- a/src/HtmlTemplate/TagTree.php
+++ b/src/HtmlTemplate/TagTree.php
@@ -15,14 +15,12 @@ class TagTree
 {
     use WarnDynamicPropertyTrait;
 
-    /** @var HtmlTemplate */
-    private $parentTemplate;
+    private HtmlTemplate $parentTemplate;
 
-    /** @var string */
-    private $tag;
+    private string $tag;
 
     /** @var array<int, Value|string|HtmlTemplate> */
-    private $children = [];
+    private array $children = [];
 
     public function __construct(HtmlTemplate $parentTemplate, string $tag)
     {

--- a/src/HtmlTemplate/Value.php
+++ b/src/HtmlTemplate/Value.php
@@ -11,11 +11,9 @@ class Value
 {
     use WarnDynamicPropertyTrait;
 
-    /** @var string */
-    private $value = '';
+    private string $value = '';
 
-    /** @var bool */
-    private $isEncoded = false;
+    private bool $isEncoded = false;
 
     private function encodeValueToHtml(string $value): string
     {

--- a/src/Text.php
+++ b/src/Text.php
@@ -9,7 +9,7 @@ namespace Atk4\Ui;
  */
 class Text extends View
 {
-    public $defaultTemplate = false;
+    public $defaultTemplate = null;
 
     public function render(): string
     {

--- a/src/Text.php
+++ b/src/Text.php
@@ -9,7 +9,7 @@ namespace Atk4\Ui;
  */
 class Text extends View
 {
-    public $defaultTemplate = null;
+    public $defaultTemplate;
 
     public function render(): string
     {

--- a/src/View.php
+++ b/src/View.php
@@ -95,7 +95,6 @@ class View extends AbstractView
         }
 
         $defaults = is_array($label) ? $label : [$label];
-        unset($label);
 
         if (array_key_exists(0, $defaults)) {
             $defaults['content'] = $defaults[0];
@@ -213,7 +212,7 @@ class View extends AbstractView
     protected function init(): void
     {
         $addLater = $this->_addLater;
-        $this->_addLater = [];
+        $this->_addLater = null;
 
         parent::init();
 
@@ -236,7 +235,6 @@ class View extends AbstractView
             $this->template->setApp($this->getApp());
         }
 
-        // add default objects
         foreach ($addLater as [$object, $region]) {
             $this->add($object, $region);
         }

--- a/src/View.php
+++ b/src/View.php
@@ -576,7 +576,7 @@ class View extends AbstractView
         if ($this->style) {
             $styles = [];
             foreach ($this->style as $k => $v) {
-                $styles[] = $k . ': ' . $v;;
+                $styles[] = $k . ': ' . $v;
             }
             $this->template->append('style', implode('; ', $styles) . ';');
         }

--- a/src/View.php
+++ b/src/View.php
@@ -576,14 +576,11 @@ class View extends AbstractView
         }
 
         if ($this->style) {
-            $style = $this->style;
-            array_walk(
-                $style,
-                function (string &$item, string $key) {
-                    $item = $key . ': ' . $item;
-                }
-            );
-            $this->template->append('style', implode('; ', $style) . ';');
+            $styles = [];
+            foreach ($this->style as $k => $v) {
+                $styles[] = $k . ': ' . $v;;
+            }
+            $this->template->append('style', implode('; ', $styles) . ';');
         }
 
         if ($this->ui) {

--- a/src/View.php
+++ b/src/View.php
@@ -216,22 +216,23 @@ class View extends AbstractView
 
         parent::init();
 
-        if ($this->region && !$this->template && !$this->defaultTemplate && $this->issetOwner() && $this->getOwner()->template) {
-            $this->template = $this->getOwner()->template->cloneRegion($this->region);
+        if ($this->region === null) {
+            $this->region = 'Content';
+        }
 
-            $this->getOwner()->template->del($this->region);
-        } else {
-            // set up template
-            if (is_string($this->defaultTemplate) && $this->template === null) {
+        if ($this->template === null) {
+            if ($this->defaultTemplate !== null) {
                 $this->template = $this->getApp()->loadTemplate($this->defaultTemplate);
-            }
+            } else {
+                if ($this->region !== 'Content' && $this->issetOwner() && $this->getOwner()->template) {
+                    $this->template = $this->getOwner()->template->cloneRegion($this->region);
 
-            if (!$this->region) {
-                $this->region = 'Content';
+                    $this->getOwner()->template->del($this->region);
+                }
             }
         }
 
-        if ($this->template && !$this->template->issetApp() && $this->issetApp()) {
+        if ($this->template !== null && !$this->template->issetApp() && $this->issetApp()) {
             $this->template->setApp($this->getApp());
         }
 
@@ -268,7 +269,7 @@ class View extends AbstractView
         if (!is_object($object)) { // @phpstan-ignore-line
             // for BC do not throw
             // later consider to accept strictly objects only
-            $object = AbstractView::addToWithCl($this, $object, [], true);
+            $object = AbstractView::fromSeed($object);
         }
 
         if (!$this->issetApp()) {

--- a/src/View.php
+++ b/src/View.php
@@ -1142,11 +1142,6 @@ class View extends AbstractView
 
         $actions['indent'] = '';
 
-        // delegate $action rendering in hosting app if exist.
-        if ($this->issetApp() && $this->getApp()->hasMethod('getViewJS')) {
-            return $this->getApp()->getViewJS($actions);
-        }
-
         return (new JsExpression('[]()', [new JsFunction([], $actions)]))->jsRender();
     }
 

--- a/src/View.php
+++ b/src/View.php
@@ -576,9 +576,9 @@ class View extends AbstractView
         if ($this->style) {
             $styles = [];
             foreach ($this->style as $k => $v) {
-                $styles[] = $k . ': ' . $v;
+                $styles[] = $k . ': ' . $v . ';';
             }
-            $this->template->append('style', implode('; ', $styles) . ';');
+            $this->template->append('style', implode(' ', $styles));
         }
 
         if ($this->ui) {

--- a/src/View.php
+++ b/src/View.php
@@ -226,7 +226,6 @@ class View extends AbstractView
             } else {
                 if ($this->region !== 'Content' && $this->issetOwner() && $this->getOwner()->template) {
                     $this->template = $this->getOwner()->template->cloneRegion($this->region);
-
                     $this->getOwner()->template->del($this->region);
                 }
             }


### PR DESCRIPTION
Chasing 200 microseconds taken for each `$x->add(new View())` call paid off. The problem was a `realpath()`.

This PR cuts render time in half with many render tree Views, as every View usually loads a template.