### PR TITLE
Add support for custom decimal separator for numeric types

### DIFF
--- a/docs/paginator.rst
+++ b/docs/paginator.rst
@@ -40,7 +40,7 @@ to display current page BEFORE the paginator on your page::
 Remember that values of 'page' and 'total' are integers, so you may need to do type-casting::
 
     $label->set($p->page); // will not work
-    $label->set((string)$p->page); // works fine
+    $label->set((string) $p->page); // works fine
 
 Range and Logic
 ===============

--- a/src/Form/Control/Dropdown.php
+++ b/src/Form/Control/Dropdown.php
@@ -264,7 +264,7 @@ class Dropdown extends Input
     {
         foreach ($this->model as $key => $row) {
             $title = $row->getTitle();
-            $this->_tItem->set('value', (string) $key);
+            $this->_tItem->set('value', $key);
             $this->_tItem->set('title', $title || is_numeric($title) ? (string) $title : '');
             // add item to template
             $this->template->dangerouslyAppendHtml('Item', $this->_tItem->renderToHtml());
@@ -277,7 +277,7 @@ class Dropdown extends Input
     protected function _renderItemsForValues(): void
     {
         foreach ($this->values as $key => $val) {
-            $this->_tItem->set('value', (string) $key);
+            $this->_tItem->set('value', $key);
             if (is_array($val)) {
                 if (array_key_exists('icon', $val)) {
                     $this->_tIcon->set('iconClass', $val['icon'] . ' icon');
@@ -305,7 +305,7 @@ class Dropdown extends Input
     protected function _addCallBackRow($row, $key = null): void
     {
         $res = ($this->renderRowFunction)($row, $key);
-        $this->_tItem->set('value', (string) $res['value']);
+        $this->_tItem->set('value', $res['value']);
         $this->_tItem->set('title', $res['title']);
 
         // Icon

--- a/src/Form/Control/ScopeBuilder.php
+++ b/src/Form/Control/ScopeBuilder.php
@@ -547,7 +547,7 @@ class ScopeBuilder extends Form\Control
     public static function queryToCondition(array $query): Scope\Condition
     {
         $key = $query['rule'] ?? null;
-        $operator = (string) ($query['operator'] ?? null);
+        $operator = $query['operator'] ?? null;
         $value = $query['value'] ?? null;
 
         switch ($operator) {
@@ -573,7 +573,7 @@ class ScopeBuilder extends Form\Control
                 break;
             case self::OPERATOR_IN:
             case self::OPERATOR_NOT_IN:
-                $value = explode(static::detectDelimiter($value), (string) $value);
+                $value = explode(static::detectDelimiter($value), $value);
 
                 break;
         }

--- a/src/HtmlTemplate.php
+++ b/src/HtmlTemplate.php
@@ -6,6 +6,7 @@ namespace Atk4\Ui;
 
 use Atk4\Core\AppScopeTrait;
 use Atk4\Core\WarnDynamicPropertyTrait;
+use Atk4\Data\Field;
 use Atk4\Data\Model;
 use Atk4\Ui\HtmlTemplate\TagTree;
 use Atk4\Ui\HtmlTemplate\Value as HtmlValue;
@@ -174,7 +175,11 @@ class HtmlTemplate
         }
 
         // TODO remove later in favor of strong string type
-        $value = (string) $value;
+        if ($value === null) {
+            $value = '';
+        } elseif (is_int($value)) {
+            $value = $this->getApp()->uiPersistence->typecastSaveField(new Field(['type' => 'integer']), $value);
+        }
 
         $htmlValue = new HtmlValue();
         if ($encodeHtml) {

--- a/src/HtmlTemplate.php
+++ b/src/HtmlTemplate.php
@@ -177,7 +177,7 @@ class HtmlTemplate
         // TODO remove later in favor of strong string type
         if ($value === null) {
             $value = '';
-        } elseif (is_int($value)) {
+        } elseif (is_int($value)) { // @phpstan-ignore-line
             $value = $this->getApp()->uiPersistence->typecastSaveField(new Field(['type' => 'integer']), $value);
         }
 

--- a/src/Persistence/Ui.php
+++ b/src/Persistence/Ui.php
@@ -8,6 +8,7 @@ use Atk4\Data\Field;
 use Atk4\Data\Field\PasswordField;
 use Atk4\Data\Model;
 use Atk4\Data\Persistence;
+use Atk4\Data\Persistence\Sql\Expression;
 use Atk4\Ui\Exception;
 
 /**
@@ -25,14 +26,15 @@ class Ui extends Persistence
     /** @var string */
     public $locale = 'en';
 
+    /** @var string Thousands separator for numeric types. */
+    public $thousandsSeparator = ' ';
+    /** @var string Decimal point separator for numeric (non-integer) types. */
+    public $decimalSeparator = '.';
+
     /** @var string Currency symbol for 'atk4_money' type. */
     public $currency = '€';
     /** @var int Number of decimal digits for 'atk4_money' type. */
     public $currencyDecimals = 2;
-    /** @var string Decimal point separator for 'atk4_money' type. */
-    public $currencyDecimalSeparator = '.';
-    /** @var string Thousands separator for 'atk4_money' type. */
-    public $currencyThousandsSeparator = ' ';
 
     /** @var string */
     public $timezone;
@@ -93,11 +95,25 @@ class Ui extends Persistence
                 $value = $value ? $this->yes : $this->no;
 
                 break;
+            case 'integer':
+            case 'float':
+                $value = parent::_typecastLoadField($field, $value);
+                $value = is_int($value)
+                    ? (string) $value
+                    : Expression::castFloatToString($value);
+                $value = preg_replace_callback('~\.?\d+~', function ($matches) {
+                    return substr($matches[0], 0, 1) === '.'
+                        ? $this->decimalSeparator . preg_replace('~\d{3}\K(?!$)~', /* ' ' */ '', substr($matches[0], 1))
+                        : preg_replace('~(?<!^)(?=(?:\d{3})+$)~', $this->thousandsSeparator, $matches[0]);
+                }, $value);
+                $value = str_replace(' ', "\u{00a0}" /* Unicode NBSP */, $value);
+
+                break;
             case 'atk4_money':
                 $value = parent::_typecastLoadField($field, $value);
                 $valueDecimals = strlen(preg_replace('~^[^.]$|^.+\.|0+$~s', '', number_format($value, max(0, 11 - (int) log10($value)), '.', '')));
                 $value = ($this->currency ? $this->currency . ' ' : '')
-                    . number_format($value, max($this->currencyDecimals, $valueDecimals), $this->currencyDecimalSeparator, $this->currencyThousandsSeparator);
+                    . number_format($value, max($this->currencyDecimals, $valueDecimals), $this->decimalSeparator, $this->thousandsSeparator);
                 $value = str_replace(' ', "\u{00a0}" /* Unicode NBSP */, $value);
 
                 break;
@@ -142,12 +158,14 @@ class Ui extends Persistence
                 }
 
                 break;
+            case 'integer':
+            case 'float':
             case 'atk4_money':
                 if (is_string($value)) {
                     $value = str_replace([' ', "\u{00a0}" /* Unicode NBSP */, '_', $this->currency, '$', '€'], '', $value);
-                    $dSep = $this->currencyDecimalSeparator;
+                    $dSep = $this->decimalSeparator;
                     $tSeps = array_filter(
-                        array_unique([$dSep, $this->currencyThousandsSeparator, '.', ',']),
+                        array_unique([$dSep, $this->thousandsSeparator, '.', ',']),
                         fn ($sep) => strpos($value, $sep) !== false
                     );
                     usort($tSeps, fn ($sepA, $sepB) => strrpos($value, $sepB) <=> strrpos($value, $sepA));

--- a/src/Persistence/Ui.php
+++ b/src/Persistence/Ui.php
@@ -228,13 +228,6 @@ class Ui extends Persistence
     {
         $result = [];
         foreach ($row as $key => $value) {
-            // no knowledge of the field, it wasn't defined, leave it as-is
-            if (!$model->hasField($key)) {
-                $result[$key] = $value;
-
-                continue;
-            }
-
             $result[$key] = $this->typecastSaveField($model->getField($key), $value);
         }
 

--- a/tests/PersistenceUiTest.php
+++ b/tests/PersistenceUiTest.php
@@ -58,6 +58,7 @@ class PersistenceUiTest extends TestCase
         yield [[], ['type' => 'integer'], 1, '1'];
         yield [[], ['type' => 'integer'], 0, '0'];
         yield [[], ['type' => 'integer'], -1_100_230_000_456_345_678, $fixSpaceToNbspFx('-1 100 230 000 456 345 678')];
+        yield [['thousandsSeparator' => ','], ['type' => 'integer'], 12345678, '12,345,678'];
         yield [[], ['type' => 'float'], 1.0, '1.0'];
         yield [[], ['type' => 'float'], 0.0, '0.0'];
         yield [[], ['type' => 'float'], -1_100_230_000.4567, $fixSpaceToNbspFx('-1 100 230 000.4567')];
@@ -65,6 +66,10 @@ class PersistenceUiTest extends TestCase
         yield [[], ['type' => 'float'], 1.100123E-6, '1.100123E-6'];
         yield [[], ['type' => 'float'], 1.100123E+221, '1.100123E+221'];
         yield [[], ['type' => 'float'], -1.100123E-221, '-1.100123E-221'];
+        yield [[], ['type' => 'float'], 12345678.3579, $fixSpaceToNbspFx('12 345 678.3579')];
+        yield [['decimalSeparator' => ','], ['type' => 'float'], 12345678.3579, $fixSpaceToNbspFx('12 345 678,3579')];
+        yield [['thousandsSeparator' => ','], ['type' => 'float'], 12345678.3579, '12,345,678.3579'];
+        yield [['decimalSeparator' => ',', 'thousandsSeparator' => '.'], ['type' => 'float'], 12345678.3579, '12.345.678,3579'];
         yield [[], ['type' => 'boolean'], false, 'No'];
         yield [[], ['type' => 'boolean'], true, 'Yes'];
 
@@ -120,5 +125,34 @@ class PersistenceUiTest extends TestCase
 
         yield [[], ['type' => 'boolean'], false, '0', false];
         yield [[], ['type' => 'boolean'], true, '1', false];
+
+        yield [[], ['type' => 'integer'], 0, '0.4', false];
+        yield [[], ['type' => 'integer'], 1, '1.49', false];
+        // yield [[], ['type' => 'integer'], 2, '1.5', false];
+        yield [[], ['type' => 'integer'], -1, '-1.49', false];
+        // yield [[], ['type' => 'integer'], -2, '-1.5', false];
+        yield [[], ['type' => 'integer'], -1_100_230_000_456_345_678, '-1_100_230_000_456_345_6_7_8', false];
+
+        yield [[], ['type' => 'float'], 1.0, '1', false];
+        yield [[], ['type' => 'float'], 0.0, '0', false];
+        yield [[], ['type' => 'float'], 0.3, '.3', false];
+        yield [[], ['type' => 'float'], -0.3, '-.3', false];
+        yield [[], ['type' => 'float'], 0.3, '+00.3', false];
+        yield [[], ['type' => 'float'], -0.3, '-00.300', false];
+        yield [[], ['type' => 'float'], 1234567.23456789, '1234567.23456789', false];
+        yield [[], ['type' => 'float'], 1234567.23456789, '1234_5_6_7.234 567 89', false];
+
+        yield [[], ['type' => 'atk4_money'], 2.0, '€2', false];
+        yield [[], ['type' => 'atk4_money'], 2.0, '$2', false];
+        yield [[], ['type' => 'atk4_money'], 2.0, '2€', false];
+        yield [[], ['type' => 'atk4_money'], 2.0, '2$', false];
+        yield [[], ['type' => 'atk4_money'], -1.3, '€-1.3', false];
+        yield [[], ['type' => 'atk4_money'], -1.3, '-1.3$', false];
+        yield [[], ['type' => 'atk4_money'], 0.3, '€.3', false];
+        yield [[], ['type' => 'atk4_money'], 0.3, '.3$', false];
+        yield [[], ['type' => 'atk4_money'], -0.3, '€-.3', false];
+        yield [[], ['type' => 'atk4_money'], -0.3, '-.3$', false];
+        // yield [[], ['type' => 'atk4_money'], 4.2, '4€2', false];
+        // yield [[], ['type' => 'atk4_money'], -4.2, '-4$2', false];
     }
 }

--- a/tests/PersistenceUiTest.php
+++ b/tests/PersistenceUiTest.php
@@ -48,6 +48,8 @@ class PersistenceUiTest extends TestCase
 
     public function providerTypecastBidirectional(): iterable
     {
+        $fixSpaceToNbspFx = fn (string $v) => str_replace(' ', "\u{00a0}", $v);
+
         yield [[], [], '1', '1'];
         yield [[], [], '0', '0'];
         yield [[], ['type' => 'string'], '1', '1'];
@@ -55,10 +57,10 @@ class PersistenceUiTest extends TestCase
         yield [[], ['type' => 'text'], "\n0\n\n0", "\n0\n\n0"];
         yield [[], ['type' => 'integer'], 1, '1'];
         yield [[], ['type' => 'integer'], 0, '0'];
-        yield [[], ['type' => 'integer'], -1_100_230_000_456_345_678, '-1100230000456345678'];
-        yield [[], ['type' => 'float'], 1.0, '1'];
-        yield [[], ['type' => 'float'], 0.0, '0'];
-        yield [[], ['type' => 'float'], -1_100_230_000.4567, '-1100230000.4567'];
+        yield [[], ['type' => 'integer'], -1_100_230_000_456_345_678, $fixSpaceToNbspFx('-1 100 230 000 456 345 678')];
+        yield [[], ['type' => 'float'], 1.0, '1.0'];
+        yield [[], ['type' => 'float'], 0.0, '0.0'];
+        yield [[], ['type' => 'float'], -1_100_230_000.4567, $fixSpaceToNbspFx('-1 100 230 000.4567')];
         yield [[], ['type' => 'float'], 1.100123, '1.100123'];
         yield [[], ['type' => 'float'], 1.100123E-6, '1.100123E-6'];
         yield [[], ['type' => 'float'], 1.100123E+221, '1.100123E+221'];
@@ -79,7 +81,6 @@ class PersistenceUiTest extends TestCase
             yield [['timezone' => $tz, 'datetimeFormat' => 'j.n.Y g:i:s A'], ['type' => 'datetime'], $evalDatetime, '2.1.2022 10:20:30 AM'];
         }
 
-        $fixSpaceToNbspFx = fn (string $v) => str_replace(' ', "\u{00a0}", $v);
         yield [[], ['type' => 'atk4_money'], 1.0, $fixSpaceToNbspFx('€ 1.00')];
         yield [[], ['type' => 'atk4_money'], 0.0, $fixSpaceToNbspFx('€ 0.00')];
         yield [['currency' => ''], ['type' => 'atk4_money'], 1.0, $fixSpaceToNbspFx('1.00')];
@@ -88,10 +89,10 @@ class PersistenceUiTest extends TestCase
         yield [['currencyDecimals' => 4], ['type' => 'atk4_money'], 1.102, $fixSpaceToNbspFx('€ 1.1020')];
         yield [[], ['type' => 'atk4_money'], 1_234_056_789.1, $fixSpaceToNbspFx('€ 1 234 056 789.10')];
         yield [[], ['type' => 'atk4_money'], 234_056_789.101, $fixSpaceToNbspFx('€ 234 056 789.101')];
-        yield [['currencyDecimalSeparator' => ','], ['type' => 'atk4_money'], 1.0, $fixSpaceToNbspFx('€ 1,00')];
+        yield [['decimalSeparator' => ','], ['type' => 'atk4_money'], 1.0, $fixSpaceToNbspFx('€ 1,00')];
         yield [[], ['type' => 'atk4_money'], 1000.0, $fixSpaceToNbspFx('€ 1 000.00')];
-        yield [['currencyThousandsSeparator' => ','], ['type' => 'atk4_money'], 1000.0, $fixSpaceToNbspFx('€ 1,000.00')];
-        yield [['currencyDecimalSeparator' => ',', 'currencyThousandsSeparator' => '.'], ['type' => 'atk4_money'], 1000.0, $fixSpaceToNbspFx('€ 1.000,00')];
+        yield [['thousandsSeparator' => ','], ['type' => 'atk4_money'], 1000.0, $fixSpaceToNbspFx('€ 1,000.00')];
+        yield [['decimalSeparator' => ',', 'thousandsSeparator' => '.'], ['type' => 'atk4_money'], 1000.0, $fixSpaceToNbspFx('€ 1.000,00')];
 
         foreach (['string', 'text', 'integer', 'float', 'boolean', 'date', 'time', 'datetime', 'atk4_money'] as $type) {
             yield [[], ['type' => $type], null, null];
@@ -116,5 +117,8 @@ class PersistenceUiTest extends TestCase
         yield [[], ['type' => 'text'], "\n0", "\r0", false];
         yield [[], ['type' => 'text'], "\n0", "\r\n0", false];
         yield [[], ['type' => 'text', 'nullable' => false], '', '', false];
+
+        yield [[], ['type' => 'boolean'], false, '0', false];
+        yield [[], ['type' => 'boolean'], true, '1', false];
     }
 }


### PR DESCRIPTION
extend #1763

in the future the numeric type detection should be based on registry in atk4/data where it is currently hardcoded as well