### PR TITLE
Share user action executor for multiple entities

### DIFF
--- a/demos/_includes/DemoLookup.php
+++ b/demos/_includes/DemoLookup.php
@@ -44,10 +44,10 @@ class DemoLookup extends Form\Control\Lookup
             $form->setModel($entity, $this->plus['fields'] ?? null);
 
             $form->onSubmit(function (Form $form) {
-                $form->model->save();
+                $msg = $form->model->getUserAction('add')->execute();
 
                 $ret = [
-                    new JsToast('Form submit!. Data are not save in demo mode.'),
+                    new JsToast($msg),
                     (new Jquery())->closest('.atk-modal')->modal('hide'),
                 ];
 

--- a/demos/_unit-test/modal-error.php
+++ b/demos/_unit-test/modal-error.php
@@ -32,7 +32,9 @@ $modal->set(function (View $p) {
     $country = new Country($p->getApp()->db);
     $button = Button::addTo($p)->set('Test ModalExecutor load PHP error');
     $executor = ModalExecutor::assertInstanceOf($p->getExecutorFactory()->createExecutor($country->getUserAction('edit'), $button));
-    $executor->stickyGet($executor->name, '-1');
+    if (\Closure::bind(fn () => $executor->loader, null, ModalExecutor::class)()->cb->isTriggered()) {
+        $executor->stickyGet($executor->name, '-1');
+    }
     $button->on('click', $executor);
 });
 $button = Button::addTo($app)->set('Test');

--- a/demos/init-db.php
+++ b/demos/init-db.php
@@ -51,7 +51,7 @@ trait ModelPreventModificationTrait
         $action->callback = function (Model $model, ...$args) use ($action, $originalCallback, $outputCallback) {
             if ($model->isEntity()) {
                 $action = $action->getActionForEntity($model);
-                $loadedModel = clone $model;
+                $loadedEntity = clone $model;
             }
 
             $callbackBackup = $action->callback;
@@ -62,7 +62,7 @@ trait ModelPreventModificationTrait
                 $action->callback = $callbackBackup;
             }
 
-            return $outputCallback($model->isEntity() && !$model->isLoaded() ? $loadedModel : $model, ...$args);
+            return $outputCallback($model->isEntity() && !$model->isLoaded() ? $loadedEntity : $model, ...$args);
         };
     }
 

--- a/demos/init-db.php
+++ b/demos/init-db.php
@@ -51,6 +51,7 @@ trait ModelPreventModificationTrait
         $action->callback = function (Model $model, ...$args) use ($action, $originalCallback, $outputCallback) {
             if ($model->isEntity()) {
                 $action = $action->getActionForEntity($model);
+                $loadedModel = clone $model;
             }
 
             $callbackBackup = $action->callback;
@@ -61,23 +62,28 @@ trait ModelPreventModificationTrait
                 $action->callback = $callbackBackup;
             }
 
-            return $outputCallback($model, ...$args);
+            return $outputCallback($model->isEntity() && !$model->isLoaded() ? $loadedModel : $model, ...$args);
         };
     }
 
     protected function initPreventModification(): void
     {
-        $this->wrapUserActionCallbackPreventModification($this->getUserAction('add'), function (Model $model) {
-            return 'Form Submit! Data are not save in demo mode.';
+        $makeMessageFx = function (string $actionName, Model $model) {
+            return $model->getModelCaption() . ' action "' . $actionName . '" with "' . $model->getTitle() . '" entity '
+                . ' was executed. In demo mode, all changes are reverved.';
+        };
+
+        $this->wrapUserActionCallbackPreventModification($this->getUserAction('add'), function (Model $model) use ($makeMessageFx) {
+            return $makeMessageFx('add', $model);
         });
 
-        $this->wrapUserActionCallbackPreventModification($this->getUserAction('edit'), function (Model $model) {
-            return 'Form Submit! Data are not save in demo mode.';
+        $this->wrapUserActionCallbackPreventModification($this->getUserAction('edit'), function (Model $model) use ($makeMessageFx) {
+            return $makeMessageFx('edit', $model);
         });
 
         $this->getUserAction('delete')->confirmation = 'Please go ahead. Demo mode does not really delete data.';
-        $this->wrapUserActionCallbackPreventModification($this->getUserAction('delete'), function (Model $model) {
-            return 'Only simulating delete when in demo mode.';
+        $this->wrapUserActionCallbackPreventModification($this->getUserAction('delete'), function (Model $model) use ($makeMessageFx) {
+            return $makeMessageFx('delete', $model);
         });
     }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -269,10 +269,16 @@ parameters:
             message: '~^Property Atk4\\Ui\\CardDeck::\$container \(Atk4\\Ui\\View\|null\) does not accept default value of type array<int\|string, string>\.$~'
         -
             path: 'src/CardDeck.php'
+            message: '~^Property Atk4\\Ui\\CardDeck::\$sharedExecutorsContainer \(Atk4\\Ui\\UserAction\\SharedExecutorsContainer\|null\) does not accept default value of type array<int, string>\.$~'
+        -
+            path: 'src/CardDeck.php'
             message: '~^Property Atk4\\Ui\\CardDeck::\$cardHolder \(Atk4\\Ui\\View\) does not accept default value of type array<int\|string, string>\.$~'
         -
             path: 'src/CardDeck.php'
             message: '~^Property Atk4\\Ui\\CardDeck::\$paginator \(Atk4\\Ui\\Paginator\|false\|null\) does not accept default value of type array\{''Atk4\\\\Ui\\\\Paginator''\}\.$~'
+        -
+            path: 'src/CardDeck.php'
+            message: '~^Property Atk4\\Ui\\CardDeck::\$sharedExecutorsContainer \(Atk4\\Ui\\UserAction\\SharedExecutorsContainer\|null\) does not accept Atk4\\Ui\\AbstractView\.$~'
         -
             path: 'src/CardDeck.php'
             message: '~^Property Atk4\\Ui\\CardDeck::\$container \(Atk4\\Ui\\View\|null\) does not accept Atk4\\Ui\\AbstractView\.$~'

--- a/src/Behat/Context.php
+++ b/src/Behat/Context.php
@@ -62,10 +62,7 @@ class Context extends RawMinkContext implements BehatContext
         if (!str_starts_with($event->getStep()->getText(), 'Toast display should contain text ')
             && $event->getStep()->getText() !== 'No toast should be displayed'
         ) {
-            $hadToast = $this->getSession()->evaluateScript('jQuery(\'.toast-box > .ui.toast\').toast(\'close\').length > 0;');
-            if ($hadToast) {
-                usleep(600_000); // TODO
-            }
+            $this->getSession()->executeScript('jQuery(\'.toast-box > .ui.toast\').toast(\'destroy\')');
         }
     }
 

--- a/src/Behat/Context.php
+++ b/src/Behat/Context.php
@@ -62,7 +62,10 @@ class Context extends RawMinkContext implements BehatContext
         if (!str_starts_with($event->getStep()->getText(), 'Toast display should contain text ')
             && $event->getStep()->getText() !== 'No toast should be displayed'
         ) {
-            $this->getSession()->executeScript('jQuery(\'.toast-box > .ui.toast\').toast(\'close\');');
+            $hadToast = $this->getSession()->evaluateScript('jQuery(\'.toast-box > .ui.toast\').toast(\'close\').length > 0;');
+            if ($hadToast) {
+                usleep(600_000); // TODO
+            }
         }
     }
 
@@ -171,7 +174,7 @@ class Context extends RawMinkContext implements BehatContext
     protected function assertNoDuplicateId(): void
     {
         [$invalidIds, $duplicateIds] = $this->getSession()->evaluateScript(<<<'EOF'
-            return (function () {
+            (function () {
                 const idRegex = /^[a-z_][0-9a-z_\-]*$/is;
                 const invalidIds = [];
                 const duplicateIds = [];
@@ -642,7 +645,7 @@ class Context extends RawMinkContext implements BehatContext
 
         $this->getScopeBuilderRuleElem($name);
         $idx = ($value === 'Yes') ? 0 : 1;
-        $isChecked = $this->getSession()->evaluateScript('return $(\'[data-name="' . $name . '"]\').find(\'input\')[' . $idx . '].checked');
+        $isChecked = $this->getSession()->evaluateScript('$(\'[data-name="' . $name . '"]\').find(\'input\')[' . $idx . '].checked');
         if (!$isChecked) {
             throw new \Exception('Radio value selected is not: ' . $value);
         }

--- a/src/Behat/MinkSeleniumDriver.php
+++ b/src/Behat/MinkSeleniumDriver.php
@@ -156,7 +156,7 @@ class MinkSeleniumDriver extends \Behat\Mink\Driver\Selenium2Driver
 
     public function evaluateScript($script, array $args = [])
     {
-        if (strpos(trim($script), 'return ') !== 0) {
+        if (!str_starts_with(trim($script), 'return ')) {
             $script = 'return ' . $script;
         }
 

--- a/src/Card.php
+++ b/src/Card.php
@@ -230,7 +230,7 @@ class Card extends View
         }
 
         $cardDeck = $this->getClosestOwner(CardDeck::class);
-        $btn->on('click', $cardDeck && $action->shortName !== 'delete' ? $cardDeck->sharedExecutorsContainer->getExecutor($action) : $action, $defaults);
+        $btn->on('click', $cardDeck ? $cardDeck->sharedExecutorsContainer->getExecutor($action) : $action, $defaults);
 
         return $this;
     }

--- a/src/Card.php
+++ b/src/Card.php
@@ -207,6 +207,8 @@ class Card extends View
 
     /**
      * Execute Model user action via button in Card.
+     *
+     * @return $this
      */
     public function addClickAction(Model\UserAction $action, Button $button = null, array $args = [], string $confirm = null): self
     {

--- a/src/Card.php
+++ b/src/Card.php
@@ -229,7 +229,8 @@ class Card extends View
             $defaults['confirm'] = $confirm;
         }
 
-        $btn->on('click', $action, $defaults);
+        $cardDeck = $this->getClosestOwner(CardDeck::class);
+        $btn->on('click', $cardDeck && $action->shortName !== 'delete' ? $cardDeck->sharedExecutorsContainer->getExecutor($action) : $action, $defaults);
 
         return $this;
     }

--- a/src/CardDeck.php
+++ b/src/CardDeck.php
@@ -10,6 +10,7 @@ use Atk4\Ui\Js\JsExpressionable;
 use Atk4\Ui\Js\JsToast;
 use Atk4\Ui\UserAction\ExecutorFactory;
 use Atk4\Ui\UserAction\ExecutorInterface;
+use Atk4\Ui\UserAction\SharedExecutorsContainer;
 
 /**
  * A collection of Card set from a model.
@@ -35,6 +36,9 @@ class CardDeck extends View
 
     /** @var bool If each card should use action or not. */
     public $useAction = true;
+
+    /** @var SharedExecutorsContainer|null */
+    public $sharedExecutorsContainer = [SharedExecutorsContainer::class];
 
     /** @var View|null The container view. The view that is reload when page or data changed. */
     public $container = [View::class, 'ui' => 'vertical segment'];
@@ -89,6 +93,8 @@ class CardDeck extends View
     protected function init(): void
     {
         parent::init();
+
+        $this->sharedExecutorsContainer = $this->add($this->sharedExecutorsContainer);
 
         $this->container = $this->add($this->container);
 

--- a/src/Form/Control.php
+++ b/src/Form/Control.php
@@ -99,11 +99,9 @@ class Control extends View
     {
         if ($this->entityField) {
             $this->entityField->set($value);
-
-            return $this;
+        } else {
+            $this->content = $value;
         }
-
-        $this->content = $value;
 
         return $this;
     }

--- a/src/Form/Control/Multiline.php
+++ b/src/Form/Control/Multiline.php
@@ -335,6 +335,9 @@ class Multiline extends Form\Control
         return $rowErrors;
     }
 
+    /**
+     * @return $this
+     */
     public function saveRows(): self
     {
         $model = $this->model;

--- a/src/Form/Control/ScopeBuilder.php
+++ b/src/Form/Control/ScopeBuilder.php
@@ -332,7 +332,7 @@ class ScopeBuilder extends Form\Control
     /**
      * Add the field rules to use in VueQueryBuilder.
      */
-    protected function addFieldRule(Field $field): self
+    protected function addFieldRule(Field $field): void
     {
         if ($field->enum || $field->values) {
             $type = 'enum';
@@ -349,8 +349,6 @@ class ScopeBuilder extends Form\Control
         ], $field->ui['scopebuilder'] ?? []), $field);
 
         $this->rules[] = $rule;
-
-        return $this;
     }
 
     /**
@@ -405,7 +403,7 @@ class ScopeBuilder extends Form\Control
     /**
      * Add rules on the referenced model fields.
      */
-    protected function addReferenceRules(Field $field): self
+    protected function addReferenceRules(Field $field): void
     {
         if ($field->hasReference()) {
             $reference = $field->getReference();
@@ -428,8 +426,6 @@ class ScopeBuilder extends Form\Control
                 $this->addFieldRule($theirField);
             }
         }
-
-        return $this;
     }
 
     protected function getRule(string $type, array $defaults = [], Field $field = null): array

--- a/src/HtmlTemplate.php
+++ b/src/HtmlTemplate.php
@@ -87,6 +87,9 @@ class HtmlTemplate
         $this->tagTrees = $this->cloneTagTrees($this->tagTrees);
     }
 
+    /**
+     * @return static
+     */
     public function cloneRegion(string $tag): self
     {
         $template = new static();
@@ -204,6 +207,8 @@ class HtmlTemplate
      * would read and set multiple region values from $_GET array.
      *
      * @param string|array|Model $tag
+     *
+     * @return $this
      */
     public function set($tag, string $value = null): self
     {
@@ -217,6 +222,8 @@ class HtmlTemplate
      * $tag.
      *
      * @param string|array|Model $tag
+     *
+     * @return $this
      */
     public function trySet($tag, string $value = null): self
     {
@@ -230,6 +237,8 @@ class HtmlTemplate
      * encoding, so you must be sure to sanitize.
      *
      * @param string|array|Model $tag
+     *
+     * @return $this
      */
     public function dangerouslySetHtml($tag, string $value = null): self
     {
@@ -243,6 +252,8 @@ class HtmlTemplate
      * $tag.
      *
      * @param string|array|Model $tag
+     *
+     * @return $this
      */
     public function tryDangerouslySetHtml($tag, string $value = null): self
     {
@@ -255,6 +266,8 @@ class HtmlTemplate
      * Add more content inside a tag.
      *
      * @param string|array|Model $tag
+     *
+     * @return $this
      */
     public function append($tag, ?string $value): self
     {
@@ -268,6 +281,8 @@ class HtmlTemplate
      * $tag.
      *
      * @param string|array|Model $tag
+     *
+     * @return $this
      */
     public function tryAppend($tag, ?string $value): self
     {
@@ -281,6 +296,8 @@ class HtmlTemplate
      * encoding, so you must be sure to sanitize.
      *
      * @param string|array|Model $tag
+     *
+     * @return $this
      */
     public function dangerouslyAppendHtml($tag, ?string $value): self
     {
@@ -294,6 +311,8 @@ class HtmlTemplate
      * $tag.
      *
      * @param string|array|Model $tag
+     *
+     * @return $this
      */
     public function tryDangerouslyAppendHtml($tag, ?string $value): self
     {
@@ -307,6 +326,8 @@ class HtmlTemplate
      * it will be also removed.
      *
      * @param string|array $tag
+     *
+     * @return $this
      */
     public function del($tag): self
     {
@@ -333,6 +354,8 @@ class HtmlTemplate
      * Similar to del() but won't throw exception if tag is not present.
      *
      * @param string|array $tag
+     *
+     * @return $this
      */
     public function tryDel($tag): self
     {
@@ -351,6 +374,9 @@ class HtmlTemplate
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function loadFromFile(string $filename): self
     {
         if ($this->tryLoadFromFile($filename) !== false) {
@@ -398,6 +424,9 @@ class HtmlTemplate
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function loadFromString(string $str): self
     {
         $this->parseTemplate($str);

--- a/src/Js/JsToast.php
+++ b/src/Js/JsToast.php
@@ -41,6 +41,8 @@ class JsToast implements JsExpressionable
      * Set message to display in Toast.
      *
      * @param string $msg
+     *
+     * @return $this
      */
     public function setMessage($msg): self
     {

--- a/src/JsCallback.php
+++ b/src/JsCallback.php
@@ -75,6 +75,9 @@ class JsCallback extends Callback
         $this->confirm = $text;
     }
 
+    /**
+     * @return $this
+     */
     public function set($fx = null, $args = null)
     {
         $this->args = [];

--- a/src/Popup.php
+++ b/src/Popup.php
@@ -125,6 +125,8 @@ class Popup extends View
      * for adding content to it.
      *
      * @param \Closure $fx
+     *
+     * @return $this
      */
     public function set($fx = null, $ignore = null)
     {

--- a/src/UserAction/ConfirmationExecutor.php
+++ b/src/UserAction/ConfirmationExecutor.php
@@ -113,7 +113,7 @@ class ConfirmationExecutor extends Modal implements JsExecutorInterface
     }
 
     /**
-     * Perform this action steps.
+     * Perform the current step.
      */
     public function executeModelAction(): void
     {

--- a/src/UserAction/JsCallbackExecutor.php
+++ b/src/UserAction/JsCallbackExecutor.php
@@ -51,10 +51,7 @@ class JsCallbackExecutor extends JsCallback implements ExecutorInterface
         return $this;
     }
 
-    /**
-     * Execute model user action.
-     */
-    public function executeModelAction(array $args = [])
+    public function executeModelAction(array $args = []): void
     {
         $this->set(function (Jquery $j) {
             // may be id is passed as 'id' or model->idField within $post args.
@@ -94,8 +91,6 @@ class JsCallbackExecutor extends JsCallback implements ExecutorInterface
 
             return $js;
         }, $args);
-
-        return $this;
     }
 
     /**

--- a/src/UserAction/JsCallbackExecutor.php
+++ b/src/UserAction/JsCallbackExecutor.php
@@ -54,10 +54,14 @@ class JsCallbackExecutor extends JsCallback implements ExecutorInterface
 
     public function jsExecute(array $urlArgs = []): JsExpression
     {
-        $res = parent::jsExecute();
-        $res->_chain[0][1][0]['urlOptions'] = array_merge($res->_chain[0][1][0]['urlOptions'], $urlArgs); // @phpstan-ignore-line TODO hack to accept/pass ID to parent/JsCallback::jsExecute() like JsExecutorInterface does
-
-        return $res;
+        // TODO hack to parametrize parent::jsExecute() like JsExecutorInterface::jsExecute($urlArgs)
+        $argsOrig = $this->args;
+        $this->args = array_merge($this->args, $urlArgs);
+        try {
+            return parent::jsExecute();
+        } finally {
+            $this->args = $argsOrig;
+        }
     }
 
     public function executeModelAction(array $args = []): void
@@ -66,7 +70,7 @@ class JsCallbackExecutor extends JsCallback implements ExecutorInterface
             // may be id is passed as 'id' or model->idField within $post args.
             $id = $this->getApp()->uiPersistence->typecastLoadField(
                 $this->action->getModel()->getField($this->action->getModel()->idField),
-                $_POST['c0'] ?? $_POST['id'] ?? $_POST[$this->action->getModel()->idField] ?? $_POST[$this->name] ?? null
+                $_POST['c0'] ?? $_POST[$this->name] ?? $_POST['id'] ?? $_POST[$this->action->getModel()->idField] ?? null
             );
             if ($id && $this->action->appliesTo === Model\UserAction::APPLIES_TO_SINGLE_RECORD) {
                 if ($this->action->isOwnerEntity() && $this->action->getEntity()->getId()) {

--- a/src/UserAction/JsCallbackExecutor.php
+++ b/src/UserAction/JsCallbackExecutor.php
@@ -7,6 +7,7 @@ namespace Atk4\Ui\UserAction;
 use Atk4\Core\HookTrait;
 use Atk4\Data\Model;
 use Atk4\Ui\Js\Jquery;
+use Atk4\Ui\Js\JsExpression;
 use Atk4\Ui\Js\JsExpressionable;
 use Atk4\Ui\Js\JsToast;
 use Atk4\Ui\JsCallback;
@@ -51,13 +52,21 @@ class JsCallbackExecutor extends JsCallback implements ExecutorInterface
         return $this;
     }
 
+    public function jsExecute(array $urlArgs = []): JsExpression
+    {
+        $res = parent::jsExecute();
+        $res->_chain[0][1][0]['urlOptions'] = array_merge($res->_chain[0][1][0]['urlOptions'], $urlArgs); // @phpstan-ignore-line TODO hack to accept/pass ID to parent/JsCallback::jsExecute() like JsExecutorInterface does, later, it should be passed using GET method
+
+        return $res;
+    }
+
     public function executeModelAction(array $args = []): void
     {
         $this->set(function (Jquery $j) {
             // may be id is passed as 'id' or model->idField within $post args.
             $id = $this->getApp()->uiPersistence->typecastLoadField(
                 $this->action->getModel()->getField($this->action->getModel()->idField),
-                $_POST['c0'] ?? $_POST['id'] ?? $_POST[$this->action->getModel()->idField] ?? null
+                $_POST['c0'] ?? $_POST['id'] ?? $_POST[$this->action->getModel()->idField] ?? $_POST[$this->name] ?? null
             );
             if ($id && $this->action->appliesTo === Model\UserAction::APPLIES_TO_SINGLE_RECORD) {
                 if ($this->action->isOwnerEntity() && $this->action->getEntity()->getId()) {

--- a/src/UserAction/JsCallbackExecutor.php
+++ b/src/UserAction/JsCallbackExecutor.php
@@ -55,7 +55,7 @@ class JsCallbackExecutor extends JsCallback implements ExecutorInterface
     public function jsExecute(array $urlArgs = []): JsExpression
     {
         $res = parent::jsExecute();
-        $res->_chain[0][1][0]['urlOptions'] = array_merge($res->_chain[0][1][0]['urlOptions'], $urlArgs); // @phpstan-ignore-line TODO hack to accept/pass ID to parent/JsCallback::jsExecute() like JsExecutorInterface does, later, it should be passed using GET method
+        $res->_chain[0][1][0]['urlOptions'] = array_merge($res->_chain[0][1][0]['urlOptions'], $urlArgs); // @phpstan-ignore-line TODO hack to accept/pass ID to parent/JsCallback::jsExecute() like JsExecutorInterface does
 
         return $res;
     }

--- a/src/UserAction/JsCallbackExecutor.php
+++ b/src/UserAction/JsCallbackExecutor.php
@@ -67,10 +67,9 @@ class JsCallbackExecutor extends JsCallback implements ExecutorInterface
     public function executeModelAction(array $args = []): void
     {
         $this->set(function (Jquery $j) {
-            // may be id is passed as 'id' or model->idField within $post args.
             $id = $this->getApp()->uiPersistence->typecastLoadField(
                 $this->action->getModel()->getField($this->action->getModel()->idField),
-                $_POST['c0'] ?? $_POST[$this->name] ?? $_POST['id'] ?? $_POST[$this->action->getModel()->idField] ?? null
+                $_POST['c0'] ?? $_POST[$this->name] ?? null
             );
             if ($id && $this->action->appliesTo === Model\UserAction::APPLIES_TO_SINGLE_RECORD) {
                 if ($this->action->isOwnerEntity() && $this->action->getEntity()->getId()) {

--- a/src/UserAction/ModalExecutor.php
+++ b/src/UserAction/ModalExecutor.php
@@ -116,6 +116,8 @@ class ModalExecutor extends Modal implements JsExecutorInterface
      * Assign a View that will fire action execution.
      * If action require steps, it will automatically initialize
      * proper step to execute first.
+     *
+     * @return $this
      */
     public function assignTrigger(View $view, array $urlArgs = [], string $when = 'click', string $selector = null): self
     {

--- a/src/UserAction/SharedExecutor.php
+++ b/src/UserAction/SharedExecutor.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atk4\Ui\UserAction;
+
+use Atk4\Ui\AbstractView;
+use Atk4\Ui\Js\JsExpressionable;
+
+class SharedExecutor
+{
+    /** @var AbstractView&ExecutorInterface */
+    private ExecutorInterface $executor;
+
+    /**
+     * @param AbstractView&ExecutorInterface $executor
+     */
+    public function __construct(ExecutorInterface $executor)
+    {
+        $this->executor = $executor;
+    }
+
+    /**
+     * @return AbstractView&ExecutorInterface
+     */
+    public function getExecutor(): ExecutorInterface
+    {
+        return $this->executor;
+    }
+
+    /**
+     * @return array<int, JsExpressionable>
+     */
+    public function jsExecute(array $urlArgs): array
+    {
+        return $this->getExecutor()->jsExecute($urlArgs); // @phpstan-ignore-line TODO dedup JS
+    }
+}

--- a/src/UserAction/SharedExecutor.php
+++ b/src/UserAction/SharedExecutor.php
@@ -33,6 +33,12 @@ class SharedExecutor
      */
     public function jsExecute(array $urlArgs): array
     {
-        return $this->getExecutor()->jsExecute($urlArgs); // @phpstan-ignore-line TODO dedup JS
+        // TODO executor::jsExecute() should be called only once, registered as a custom jQuery event and then
+        // call the event from JS with arguments to improve performance, ie. render (possibly large) JS only once
+        $res = $this->getExecutor()->jsExecute($urlArgs); // @phpstan-ignore-line
+
+        return $this->getExecutor() instanceof JsCallbackExecutor
+            ? [$res]
+            : $res;
     }
 }

--- a/src/UserAction/SharedExecutorsContainer.php
+++ b/src/UserAction/SharedExecutorsContainer.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atk4\Ui\UserAction;
+
+use Atk4\Data\Model;
+use Atk4\Ui\View;
+
+/**
+ * Multi entity views like CardDeck can render many items with the same UA, to improve
+ * the performance and reduce the total page size, render the UA executors only once.
+ */
+class SharedExecutorsContainer extends View
+{
+    /** @var array<string, SharedExecutor> */
+    public array $sharedExecutors = [];
+
+    public function getExecutor(Model\UserAction $action): SharedExecutor
+    {
+        $action->getOwner()->assertIsModel(); // @phpstan-ignore-line
+        $this->getOwner()->model->assertIsModel($action->getModel());
+
+        if (!isset($this->sharedExecutors[$action->shortName])) {
+            $ex = $this->getExecutorFactory()->createExecutor($action, $this);
+            $ex->executeModelAction();
+            $this->sharedExecutors[$action->shortName] = new SharedExecutor($ex);
+        }
+
+        return $this->sharedExecutors[$action->shortName];
+    }
+}

--- a/src/View.php
+++ b/src/View.php
@@ -1043,7 +1043,7 @@ class View extends AbstractView
             }, $arguments);
 
             $actions[] = $lazyJsRenderFx(fn () => $cb->jsExecute());
-        } elseif ($action instanceof UserAction\ExecutorInterface || $action instanceof Model\UserAction) {
+        } elseif ($action instanceof UserAction\ExecutorInterface || $action instanceof UserAction\SharedExecutor || $action instanceof Model\UserAction) {
             $ex = $action instanceof Model\UserAction ? $this->getExecutorFactory()->createExecutor($action, $this) : $action;
 
             $setupNonSharedExecutorFx = function (UserAction\ExecutorInterface $ex) use (&$defaults, &$arguments): void {
@@ -1068,7 +1068,10 @@ class View extends AbstractView
                 }
             };
 
-            if ($ex instanceof UserAction\JsExecutorInterface && $ex instanceof self) {
+            if ($ex instanceof UserAction\SharedExecutor) {
+                $setupNonSharedExecutorFx($ex->getExecutor());
+                $actions = $ex->jsExecute($arguments);
+            } elseif ($ex instanceof UserAction\JsExecutorInterface && $ex instanceof self) {
                 $setupNonSharedExecutorFx($ex);
                 $ex->executeModelAction();
                 $actions = $ex->jsExecute($arguments);

--- a/src/View.php
+++ b/src/View.php
@@ -1081,8 +1081,8 @@ class View extends AbstractView
                 $actions = $ex->jsExecute($arguments);
             } elseif ($ex instanceof UserAction\JsCallbackExecutor) {
                 $setupNonSharedExecutorFx($ex);
-                $ex->executeModelAction($arguments);
-                $actions = [$lazyJsRenderFx(fn () => $ex->jsExecute())];
+                $ex->executeModelAction();
+                $actions = [$lazyJsRenderFx(fn () => $ex->jsExecute($arguments))];
             } else {
                 throw new Exception('Executor must be of type UserAction\JsCallbackExecutor or UserAction\JsExecutorInterface');
             }

--- a/src/View.php
+++ b/src/View.php
@@ -750,7 +750,6 @@ class View extends AbstractView
      * You can bind it by passing object into on() method.
      *
      * 1. Calling with arguments:
-     *
      * $view->js(); // technically does nothing
      * $a = $view->js()->hide(); // creates chain for hiding $view but does not bind to event yet.
      *
@@ -768,7 +767,7 @@ class View extends AbstractView
      * 4. $view->js(true)->find('.current')->text($text);
      *
      * Will convert calls to jQuery chain into JavaScript string:
-     *  $('#view').find('.current').text('abc'); // The $text will be json-encoded to avoid JS injection.
+     *  $('#view').find('.current').text('abc'); // the text will be JSON encoded to avoid JS injection
      *
      * Documentation:
      *

--- a/tests-behat/callback.feature
+++ b/tests-behat/callback.feature
@@ -19,4 +19,4 @@ Feature: Callback
     Then I click using selector "xpath((//div.ui.atk-test.button)[1])"
     Then Modal is open with text "Edit Country"
     Then I press Modal button "Save"
-    Then Toast display should contain text "Form Submit"
+    Then Toast display should contain text 'Country action "edit" with "Andorra" entity was executed.'

--- a/tests-behat/card-deck.feature
+++ b/tests-behat/card-deck.feature
@@ -11,7 +11,7 @@ Feature: CardDeck
     Then I fill in "atk_fp_country__numcode" with "123"
     Then I fill in "atk_fp_country__phonecode" with "1"
     Then I press Modal button "Save"
-    Then Toast display should contain text "Form Submit"
+    Then Toast display should contain text 'Country action "add" with "Test" entity was executed.'
 
   Scenario: search
     Then I fill in "atk-vue-search" with "united kingdom"
@@ -21,12 +21,13 @@ Feature: CardDeck
     Then I press button "Edit"
     Then Modal is open with text "Edit Country"
     Then I press Modal button "Save"
-    Then Toast display should contain text "Form Submit"
+    Then Toast display should contain text 'Country action "edit" with "United Kingdom" entity was executed.'
     # make sure search query stick
     Then I should see "United Kingdom"
 
   Scenario: delete
     Then I press button "Delete"
     Then I press Modal button "Ok"
+    Then Toast display should contain text 'Country action "delete" with "United Kingdom" entity was executed.'
     # TODO https://github.com/atk4/ui/issues/1848
     # Then I should not see "United Kingdom"

--- a/tests-behat/crud.feature
+++ b/tests-behat/crud.feature
@@ -11,7 +11,7 @@ Feature: Crud
     Then I fill in "atk_fp_country__numcode" with "123"
     Then I fill in "atk_fp_country__phonecode" with "1"
     Then I press Modal button "Save"
-    Then Toast display should contain text "Form Submit"
+    Then Toast display should contain text 'Country action "add" with "Test" entity was executed.'
 
   Scenario: search
     Then I search grid for "united kingdom"
@@ -22,13 +22,14 @@ Feature: Crud
     Then I press button "Edit"
     Then Modal is open with text "Edit Country"
     Then I press Modal button "Save"
-    Then Toast display should contain text "Form Submit"
+    Then Toast display should contain text 'Country action "edit" with "United Kingdom" entity was executed.'
     # make sure search query stick
     Then I should see "United Kingdom"
 
   Scenario: delete
     Then I press button "Delete"
     Then I press Modal button "Ok"
+    Then Toast display should contain text 'Country action "delete" with "United Kingdom" entity was executed.'
     Then I should not see "United Kingdom"
 
   Scenario: search across multiple columns

--- a/tests-behat/lookup.feature
+++ b/tests-behat/lookup.feature
@@ -25,4 +25,4 @@ Feature: Lookup
     When I fill in "atk_fp_country__numcode" with "88"
     When I fill in "atk_fp_country__phonecode" with "8"
     Then I press Modal button "Save"
-    Then Toast display should contain text "Form submit!"
+    Then Toast display should contain text 'Country action "add" with "New country" entity was executed.'


### PR DESCRIPTION
fix #1976

time to render 2 (add, delete) actions for 1000 entities is reduced from ~2000 ms to ~500 ms, ie performance is improved ~4x!

no BC break, everything works as before, only the performance on both server & client side is massively improved, also much less data needs to be transfered between the server and client