### PR TITLE
Prevent object to JSON encode in App

### DIFF
--- a/demos/form-control/multiline.php
+++ b/demos/form-control/multiline.php
@@ -60,5 +60,14 @@ $form->onSubmit(function (Form $form) use ($multiline) {
         return $multiline->saveRows()->model->export();
     });
 
-    return new JsToast($form->getApp()->encodeJson(array_values($rows)));
+    // TODO typecast using https://github.com/atk4/ui/pull/1991 once merged
+    foreach ($rows as $kRow => $row) {
+        foreach ($row as $kV => $v) {
+            if ($v instanceof \DateTime) {
+                $rows[$kRow][$kV] = $form->getApp()->uiPersistence->typecastSaveField($multiline->model->getField($kV), $row[$kV]);
+            }
+        }
+    }
+
+    return new JsToast($form->getApp()->encodeJson($rows));
 });

--- a/src/App.php
+++ b/src/App.php
@@ -975,6 +975,21 @@ class App
      */
     public function encodeJson($data, bool $forceObject = false): string
     {
+        if (is_array($data) || is_object($data)) {
+            $checkNoObjectFx = function ($v) {
+                if (is_object($v)) {
+                    throw (new Exception('Object to JSON encode is not supported'))
+                        ->addMoreInfo('value', $v);
+                }
+            };
+
+            if (is_object($data)) {
+                $checkNoObjectFx($data);
+            } else {
+                array_walk_recursive($data, $checkNoObjectFx);
+            }
+        }
+
         $options = \JSON_UNESCAPED_SLASHES | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_UNICODE | \JSON_PRETTY_PRINT;
         if ($forceObject) {
             $options |= \JSON_FORCE_OBJECT;

--- a/src/Console.php
+++ b/src/Console.php
@@ -281,8 +281,8 @@ class Console extends View implements \Psr\Log\LoggerInterface
                 throw new Exception('Unexpected stream_select() result');
             }
 
-            $stat = proc_get_status($proc);
-            if (!$stat['running']) {
+            $status = proc_get_status($proc);
+            if (!$status['running']) {
                 proc_close($proc);
 
                 break;
@@ -305,7 +305,7 @@ class Console extends View implements \Psr\Log\LoggerInterface
             }
         }
 
-        $this->lastExitCode = $stat['exitcode'];
+        $this->lastExitCode = $status['exitcode'];
 
         return $this->lastExitCode ? false : true;
     }

--- a/tests/JsTest.php
+++ b/tests/JsTest.php
@@ -14,6 +14,11 @@ use Atk4\Ui\Js\JsFunction;
 
 class JsTest extends TestCase
 {
+    protected function createAppWithoutConstructor(): App
+    {
+        return (new \ReflectionClass(App::class))->newInstanceWithoutConstructor();
+    }
+
     public function testBasicExpressions(): void
     {
         static::assertSame('2 + 2', (new JsExpression('2 + 2'))->jsRender());
@@ -56,7 +61,7 @@ class JsTest extends TestCase
 
             // test JSON renderer in App too
             // test extensively because of complex custom regex impl
-            $app = (new \ReflectionClass(App::class))->newInstanceWithoutConstructor();
+            $app = $this->createAppWithoutConstructor();
             $expectedRaw = json_decode($expected);
             foreach ([
                 [$expectedRaw, $in], // direct value
@@ -71,6 +76,24 @@ class JsTest extends TestCase
                 static::assertSame(json_encode(['x' => $inDataJson]), preg_replace('~\s+~', '', $app->encodeJson(['x' => $inDataJson])));
             }
         }
+    }
+
+    public function testJsonEncodeObjectException(): void
+    {
+        $app = $this->createAppWithoutConstructor();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Object to JSON encode is not supported');
+        $app->encodeJson(new \stdClass());
+    }
+
+    public function testJsonEncodeArrayWithObjectException(): void
+    {
+        $app = $this->createAppWithoutConstructor();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Object to JSON encode is not supported');
+        $app->encodeJson([[0, new \stdClass()]]);
     }
 
     public function testNestedExpressions(): void


### PR DESCRIPTION
`json_encode` encodes public properties of an object only, encoding an object is often a mistake so better to catch it

in the future, if needed, we can support encode of objects implementing `JsonSerializable` interface, but as `JsExpression` does not implement such interface, it was never supported by atk4/ui, thus also I do not expect any BC break from this PR