### PR TITLE
Drop AbstractView::initDefaultApp and App::init methods

### DIFF
--- a/demos/_unit-test/calendar-input.php
+++ b/demos/_unit-test/calendar-input.php
@@ -12,8 +12,9 @@ use Atk4\Ui\View;
 /** @var \Atk4\Ui\App $app */
 require_once __DIR__ . '/../init-app.php';
 
-$output = function (?\DateTime $dt, string $format) {
+$output = function (?\DateTime $dt, string $format) use ($app) {
     $view = new Message();
+    $view->setApp($app);
     $view->invokeInit();
     $view->text->addHtml($dt === null ? 'empty' : $dt->format($format));
 

--- a/demos/_unit-test/modal-error.php
+++ b/demos/_unit-test/modal-error.php
@@ -31,7 +31,7 @@ $modal->set(function (View $p) {
 
     $country = new Country($p->getApp()->db);
     $button = Button::addTo($p)->set('Test ModalExecutor load PHP error');
-    $executor = ModalExecutor::assertInstanceOf($p->getExecutorFactory()->create($country->getUserAction('edit'), $button));
+    $executor = ModalExecutor::assertInstanceOf($p->getExecutorFactory()->createExecutor($country->getUserAction('edit'), $button));
     $executor->stickyGet($executor->name, '-1');
     $button->on('click', $executor);
 });

--- a/demos/_unit-test/scope-builder.php
+++ b/demos/_unit-test/scope-builder.php
@@ -37,6 +37,7 @@ $form->addControl('qb', [Form\Control\ScopeBuilder::class, 'model' => $model], [
 $form->onSubmit(function (Form $form) use ($model) {
     $message = $form->model->get('qb')->toWords($model);
     $view = (new View(['name' => false]))->addClass('atk-scope-builder-response');
+    $view->setApp($form->getApp());
     $view->invokeInit();
 
     $view->set($message);

--- a/demos/collection/grid.php
+++ b/demos/collection/grid.php
@@ -48,7 +48,7 @@ $grid->menu->addItem(['Delete All', 'icon' => 'trash', 'class.red active' => tru
 $grid->addColumn(null, [Table\Column\Template::class, 'hello<b>world</b>']);
 
 // Creating a button for executing model test user action.
-$grid->addExecutorButton($grid->getExecutorFactory()->create($model->getUserAction('test'), $grid));
+$grid->addExecutorButton($grid->getExecutorFactory()->createExecutor($model->getUserAction('test'), $grid));
 
 $grid->addActionButton('Say HI', function (Jquery $j, $id) use ($grid) {
     $model = Country::assertInstanceOf($grid->model);
@@ -61,7 +61,7 @@ $grid->addModalAction(['icon' => 'external'], 'Modal Test', function (View $p, $
 });
 
 // Creating an executor for delete action.
-$deleteExecutor = $grid->getExecutorFactory()->create($model->getUserAction('delete'), $grid);
+$deleteExecutor = $grid->getExecutorFactory()->createExecutor($model->getUserAction('delete'), $grid);
 $deleteExecutor->onHook(BasicExecutor::HOOK_AFTER_EXECUTE, function () {
     return [
         (new Jquery())->closest('tr')->transition('fade left'),

--- a/demos/data-action/jsactionsgrid.php
+++ b/demos/data-action/jsactionsgrid.php
@@ -56,7 +56,7 @@ foreach ($country->getUserActions(UserAction::APPLIES_TO_SINGLE_RECORD) as $acti
     if (in_array($action->shortName, ['add', 'edit', 'delete'], true)) {
         continue;
     }
-    $grid->addExecutorMenuItem($executor = $app->getExecutorFactory()->create($action, $grid));
+    $grid->addExecutorMenuItem($executor = $app->getExecutorFactory()->createExecutor($action, $grid));
 }
 
 $grid->ipp = 10;

--- a/demos/form-control/dropdown-plus.php
+++ b/demos/form-control/dropdown-plus.php
@@ -29,6 +29,7 @@ $form->onSubmit(function (Form $form) use ($app) {
     $message = $app->encodeJson($form->model->get());
 
     $view = new Message('Values: ');
+    $view->setApp($form->getApp());
     $view->invokeInit();
     $view->text->addParagraph($message);
 
@@ -108,6 +109,7 @@ $form->onSubmit(function (Form $form) use ($app) {
     $message = $app->encodeJson($form->model->get());
 
     $view = new Message('Values: ');
+    $view->setApp($form->getApp());
     $view->invokeInit();
     $view->text->addParagraph($message);
 

--- a/demos/form-control/lookup.php
+++ b/demos/form-control/lookup.php
@@ -48,7 +48,8 @@ $form->addControl('country3', [
 ]);
 
 $form->onSubmit(function (Form $form) {
-    $view = new Message('Select:'); // need in behat test.
+    $view = new Message('Select:');
+    $view->setApp($form->getApp());
     $view->invokeInit();
     $view->text->addParagraph($form->model->ref('country1')->get(Country::hinting()->fieldName()->name) ?? 'null');
     $view->text->addParagraph($form->model->ref('country2')->get(Country::hinting()->fieldName()->name) ?? 'null');

--- a/demos/form-control/tree-item-selector.php
+++ b/demos/form-control/tree-item-selector.php
@@ -61,6 +61,7 @@ $form->onSubmit(function (Form $form) use ($app) {
     ];
 
     $view = new Message('Items: ');
+    $view->setApp($form->getApp());
     $view->invokeInit();
     $view->text->addParagraph($app->encodeJson($response));
 

--- a/demos/form/form.php
+++ b/demos/form/form.php
@@ -80,6 +80,7 @@ $form->buttonSave->set('Compare Date');
 $form->onSubmit(function (Form $form) {
     $message = 'field = ' . print_r($form->model->get('field'), true) . '; <br> control = ' . print_r($form->model->get('control'), true);
     $view = new Message('Date field vs control:');
+    $view->setApp($form->getApp());
     $view->invokeInit();
     $view->text->addHtml($message);
 
@@ -112,6 +113,7 @@ $form->addControl('email3');
 $form->buttonSave->set('Save3');
 $form->onSubmit(function (Form $form) {
     $view = new Message('some header');
+    $view->setApp($form->getApp());
     $view->invokeInit();
     $view->text->addParagraph('some text ' . random_int(1, 100));
 
@@ -124,6 +126,7 @@ $form->addControl('email4');
 $form->buttonSave->set('Save4');
 $form->onSubmit(function (Form $form) {
     $view = new Message('some header');
+    $view->setApp($form->getApp());
     $view->invokeInit();
     $view->text->addParagraph('some text ' . random_int(1, 100));
 

--- a/demos/javascript/vue-component.php
+++ b/demos/javascript/vue-component.php
@@ -31,8 +31,9 @@ $inline_edit = VueComponent\InlineEdit::addTo($app);
 $inline_edit->fieldName = $model->fieldName()->name;
 $inline_edit->setModel($model);
 
-$inline_edit->onChange(function (string $value) {
+$inline_edit->onChange(function (string $value) use ($app) {
     $view = new Message();
+    $view->setApp($app);
     $view->invokeInit();
     $view->text->addParagraph('new value: ' . $value);
 

--- a/demos/layout/layouts_manual.php
+++ b/demos/layout/layouts_manual.php
@@ -19,4 +19,5 @@ Lister::addTo($layout, [], ['Report'])
 $app->html = null;
 $app->initLayout([Layout::class]);
 
+$layout->setApp($app);
 Text::addTo($app->layout)->addHtml($layout->render());

--- a/docs/app.rst
+++ b/docs/app.rst
@@ -9,10 +9,8 @@ Purpose of App class
 .. php:namespace:: Atk4\Ui
 .. php:class:: App
 
-App is a mandatory object that's essential for Agile UI to operate. If you don't create App object explicitly, it
-will be automatically created if you execute `$component->invokeInit()` or `$component->render()`.
-
-In most use-scenarios, however, you would create instance of an App class yourself before other components::
+App is a mandatory object that's essential for Agile UI to operate. You should create instance
+of an App class yourself before other components::
 
     $app = new \Atk4\Ui\App('My App');
     $app->initLayout([\Atk4\Ui\Layout\Centered::class]);

--- a/docs/dataexecutor.rst
+++ b/docs/dataexecutor.rst
@@ -136,9 +136,9 @@ The Executor Factory
 
 Executor factory is responsible for creating proper executor type in regards to the model user action being used.
 
-The factory create method::
+The factory createExecutor method::
 
-    ExecutorFactory::create(UserAction $action, View $owner, $requiredType = null)
+    ExecutorFactory::createExecutor(UserAction $action, View $owner, $requiredType = null)
 
 Based on parameter passed to the method, it will return proper executor for the model user action.
 
@@ -147,13 +147,13 @@ for that specific type.
 
 When required is not set, it will first look for a specific executor that has been already register for the model/action.
 
-If no executor type is found, then the create method will determine one, based on the model user action properties:
+If no executor type is found, then the createExecutor method will determine one, based on the model user action properties:
 
 - if action contains a callable confirmation property, then, the executor create is based on CONFIRMATION_EXECUTOR type;
 - if action contains use either, fields, argument or preview properties, then, the executor create is based on MODAL_EXECUTOR type;
 - if action does not use any of the above properties, then, the executor create is based on JS_EXECUTOR type.
 
-The create method also add the executor to the View passed as argument. However, note that when an executor View parent
+The createExecutor method also add the executor to the View passed as argument. However, note that when an executor View parent
 class is of type Modal, then it will be attached to the $app->html view instead. This is because Modal view in ui needs
 to be added to $app->html view in order to work correctly on reload.
 
@@ -187,7 +187,7 @@ For example, you need a custom executor to be created when using a specific mode
     //...
     ExecutorFactory::registerExecutor($action, [MySpecialFormExecutor::class]);
 
-Then, when ExecutorFactory::create method is called for this $action, MySpecialExecutor instance will be create in order
+Then, when ExecutorFactory::createExecutor method is called for this $action, MySpecialExecutor instance will be create in order
 to run this user model action.
 
 Triggering model user action

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -228,6 +228,7 @@ of application layout with a line::
 To render a component individually and get the HTML and JavaScript use this format::
 
     $form = new Form();
+    $form->setApp($app);
     $form->invokeInit();
     $form->setModel(new User($db));
 

--- a/docs/view.rst
+++ b/docs/view.rst
@@ -502,18 +502,9 @@ Rest of yet-to-document/implement methods and properties
         :param $val:
 
 
-
-    .. php:method:: initDefaultApp()
-
-        For the absence of the application, we would add a very
-        simple one
-
     .. php:method:: set($arg1 = [], $arg2 = null)
 
         :param $arg1:
         :param $arg2:
 
     .. php:method:: recursiveRender()
-
-
-

--- a/src/AbstractView.php
+++ b/src/AbstractView.php
@@ -45,29 +45,11 @@ abstract class AbstractView
     protected bool $_rendered = false;
 
     /**
-     * For the absence of the application, we would add a very
-     * simple one.
-     */
-    protected function initDefaultApp(): void
-    {
-        $this->setApp(new App([
-            'catchExceptions' => false,
-            'alwaysRun' => false,
-            'catchRunawayCallbacks' => false,
-        ]));
-        $this->getApp()->invokeInit();
-    }
-
-    /**
      * Called when view becomes part of render tree. You can override it but avoid
      * placing any "heavy processing" here.
      */
     protected function init(): void
     {
-        if (!$this->issetApp()) {
-            $this->initDefaultApp();
-        }
-
         if ($this->name === null) {
             $this->name = 'atk';
         }

--- a/src/App.php
+++ b/src/App.php
@@ -10,7 +10,6 @@ use Atk4\Core\DynamicMethodTrait;
 use Atk4\Core\ExceptionRenderer;
 use Atk4\Core\Factory;
 use Atk4\Core\HookTrait;
-use Atk4\Core\InitializerTrait;
 use Atk4\Core\TraitUtil;
 use Atk4\Core\WarnDynamicPropertyTrait;
 use Atk4\Data\Persistence;
@@ -28,9 +27,6 @@ class App
     use DiContainerTrait;
     use DynamicMethodTrait;
     use HookTrait;
-    use InitializerTrait {
-        init as private _init;
-    }
 
     public const HOOK_BEFORE_EXIT = self::class . '@beforeExit';
     public const HOOK_BEFORE_RENDER = self::class . '@beforeRender';
@@ -572,14 +568,6 @@ class App
         if ($isExitException) {
             $this->callExit();
         }
-    }
-
-    /**
-     * Initialize app.
-     */
-    protected function init(): void
-    {
-        $this->_init();
     }
 
     /**

--- a/src/CallbackLater.php
+++ b/src/CallbackLater.php
@@ -18,8 +18,6 @@ class CallbackLater extends Callback
      */
     public function set($fx = null, $args = null)
     {
-        $this->getApp(); // assert has App
-
         if ($this->getApp()->isRendering) {
             return parent::set($fx, $args);
         }

--- a/src/CardDeck.php
+++ b/src/CardDeck.php
@@ -193,7 +193,7 @@ class CardDeck extends View
      */
     protected function initActionExecutor(Model\UserAction $action): ExecutorInterface
     {
-        $executor = $this->getExecutorFactory()->create($action, $this);
+        $executor = $this->getExecutorFactory()->createExecutor($action, $this);
         if ($action->appliesTo === Model\UserAction::APPLIES_TO_SINGLE_RECORD) {
             $executor->jsSuccess = function (ExecutorInterface $ex, Model $m, $id, $return) use ($action) {
                 return $this->jsExecute($return, $action);

--- a/src/CardSection.php
+++ b/src/CardSection.php
@@ -71,7 +71,7 @@ class CardSection extends View
                 continue;
             }
             $label = $model->getField($field)->getCaption();
-            $value = $this->issetApp() ? $this->getApp()->uiPersistence->typecastSaveField($model->getField($field), $model->get($field)) : $model->get($field);
+            $value = $this->getApp()->uiPersistence->typecastSaveField($model->getField($field), $model->get($field));
             if ($useLabel) {
                 $value = $label . $this->glue . $value;
             }

--- a/src/Console.php
+++ b/src/Console.php
@@ -92,10 +92,8 @@ class Console extends View implements \Psr\Log\LoggerInterface
         $this->sse->set(function () use ($fx) {
             $this->sseInProgress = true;
 
-            if ($this->issetApp()) {
-                $oldLogger = $this->getApp()->logger;
-                $this->getApp()->logger = $this;
-            }
+            $oldLogger = $this->getApp()->logger;
+            $this->getApp()->logger = $this;
 
             ob_start(function (string $content) {
                 if ($this->_outputBypass || $content === '' /* needed as self::output() adds NL */) {
@@ -118,9 +116,7 @@ class Console extends View implements \Psr\Log\LoggerInterface
                 $this->outputHtmlWithoutPre('<div class="ui segment">{0}</div>', [$this->getApp()->renderExceptionHtml($e)]);
             }
 
-            if ($this->issetApp()) {
-                $this->getApp()->logger = $oldLogger;
-            }
+            $this->getApp()->logger = $oldLogger;
 
             $this->sseInProgress = false;
         });

--- a/src/Crud.php
+++ b/src/Crud.php
@@ -263,7 +263,7 @@ class Crud extends Grid
             $action->fields = $this->editFields;
         }
 
-        return $this->getExecutorFactory()->create($action, $this);
+        return $this->getExecutorFactory()->createExecutor($action, $this);
     }
 
     /**

--- a/src/Form/Control/Input.php
+++ b/src/Form/Control/Input.php
@@ -160,7 +160,7 @@ class Input extends Form\Control
         }
         if ($button instanceof UserAction || $button instanceof JsCallbackExecutor) {
             $executor = $button instanceof UserAction
-                ? $this->getExecutorFactory()->create($button, $this, ExecutorFactory::JS_EXECUTOR)
+                ? $this->getExecutorFactory()->createExecutor($button, $this, ExecutorFactory::JS_EXECUTOR)
                 : $button;
             $button = $this->add($this->getExecutorFactory()->createTrigger($executor->getAction()), $spot);
             $this->addClass('action');

--- a/src/Form/Layout.php
+++ b/src/Form/Layout.php
@@ -220,6 +220,7 @@ class Layout extends AbstractLayout
                 } else {
                     $hint->set($element->hint);
                 }
+                $hint->setApp($this->getApp());
                 $template->dangerouslySetHtml('Hint', $hint->getHtml());
             } elseif ($template->hasTag('Hint')) {
                 $template->del('Hint');

--- a/src/JsCallback.php
+++ b/src/JsCallback.php
@@ -194,6 +194,7 @@ class JsCallback extends Callback
             $html = $response->getHtml();
         } else {
             $modal = new Modal(['name' => false]);
+            $modal->setApp($this->getApp());
             $modal->add($response);
             $html = $modal->getHtml();
         }

--- a/src/JsCallback.php
+++ b/src/JsCallback.php
@@ -54,7 +54,7 @@ class JsCallback extends Callback
 
     public function jsExecute(): JsExpression
     {
-        $this->getApp(); // assert has App
+        $this->assertIsInitialized();
 
         return (new Jquery($this->getOwner() /* TODO element and loader element should be passed explicitly */))->atkAjaxec([
             'url' => $this->getJsUrl(),

--- a/src/JsSse.php
+++ b/src/JsSse.php
@@ -43,7 +43,7 @@ class JsSse extends JsCallback
 
     public function jsExecute(): JsExpression
     {
-        $this->getApp(); // assert has App
+        $this->assertIsInitialized();
 
         $options = ['url' => $this->getJsUrl()];
         if ($this->showLoader) {

--- a/src/Layout/Centered.php
+++ b/src/Layout/Centered.php
@@ -29,12 +29,11 @@ class Centered extends Layout
         parent::init();
 
         // if image is still unset load it when layout is initialized from the App
-        if ($this->image === null && $this->issetApp()) {
+        if ($this->image === null) {
             $this->image = $this->getApp()->cdn['atk'] . '/logo.png';
         }
 
         // set application's title
-
         $this->template->trySet('title', $this->getApp()->title);
     }
 

--- a/src/Table/Column/ActionMenu.php
+++ b/src/Table/Column/ActionMenu.php
@@ -68,6 +68,7 @@ class ActionMenu extends Table\Column
             $item = Factory::factory([View::class], ['name' => false, 'ui' => 'item', 'content' => $item]);
         }
 
+        $item->setApp($this->getApp());
         $this->items[] = $item;
 
         $item->addClass('{$_' . $name . '_disabled} i_' . $name);

--- a/src/UserAction/ExecutorFactory.php
+++ b/src/UserAction/ExecutorFactory.php
@@ -133,14 +133,6 @@ class ExecutorFactory
     }
 
     /**
-     * @return AbstractView&ExecutorInterface
-     */
-    public function create(UserAction $action, View $owner, string $requiredType = null): ExecutorInterface
-    {
-        return $this->createExecutor($action, $owner, $requiredType);
-    }
-
-    /**
      * @return ($type is self::MENU_ITEM ? MenuItem : ($type is self::TABLE_MENU_ITEM ? MenuItem : Button))
      */
     public function createTrigger(UserAction $action, string $type = null): View
@@ -156,7 +148,7 @@ class ExecutorFactory
     /**
      * @return AbstractView&ExecutorInterface
      */
-    protected function createExecutor(UserAction $action, View $owner, string $requiredType = null): ExecutorInterface
+    public function createExecutor(UserAction $action, View $owner, string $requiredType = null): ExecutorInterface
     {
         if ($requiredType !== null) {
             if (!($this->executorSeed[$requiredType] ?? null)) {

--- a/src/UserAction/StepExecutorTrait.php
+++ b/src/UserAction/StepExecutorTrait.php
@@ -460,6 +460,7 @@ trait StepExecutorTrait
             throw $e;
         } catch (\Throwable $e) {
             $msg = new Message(['Error executing ' . $this->action->caption, 'type' => 'error', 'class.red' => true]);
+            $msg->setApp($this->getApp());
             $msg->invokeInit();
             $msg->text->content = $this->getApp()->renderExceptionHtml($e);
 

--- a/src/View.php
+++ b/src/View.php
@@ -235,7 +235,7 @@ class View extends AbstractView
             }
         }
 
-        if ($this->template !== null && !$this->template->issetApp()) {
+        if ($this->template !== null && (!$this->template->issetApp() || $this->template->getApp() !== $app)) {
             $this->template->setApp($app);
         }
 

--- a/src/View.php
+++ b/src/View.php
@@ -211,6 +211,10 @@ class View extends AbstractView
      */
     protected function init(): void
     {
+        // almost every View needs an App to load a template, so assert App is set upfront
+        // TODO consider lazy loading the template
+        $app = $this->getApp();
+
         $addLater = $this->_addLater;
         $this->_addLater = null;
 
@@ -222,7 +226,7 @@ class View extends AbstractView
 
         if ($this->template === null) {
             if ($this->defaultTemplate !== null) {
-                $this->template = $this->getApp()->loadTemplate($this->defaultTemplate);
+                $this->template = $app->loadTemplate($this->defaultTemplate);
             } else {
                 if ($this->region !== 'Content' && $this->issetOwner() && $this->getOwner()->template) {
                     $this->template = $this->getOwner()->template->cloneRegion($this->region);
@@ -231,8 +235,8 @@ class View extends AbstractView
             }
         }
 
-        if ($this->template !== null && !$this->template->issetApp() && $this->issetApp()) {
-            $this->template->setApp($this->getApp());
+        if ($this->template !== null && !$this->template->issetApp()) {
+            $this->template->setApp($app);
         }
 
         foreach ($addLater as [$object, $region]) {
@@ -240,7 +244,7 @@ class View extends AbstractView
         }
 
         // allow for injecting the model with a seed
-        if ($this->model) {
+        if ($this->model !== null) {
             $this->setModel($this->model);
         }
     }

--- a/src/View.php
+++ b/src/View.php
@@ -506,9 +506,7 @@ class View extends AbstractView
     public $stickyArgs = [];
 
     /**
-     * Build an URL which this view can use for js call-backs. It should
-     * be guaranteed that requesting returned URL would at some point call
-     * $this->invokeInit().
+     * Build an URL which this view can use for JS callbacks.
      *
      * @param array $page
      */
@@ -518,9 +516,7 @@ class View extends AbstractView
     }
 
     /**
-     * Build an URL which this view can use for call-backs. It should
-     * be guaranteed that requesting returned URL would at some point call
-     * $this->invokeInit().
+     * Build an URL which this view can use for callbacks.
      *
      * @param string|array $page URL as string or array with page name as first element and other GET arguments
      */

--- a/src/View.php
+++ b/src/View.php
@@ -114,7 +114,7 @@ class View extends AbstractView
     public function setModel(Model $model): void
     {
         if ($this->model !== null && $this->model !== $model) {
-            throw new Exception('Different model already set');
+            throw new Exception('Different model is already set');
         }
 
         $this->model = $model;

--- a/src/View.php
+++ b/src/View.php
@@ -1040,7 +1040,7 @@ class View extends AbstractView
             $actions[] = $lazyJsRenderFx(fn () => $cb->jsExecute());
         } elseif ($action instanceof UserAction\ExecutorInterface || $action instanceof Model\UserAction) {
             // Setup UserAction executor.
-            $ex = $action instanceof Model\UserAction ? $this->getExecutorFactory()->create($action, $this) : $action;
+            $ex = $action instanceof Model\UserAction ? $this->getExecutorFactory()->createExecutor($action, $this) : $action;
             if ($ex instanceof self && $ex instanceof UserAction\JsExecutorInterface) {
                 if (isset($arguments['id'])) {
                     $arguments[$ex->name] = $arguments['id'];

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -5,19 +5,12 @@ declare(strict_types=1);
 namespace Atk4\Ui\Tests;
 
 use Atk4\Core\Phpunit\TestCase;
-use Atk4\Ui\App;
 use Atk4\Ui\Exception\LateOutputError;
 use Atk4\Ui\HtmlTemplate;
 
 class AppTest extends TestCase
 {
-    protected function createApp(): App
-    {
-        return new App([
-            'catchExceptions' => false,
-            'alwaysRun' => false,
-        ]);
-    }
+    use CreateAppTrait;
 
     public function testTemplateClassDefault(): void
     {

--- a/tests/ButtonTest.php
+++ b/tests/ButtonTest.php
@@ -9,12 +9,15 @@ use Atk4\Ui\Button;
 
 class ButtonTest extends TestCase
 {
+    use CreateAppTrait;
+
     /**
      * @doesNotPerformAssertions
      */
     public function testButtonIcon(): void
     {
         $b = new Button(['Load', 'icon' => 'pause']);
+        $b->setApp($this->createApp());
         $b->render();
     }
 }

--- a/tests/CreateAppTrait.php
+++ b/tests/CreateAppTrait.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atk4\Ui\Tests;
+
+use Atk4\Ui\App;
+
+trait CreateAppTrait
+{
+    protected function createApp(): App
+    {
+        return new App([
+            'catchExceptions' => false,
+            'alwaysRun' => false,
+        ]);
+    }
+}

--- a/tests/DemosTest.php
+++ b/tests/DemosTest.php
@@ -95,13 +95,15 @@ class DemosTest extends TestCase
     {
         $this->resetSuperglobals();
 
+        $rootDirRealpath = realpath(static::ROOT_DIR);
+
         $_SERVER = [
             'REQUEST_METHOD' => $request->getMethod(),
             'HTTP_HOST' => $request->getUri()->getHost(),
             'REQUEST_URI' => (string) $request->getUri(),
             'QUERY_STRING' => $request->getUri()->getQuery(),
-            'DOCUMENT_ROOT' => realpath(static::ROOT_DIR),
-            'SCRIPT_FILENAME' => realpath(static::ROOT_DIR) . $request->getUri()->getPath(),
+            'DOCUMENT_ROOT' => $rootDirRealpath,
+            'SCRIPT_FILENAME' => $rootDirRealpath . $request->getUri()->getPath(),
         ];
 
         $_GET = [];

--- a/tests/ExecutorFactoryTest.php
+++ b/tests/ExecutorFactoryTest.php
@@ -68,15 +68,15 @@ class ExecutorFactoryTest extends TestCase
         $view = View::addTo($this->app);
 
         $factory = $this->app->getExecutorFactory();
-        $modalExecutor = $factory->create($this->model->getUserAction('edit'), $view);
-        $jsCallbackExecutor = $factory->create($this->model->getUserAction('delete'), $view);
-        $confirmationExecutor = $factory->create($this->model->getUserAction('confirm'), $view);
+        $modalExecutor = $factory->createExecutor($this->model->getUserAction('edit'), $view);
+        $jsCallbackExecutor = $factory->createExecutor($this->model->getUserAction('delete'), $view);
+        $confirmationExecutor = $factory->createExecutor($this->model->getUserAction('confirm'), $view);
 
         $factory->registerTypeExecutor('MY_TYPE', [BasicExecutor::class]);
-        $myRequiredExecutor = $factory->create($this->model->getUserAction('confirm'), $view, 'MY_TYPE');
+        $myRequiredExecutor = $factory->createExecutor($this->model->getUserAction('confirm'), $view, 'MY_TYPE');
 
         $factory->registerExecutor($this->model->getUserAction('basic'), [BasicExecutor::class]);
-        $myBasicExecutor = $factory->create($this->model->getUserAction('basic'), $view);
+        $myBasicExecutor = $factory->createExecutor($this->model->getUserAction('basic'), $view);
 
         static::assertInstanceOf(ModalExecutor::class, $modalExecutor);
         static::assertInstanceOf(JsCallbackExecutor::class, $jsCallbackExecutor);

--- a/tests/ForFieldUiTest.php
+++ b/tests/ForFieldUiTest.php
@@ -27,6 +27,8 @@ class MyTestModel extends Model
  */
 class ForFieldUiTest extends TestCase
 {
+    use CreateAppTrait;
+
     /** @var Model */
     public $m;
 
@@ -46,6 +48,7 @@ class ForFieldUiTest extends TestCase
     public function testRegularField(): void
     {
         $f = new Form();
+        $f->setApp($this->createApp());
         $f->invokeInit();
         $f->setModel($this->m->createEntity());
         static::assertFalse($f->getControl('regular_field')->readOnly);
@@ -54,6 +57,7 @@ class ForFieldUiTest extends TestCase
     public function testJustDataField(): void
     {
         $f = new Form();
+        $f->setApp($this->createApp());
         $f->invokeInit();
         $f->setModel($this->m->createEntity(), ['just_for_data']);
         static::assertTrue($f->getControl('just_for_data')->readOnly);
@@ -62,6 +66,7 @@ class ForFieldUiTest extends TestCase
     public function testShowInUi(): void
     {
         $f = new Form();
+        $f->setApp($this->createApp());
         $f->invokeInit();
         $f->setModel($this->m->createEntity());
         static::assertFalse($f->getControl('no_persist_but_show_in_ui')->readOnly);

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -16,6 +16,8 @@ use Mvorisek\Atk4\Hintable\Phpstan\PhpstanUtil;
 
 class FormTest extends TestCase
 {
+    use CreateAppTrait;
+
     /** @var Form|null */
     public $form;
 
@@ -208,6 +210,7 @@ class FormTest extends TestCase
         $input = new Form\Control\Input();
         $input->disabled = true;
         $input->readOnly = true;
+        $input->setApp($this->createApp());
         static::assertStringContainsString(' disabled="disabled"', $input->render());
         static::assertStringContainsString(' readonly="readonly"', $input->render());
 
@@ -215,6 +218,7 @@ class FormTest extends TestCase
         $input->disabled = true;
         $input->readOnly = true;
         $input->inputType = 'hidden';
+        $input->setApp($this->createApp());
         static::assertStringNotContainsString('disabled', $input->render());
         static::assertStringNotContainsString('readonly', $input->render());
     }

--- a/tests/GridTest.php
+++ b/tests/GridTest.php
@@ -11,6 +11,7 @@ use Atk4\Ui\Table;
 
 class GridTest extends TestCase
 {
+    use CreateAppTrait;
     use TableTestTrait;
 
     /** @var MyModel */
@@ -30,6 +31,7 @@ class GridTest extends TestCase
     public function test1(): void
     {
         $t = new Table();
+        $t->setApp($this->createApp());
         $t->invokeInit();
         $t->setModel($this->m, []);
 
@@ -46,6 +48,7 @@ class GridTest extends TestCase
     public function test2(): void
     {
         $t = new Table();
+        $t->setApp($this->createApp());
         $t->invokeInit();
         $t->setModel($this->m, []);
 
@@ -62,6 +65,7 @@ class GridTest extends TestCase
     public function test3(): void
     {
         $t = new Table();
+        $t->setApp($this->createApp());
         $t->invokeInit();
         $t->setModel($this->m, ['email']);
         $del = $t->addColumn(null, [Table\Column\Delete::class]);

--- a/tests/JsIntegrationTest.php
+++ b/tests/JsIntegrationTest.php
@@ -13,9 +13,12 @@ use Atk4\Ui\View;
 
 class JsIntegrationTest extends TestCase
 {
+    use CreateAppTrait;
+
     public function testUniqueId1(): void
     {
         $v = new Button(['icon' => 'pencil']);
+        $v->setApp($this->createApp());
         $v->render();
 
         static::assertNotEmpty($v->icon);
@@ -28,6 +31,7 @@ class JsIntegrationTest extends TestCase
         $v = new View(['ui' => 'buttons']);
         $b1 = Button::addTo($v);
         $b2 = Button::addTo($v);
+        $v->setApp($this->createApp());
         $v->render();
 
         static::assertNotSame($b1->name, $b2->name);
@@ -37,6 +41,7 @@ class JsIntegrationTest extends TestCase
     {
         $v = new Button(['name' => 'b']);
         $j = $v->js()->hide();
+        $v->setApp($this->createApp());
         $v->render();
 
         static::assertSame('$(\'#b\').hide()', $j->jsRender());
@@ -46,6 +51,7 @@ class JsIntegrationTest extends TestCase
     {
         $v = new Button(['name' => 'b']);
         $j = $v->js(true)->hide();
+        $v->setApp($this->createApp());
         $v->renderAll();
 
         static::assertSame('(function () {
@@ -57,6 +63,7 @@ class JsIntegrationTest extends TestCase
     {
         $v = new Button(['name' => 'b']);
         $v->js('click')->hide();
+        $v->setApp($this->createApp());
         $v->renderAll();
 
         static::assertSame('(function () {
@@ -72,6 +79,7 @@ class JsIntegrationTest extends TestCase
     {
         $v = new Button(['name' => 'b']);
         $v->js('click', null);
+        $v->setApp($this->createApp());
         $v->renderAll();
 
         static::assertSame('(function () {
@@ -98,6 +106,7 @@ class JsIntegrationTest extends TestCase
             $b2->js()->hide(),
         ]);
         $b1->js(true)->data('x', 'y');
+        $v->setApp($this->createApp());
         $v->renderAll();
 
         static::assertSame('(function () {
@@ -124,6 +133,7 @@ class JsIntegrationTest extends TestCase
     public function testChainUnsupportedTypeException(): void
     {
         $v = new View();
+        $v->setApp($this->createApp());
         $v->invokeInit();
 
         $js = $v->js();
@@ -137,6 +147,7 @@ class JsIntegrationTest extends TestCase
     public function testChainJsCallbackLazyExecuteRender(): void
     {
         $v = new View();
+        $v->setApp($this->createApp());
         $v->invokeInit();
         $b = Button::addTo($v);
 

--- a/tests/ListerTest.php
+++ b/tests/ListerTest.php
@@ -12,12 +12,15 @@ use Atk4\Ui\View;
 
 class ListerTest extends TestCase
 {
+    use CreateAppTrait;
+
     /**
      * @doesNotPerformAssertions
      */
     public function testListerRender(): void
     {
         $v = new View();
+        $v->setApp($this->createApp());
         $v->invokeInit();
         $l = Lister::addTo($v, ['defaultTemplate' => 'lister.html']);
         $l->setSource(['foo', 'bar']);
@@ -29,6 +32,7 @@ class ListerTest extends TestCase
     public function testListerRender2(): void
     {
         $v = new View(['template' => new HtmlTemplate('hello{list}, world{/list}')]);
+        $v->setApp($this->createApp());
         $v->invokeInit();
         $l = Lister::addTo($v, [], ['list']);
         $l->setSource(['foo', 'bar']);
@@ -38,6 +42,7 @@ class ListerTest extends TestCase
     public function testAddAfterRender(): void
     {
         $v = new View();
+        $v->setApp($this->createApp());
         $v->invokeInit();
 
         $this->expectException(Exception::class);

--- a/tests/RenderTreeTest.php
+++ b/tests/RenderTreeTest.php
@@ -13,9 +13,12 @@ use Atk4\Ui\View;
  */
 class RenderTreeTest extends TestCase
 {
+    use CreateAppTrait;
+
     public function testBasic(): void
     {
         $view = new View();
+        $view->setApp($this->createApp());
         $view->render();
 
         $view->getApp();
@@ -26,6 +29,7 @@ class RenderTreeTest extends TestCase
     {
         $view = new View();
         $view2 = View::addTo($view);
+        $view->setApp($this->createApp());
         $view->render();
 
         $view2->getApp();

--- a/tests/SessionTraitTest.php
+++ b/tests/SessionTraitTest.php
@@ -18,17 +18,11 @@ use Atk4\Ui\SessionTrait;
  */
 class SessionTraitTest extends TestCase
 {
-    /** @var App */
-    protected $app;
+    use CreateAppTrait;
 
     protected function setUp(): void
     {
         parent::setUp();
-
-        $this->app = new App([
-            'catchExceptions' => false,
-            'alwaysRun' => false,
-        ]);
 
         session_abort();
         $sessionDir = sys_get_temp_dir() . '/atk4_test__ui__session';
@@ -55,7 +49,7 @@ class SessionTraitTest extends TestCase
 
     public function testException1(): void
     {
-        $m = new SessionWithoutNameMock($this->app);
+        $m = new SessionWithoutNameMock($this->createApp());
 
         // when try to start session without NameTrait
         $this->expectException(Exception::class);
@@ -64,7 +58,7 @@ class SessionTraitTest extends TestCase
 
     public function testConstructor(): void
     {
-        $m = new SessionMock($this->app);
+        $m = new SessionMock($this->createApp());
 
         static::assertFalse(isset($_SESSION));
         $m->atomicSession(function (): void {
@@ -78,7 +72,7 @@ class SessionTraitTest extends TestCase
      */
     public function testMemorize(): void
     {
-        $m = new SessionMock($this->app);
+        $m = new SessionMock($this->createApp());
         $m->name = 'test';
 
         // value as string
@@ -107,7 +101,7 @@ class SessionTraitTest extends TestCase
      */
     public function testLearnRecallForget(): void
     {
-        $m = new SessionMock($this->app);
+        $m = new SessionMock($this->createApp());
         $m->name = 'test';
 
         // value as string

--- a/tests/TableColumnColorRatingTest.php
+++ b/tests/TableColumnColorRatingTest.php
@@ -12,6 +12,7 @@ use Atk4\Ui\Table;
 
 class TableColumnColorRatingTest extends TestCase
 {
+    use CreateAppTrait;
     use TableTestTrait;
 
     /** @var Table */
@@ -32,6 +33,7 @@ class TableColumnColorRatingTest extends TestCase
         $m->addField('ref');
         $m->addField('rating', ['type' => 'integer']);
         $this->table = new Table();
+        $this->table->setApp($this->createApp());
         $this->table->invokeInit();
         $this->table->setModel($m, ['name', 'ref', 'rating']);
     }

--- a/tests/TableColumnLinkTest.php
+++ b/tests/TableColumnLinkTest.php
@@ -11,6 +11,7 @@ use Atk4\Ui\Table;
 
 class TableColumnLinkTest extends TestCase
 {
+    use CreateAppTrait;
     use TableTestTrait;
 
     /** @var Table */
@@ -31,6 +32,7 @@ class TableColumnLinkTest extends TestCase
         $m->addField('ref');
         $m->addField('salary');
         $this->table = new Table();
+        $this->table->setApp($this->createApp());
         $this->table->invokeInit();
         $this->table->setModel($m, ['name', 'ref']);
     }

--- a/tests/TableTest.php
+++ b/tests/TableTest.php
@@ -9,12 +9,15 @@ use Atk4\Ui\Table;
 
 class TableTest extends TestCase
 {
+    use CreateAppTrait;
+
     /**
      * @doesNotPerformAssertions
      */
     public function testAddColumnWithoutModel(): void
     {
         $t = new Table();
+        $t->setApp($this->createApp());
         $t->invokeInit();
         $t->setSource([
             ['one' => 1, 'two' => 2, 'three' => 3, 'four' => 4],

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -10,11 +10,14 @@ use Atk4\Ui\View;
 
 class ViewTest extends TestCase
 {
+    use CreateAppTrait;
+
     public function testMultipleTimesRender(): void
     {
         $v = new View();
         $v->set('foo');
 
+        $v->setApp($this->createApp());
         $a = $v->render();
         $b = $v->render();
         static::assertSame($a, $b);
@@ -25,6 +28,7 @@ class ViewTest extends TestCase
         $v = new View();
         $v->set('foo');
 
+        $v->setApp($this->createApp());
         $v->render();
 
         $this->expectException(Exception::class);
@@ -34,10 +38,12 @@ class ViewTest extends TestCase
     public function testVoidTagRender(): void
     {
         $v = new View();
+        $v->setApp($this->createApp());
         static::assertSame('<div id="atk" class="  " style="" ></div>', $v->render());
 
         $v = new View();
         $v->element = 'img';
+        $v->setApp($this->createApp());
         static::assertSame('<img id="atk" class="  " style="" >', $v->render());
     }
 }


### PR DESCRIPTION
Creating many implicit apps can imply negative performance and/or unexpected (other than configured, like implicit UI persistence comma) behaviour, both hard to debug.

If you call `View::invokeInit()` manually (not recommended, but needed for edge cases), then you need to set the app manually before the call.

This PR also asserts app is set no later than in init, this requirement may be drop in the future, but currently it is needed to load a template which is defined in almost every View.

Also drop `ExecutorFactory::create()` method in favor of `ExecutorFactory::createExecutor()`.