### PR TITLE
Form\Control::onChange() should not accept JS code as string

### DIFF
--- a/demos/form-control/input2.php
+++ b/demos/form-control/input2.php
@@ -153,34 +153,30 @@ $form = Form::addTo($app);
 $group = $form->addGroup('Calendar');
 $c1 = $group->addControl('c1', new Form\Control\Calendar(['type' => 'date']));
 $c2 = $group->addControl('c2', new Form\Control\Calendar(['type' => 'date']));
-$c3 = $group->addControl('c3', new Form\Control\Calendar(['type' => 'date']));
 
-$c1->onChange('console.log(\'c1 changed: \' + date + \', \' + text + \', \' + mode)');
-$c2->onChange(new JsExpression('console.log(\'c2 changed: \' + date + \', \' + text + \', \' + mode)'));
-$c3->onChange([
-    new JsExpression('console.log(\'c3 changed: \' + date + \', \' + text + \', \' + mode)'),
-    new JsExpression('console.log(\'c3 really changed: \' + date + \', \' + text + \', \' + mode)'),
+$c1->onChange(new JsExpression('console.log(\'c1 changed: \' + date + \', \' + text + \', \' + mode)'));
+$c2->onChange([
+    new JsExpression('console.log(\'c2 changed: \' + date + \', \' + text + \', \' + mode)'),
+    new JsExpression('console.log(\'c2 really changed: \' + date + \', \' + text + \', \' + mode)'),
 ]);
 
 $group = $form->addGroup('Line');
 $f1 = $group->addControl('f1');
 $f2 = $group->addControl('f2');
 $f3 = $group->addControl('f3');
-$f4 = $group->addControl('f4');
 
-$f1->onChange('console.log(\'f1 changed\')');
-$f2->onChange(new JsExpression('console.log(\'f2 changed\')'));
-$f3->onChange([
-    new JsExpression('console.log(\'f3 changed\')'),
-    new JsExpression('console.log(\'f3 really changed\')'),
+$f1->onChange(new JsExpression('console.log(\'f1 changed\')'));
+$f2->onChange([
+    new JsExpression('console.log(\'f2 changed\')'),
+    new JsExpression('console.log(\'f2 really changed\')'),
 ]);
-$f4->onChange(function () {
-    return new JsExpression('console.log(\'f4 changed\')');
+$f3->onChange(function () {
+    return new JsExpression('console.log(\'f3 changed\')');
 });
 
 $group = $form->addGroup('CheckBox');
 $b1 = $group->addControl('b1', new Form\Control\Checkbox());
-$b1->onChange('console.log(\'b1 changed\')');
+$b1->onChange(new JsExpression('console.log(\'b1 changed\')'));
 
 $group = $form->addGroup(['Dropdown', 'width' => 'three']);
 $d1 = $group->addControl('d1', new Form\Control\Dropdown([
@@ -191,7 +187,7 @@ $d1 = $group->addControl('d1', new Form\Control\Dropdown([
         'file' => ['File', 'icon' => 'file'],
     ],
 ]));
-$d1->onChange('console.log(\'Dropdown changed\')');
+$d1->onChange(new JsExpression('console.log(\'Dropdown changed\')'));
 
 $group = $form->addGroup('Radio');
 $r1 = $group->addControl('r1', new Form\Control\Radio([
@@ -202,7 +198,7 @@ $r1 = $group->addControl('r1', new Form\Control\Radio([
         'File',
     ],
 ]));
-$r1->onChange('console.log(\'radio changed\')');
+$r1->onChange(new JsExpression('console.log(\'radio changed\')'));
 
 Header::addTo($app, ['Line ends of Textarea']);
 

--- a/demos/interactive/popup.php
+++ b/demos/interactive/popup.php
@@ -142,8 +142,6 @@ $itemShelfClass = AnonymousClassNameCache::get_class(fn () => new class() extend
      * Associate your shelf with cart, so that when item is clicked, the content of a
      * cart is updated.
      *
-     * Also - you can supply jsAction to execute when this happens.
-     *
      * @param JsExpressionable|array $jsAction
      */
     public function linkCart(View $cart, $jsAction = null): void

--- a/docs/callbacks.rst
+++ b/docs/callbacks.rst
@@ -279,7 +279,7 @@ will send browser screen width back to the callback::
 
     $cb->set(function (\Atk4\Ui\Js\Jquery $j, $arg1) {
         return 'width is ' . $arg1;
-    }, [new \Atk4\Ui\Js\JsExpression( '$(window).width()' )]);
+    }, [new \Atk4\Ui\Js\JsExpression('$(window).width()')]);
 
     $label->detail = $cb->getUrl();
     $label->on('click', $cb);
@@ -292,7 +292,7 @@ also supports argument passing::
 
     $label->on('click', function (Jquery $j, $arg1) {
         return 'width is ' . $arg1;
-    }, ['confirm' => 'sure?', 'args' => [new \Atk4\Ui\Js\JsExpression( '$(window).width()' )]]);
+    }, ['confirm' => 'sure?', 'args' => [new \Atk4\Ui\Js\JsExpression('$(window).width()')]]);
 
 If you do not need to specify confirm, you can actually pass arguments in a key-less array too::
 
@@ -300,7 +300,7 @@ If you do not need to specify confirm, you can actually pass arguments in a key-
 
     $label->on('click', function (Jquery $j, $arg1) {
         return 'width is ' . $arg1;
-    }, [new \Atk4\Ui\Js\JsExpression( '$(window).width()' )]);
+    }, [new \Atk4\Ui\Js\JsExpression('$(window).width()')]);
 
 
 Refering to event origin

--- a/docs/form-control.rst
+++ b/docs/form-control.rst
@@ -296,7 +296,7 @@ onChange event
 .. php:method:: onChange($expression)
 
 It's prefferable to use this short-hand version of on('change', 'input', $expression) method.
-$expression argument can be string, JsExpression, array of JsExpressions or even PHP callback function.
+$expression argument can be JsExpression, array of JsExpressions or even PHP callback function.
 
     // simple string
     $f1 = $form->addControl('f1');

--- a/docs/rightpanel.rst
+++ b/docs/rightpanel.rst
@@ -64,4 +64,4 @@ This method may take up to three arguments.
     to the trigger element as long as the panel remains open. This help visualize, which element has trigger the
     panel opening.
 
-    $jsTrigger: a JsExpression that represent the jQuery object where the data property reside. Default to $(this).
+    $jsTrigger: JS expression that represent the jQuery object where the data property reside. Default to $(this).

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -188,9 +188,6 @@ parameters:
             path: 'src/Table/Column.php'
             message: '~^Call to an undefined method Atk4\\Ui\\AbstractView::setHoverable\(\)\.$~'
         -
-            path: 'src/Table/Column.php'
-            message: '~^Call to an undefined method Atk4\\Ui\\JsCallback::onSelectItem\(\)\.$~'
-        -
             path: 'src/Table/Column/Checkbox.php'
             message: '~^Call to an undefined method Atk4\\Ui\\Js\\JsChain::join\(\)\.$~'
         -

--- a/src/Accordion.php
+++ b/src/Accordion.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atk4\Ui;
 
 use Atk4\Ui\Js\JsChain;
+use Atk4\Ui\Js\JsExpressionable;
 
 /**
  * Accordion is a View holding accordion sections.
@@ -71,7 +72,7 @@ class Accordion extends View
      *
      * @return JsChain
      */
-    public function jsOpen($section, $when = false)
+    public function jsOpen($section, $when = false): JsExpressionable
     {
         return $this->jsBehavior('open', [$this->getSectionIdx($section)], $when);
     }
@@ -81,7 +82,7 @@ class Accordion extends View
      *
      * @return JsChain
      */
-    public function jsCloseOthers($when = false)
+    public function jsCloseOthers($when = false): JsExpressionable
     {
         return $this->jsBehavior('close others', [], $when);
     }
@@ -92,7 +93,7 @@ class Accordion extends View
      *
      * @return JsChain
      */
-    public function jsClose($section, $when = false)
+    public function jsClose($section, $when = false): JsExpressionable
     {
         return $this->jsBehavior('close', [$this->getSectionIdx($section)], $when);
     }
@@ -103,7 +104,7 @@ class Accordion extends View
      *
      * @return JsChain
      */
-    public function jsToggle($section, $when = false)
+    public function jsToggle($section, $when = false): JsExpressionable
     {
         return $this->jsBehavior('toggle', [$this->getSectionIdx($section)], $when);
     }
@@ -119,7 +120,7 @@ class Accordion extends View
      *
      * @return JsChain
      */
-    public function jsBehavior($behavior, array $args, $when = false)
+    public function jsBehavior($behavior, array $args, $when = false): JsExpressionable
     {
         return $this->js($when)->accordion($behavior, ...$args);
     }

--- a/src/App.php
+++ b/src/App.php
@@ -17,6 +17,7 @@ use Atk4\Ui\Exception\ExitApplicationError;
 use Atk4\Ui\Exception\LateOutputError;
 use Atk4\Ui\Exception\UnhandledCallbackExceptionError;
 use Atk4\Ui\Js\JsExpression;
+use Atk4\Ui\Js\JsExpressionable;
 use Atk4\Ui\Persistence\Ui as UiPersistence;
 use Atk4\Ui\UserAction\ExecutorFactory;
 use Psr\Log\LoggerInterface;
@@ -790,7 +791,7 @@ class App
      *
      * @param string|array $page Destination URL or page/arguments
      */
-    public function jsRedirect($page, bool $newWindow = false): JsExpression
+    public function jsRedirect($page, bool $newWindow = false): JsExpressionable
     {
         return new JsExpression('window.open([], [])', [$this->url($page), $newWindow ? '_blank' : '_top']);
     }

--- a/src/CardDeck.php
+++ b/src/CardDeck.php
@@ -225,7 +225,7 @@ class CardDeck extends View
     protected function jsExecute($return, Model\UserAction $action)
     {
         if (is_string($return)) {
-            return $this->getNotifier($action, $return);
+            return $this->jsCreateNotifier($action, $return);
         } elseif (is_array($return) || $return instanceof JsExpressionable) {
             return $return;
         } elseif ($return instanceof Model) {
@@ -238,13 +238,13 @@ class CardDeck extends View
             return $this->jsModelReturn($action, $msg);
         }
 
-        return $this->getNotifier($action, $this->defaultMsg);
+        return $this->jsCreateNotifier($action, $this->defaultMsg);
     }
 
     /**
      * Override this method for setting notifier based on action or model value.
      */
-    protected function getNotifier(Model\UserAction $action, string $msg = null): JsExpressionable
+    protected function jsCreateNotifier(Model\UserAction $action, string $msg = null): JsExpressionable
     {
         $notifier = Factory::factory($this->notifyDefault);
         if ($msg) {
@@ -262,7 +262,7 @@ class CardDeck extends View
     protected function jsModelReturn(Model\UserAction $action, string $msg = 'Done!'): array
     {
         $js = [];
-        $js[] = $this->getNotifier($action, $msg);
+        $js[] = $this->jsCreateNotifier($action, $msg);
         $card = $action->getEntity()->isLoaded() ? $this->findCard($action->getEntity()) : null;
         if ($card !== null) {
             $js[] = $card->jsReload($this->getReloadArgs());

--- a/src/Console.php
+++ b/src/Console.php
@@ -209,8 +209,11 @@ class Console extends View implements \Psr\Log\LoggerInterface
         }, $messageHtml);
 
         $this->_outputBypass = true;
-        $this->sse->send($this->js()->append($messageHtml));
-        $this->_outputBypass = false;
+        try {
+            $this->sse->send($this->js()->append($messageHtml));
+        } finally {
+            $this->_outputBypass = false;
+        }
 
         return $this;
     }
@@ -225,15 +228,16 @@ class Console extends View implements \Psr\Log\LoggerInterface
     /**
      * Executes a JavaScript action.
      *
-     * @param JsExpressionable $js
-     *
      * @return $this
      */
-    public function send($js)
+    public function send(JsExpressionable $js)
     {
         $this->_outputBypass = true;
-        $this->sse->send($js);
-        $this->_outputBypass = false;
+        try {
+            $this->sse->send($js);
+        } finally {
+            $this->_outputBypass = false;
+        }
 
         return $this;
     }

--- a/src/Crud.php
+++ b/src/Crud.php
@@ -175,14 +175,14 @@ class Crud extends Grid
 
         // display msg return by action or depending on action modifier.
         if (is_string($return)) {
-            $js[] = $this->getNotifier($return);
+            $js[] = $this->jsCreateNotifier($return);
         } else {
             if ($action->modifier === Model\UserAction::MODIFIER_CREATE || $action->modifier === Model\UserAction::MODIFIER_UPDATE) {
-                $js[] = $this->getNotifier($this->saveMsg);
+                $js[] = $this->jsCreateNotifier($this->saveMsg);
             } elseif ($action->modifier === Model\UserAction::MODIFIER_DELETE) {
-                $js[] = $this->getNotifier($this->deleteMsg);
+                $js[] = $this->jsCreateNotifier($this->deleteMsg);
             } else {
-                $js[] = $this->getNotifier($this->defaultMsg);
+                $js[] = $this->jsCreateNotifier($this->defaultMsg);
             }
         }
 
@@ -216,14 +216,9 @@ class Crud extends Grid
     }
 
     /**
-     * Return jsNotifier object.
      * Override this method for setting notifier based on action or model value.
-     *
-     * @param string|null $msg the message to display
-     *
-     * @return JsExpressionable
      */
-    protected function getNotifier(string $msg = null)
+    protected function jsCreateNotifier(string $msg = null): JsExpressionable
     {
         $notifier = Factory::factory($this->notifyDefault);
         if ($msg) {

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -46,7 +46,7 @@ class Dropdown extends Lister
         // setting dropdown option for using callback url.
         $this->dropdownOptions['onChange'] = new JsFunction(['value', 'name', 't'], [
             new JsExpression(
-                "if ($(this).data('currentValue') != value) { $(this).atkAjaxec({ url: [url], urlOptions: { item: value } }); $(this).data('currentValue', value); }",
+                'if ($(this).data(\'currentValue\') != value) { $(this).atkAjaxec({ url: [url], urlOptions: { item: value } }); $(this).data(\'currentValue\', value); }',
                 ['url' => $this->cb->getJsUrl()]
             ), ]);
 

--- a/src/Form.php
+++ b/src/Form.php
@@ -32,7 +32,7 @@ class Form extends View
     public $ui = 'form';
     public $defaultTemplate = 'form.html';
 
-    /** @var Callback Callback handling form submission. */
+    /** @var JsCallback Callback handling form submission. */
     public $cb;
 
     /**

--- a/src/Form.php
+++ b/src/Form.php
@@ -15,6 +15,7 @@ use Atk4\Ui\Js\Jquery;
 use Atk4\Ui\Js\JsChain;
 use Atk4\Ui\Js\JsConditionalForm;
 use Atk4\Ui\Js\JsExpression;
+use Atk4\Ui\Js\JsExpressionable;
 
 class Form extends View
 {
@@ -289,19 +290,18 @@ class Form extends View
     /**
      * Causes form to generate error.
      *
-     * @param string $fieldName Field name
-     * @param string $str       Error message
+     * @param string $errorMessage
      *
      * @return JsChain|array<int, JsChain>
      */
-    public function error($fieldName, $str)
+    public function error(string $fieldName, $errorMessage)
     {
         // by using this hook you can overwrite default behavior of this method
         if ($this->hookHasCallbacks(self::HOOK_DISPLAY_ERROR)) {
-            return $this->hook(self::HOOK_DISPLAY_ERROR, [$fieldName, $str]);
+            return $this->hook(self::HOOK_DISPLAY_ERROR, [$fieldName, $errorMessage]);
         }
 
-        $jsError = [$this->js()->form('add prompt', $fieldName, $str)];
+        $jsError = [$this->js()->form('add prompt', $fieldName, $errorMessage)];
 
         return $jsError;
     }
@@ -315,7 +315,7 @@ class Form extends View
      *
      * @return JsChain
      */
-    public function success($success = 'Success', $subHeader = null, $useTemplate = true)
+    public function success($success = 'Success', $subHeader = null, bool $useTemplate = true)
     {
         $response = null;
         // by using this hook you can overwrite default behavior of this method
@@ -391,7 +391,7 @@ class Form extends View
      *
      * @return Jquery
      */
-    public function jsInput($name)
+    public function jsInput($name): JsExpressionable
     {
         return $this->layout->getControl($name)->js()->find('input');
     }

--- a/src/Form.php
+++ b/src/Form.php
@@ -43,7 +43,7 @@ class Form extends View
      * Note:
      * When using your own change handler
      * on an input field, set useDefault parameter to false.
-     * ex: $input->onChange('console.log(), false)
+     * ex: $input->onChange(new JsExpression('console.log()), false)
      * Otherwise, change event is not propagate to all event handler
      * and leaving page might not be prevent.
      *

--- a/src/Form/Control.php
+++ b/src/Form/Control.php
@@ -166,7 +166,7 @@ class Control extends View
      *
      * @return Jquery
      */
-    public function jsInput($when = false, $action = null)
+    public function jsInput($when = false, $action = null): JsExpressionable
     {
         return $this->js($when, $action, '#' . $this->name . '_input');
     }

--- a/src/Form/Control.php
+++ b/src/Form/Control.php
@@ -132,7 +132,7 @@ class Control extends View
      * Shorthand method for on('change') event.
      * Some input fields, like Calendar, could call this differently.
      *
-     * If $expr is string or JsExpression, then it will execute it instantly.
+     * If $expr is JsExpressionable, then it will execute it instantly.
      * If $expr is callback method, then it'll make additional request to webserver.
      *
      * Could be preferable to set useDefault to false. For example when
@@ -140,19 +140,14 @@ class Control extends View
      * Otherwise, change handler will not be propagate to all handlers.
      *
      * Examples:
-     * $control->onChange('console.log(\'changed\')');
      * $control->onChange(new JsExpression('console.log(\'changed\')'));
-     * $control->onChange('$(this).parents(\'.form\').form(\'submit\')');
+     * $control->onChange(new JsExpression('$(this).parents(\'.form\').form(\'submit\')'));
      *
-     * @param string|JsExpression|array|\Closure $expr
-     * @param array|bool                         $defaults
+     * @param JsExpressionable|array|\Closure $expr
+     * @param array|bool                      $defaults
      */
     public function onChange($expr, $defaults = []): void
     {
-        if (is_string($expr)) {
-            $expr = new JsExpression($expr);
-        }
-
         if (is_bool($defaults)) {
             $defaults = $defaults ? [] : ['preventDefault' => false, 'stopPropagation' => false];
         }

--- a/src/Form/Control/Calendar.php
+++ b/src/Form/Control/Calendar.php
@@ -70,9 +70,6 @@ class Calendar extends Input
 
     public function onChange($expr, $default = []): void
     {
-        if (is_string($expr)) {
-            $expr = new JsExpression($expr);
-        }
         if (!is_array($expr)) {
             $expr = [$expr];
         }

--- a/src/Form/Control/Checkbox.php
+++ b/src/Form/Control/Checkbox.php
@@ -89,7 +89,7 @@ class Checkbox extends Form\Control
      *
      * @return Jquery
      */
-    public function jsChecked($when = false, $action = null)
+    public function jsChecked($when = false, $action = null): JsExpressionable
     {
         return $this->jsInput($when, $action)->get(0)->checked;
     }

--- a/src/Form/Control/Radio.php
+++ b/src/Form/Control/Radio.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Atk4\Ui\Form\Control;
 
 use Atk4\Ui\Form;
-use Atk4\Ui\Js\JsExpression;
 use Atk4\Ui\Lister;
 
 class Radio extends Form\Control
@@ -58,10 +57,6 @@ class Radio extends Form\Control
 
     public function onChange($expr, $defaults = []): void
     {
-        if (is_string($expr)) {
-            $expr = new JsExpression($expr);
-        }
-
         if (is_bool($defaults)) {
             $defaults = $defaults ? [] : ['preventDefault' => false, 'stopPropagation' => false];
         }

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -9,7 +9,6 @@ use Atk4\Core\HookTrait;
 use Atk4\Data\Field;
 use Atk4\Data\Model;
 use Atk4\Ui\Js\Jquery;
-use Atk4\Ui\Js\JsExpression;
 use Atk4\Ui\Js\JsExpressionable;
 use Atk4\Ui\Js\JsReload;
 use Atk4\Ui\UserAction\ConfirmationExecutor;
@@ -352,16 +351,7 @@ class Grid extends View
         $this->quickSearch->initValue = $q;
     }
 
-    /**
-     * Returns JS for reloading View.
-     *
-     * @param array             $args
-     * @param JsExpression|null $afterSuccess
-     * @param array             $apiConfig
-     *
-     * @return JsReload
-     */
-    public function jsReload($args = [], $afterSuccess = null, $apiConfig = [])
+    public function jsReload($args = [], $afterSuccess = null, $apiConfig = []): JsExpressionable
     {
         return new JsReload($this->container, $args, $afterSuccess, $apiConfig);
     }
@@ -687,7 +677,7 @@ class Grid extends View
      *
      * @return Jquery
      */
-    public function jsRow()
+    public function jsRow(): JsExpressionable
     {
         return $this->table->jsRow();
     }

--- a/src/HtmlTemplate.php
+++ b/src/HtmlTemplate.php
@@ -64,7 +64,7 @@ class HtmlTemplate
     public function getTagTree(string $tag): TagTree
     {
         if (!isset($this->tagTrees[$tag])) {
-            throw (new Exception('Tag not found in template'))
+            throw (new Exception('Tag is not defined in template'))
                 ->addMoreInfo('tag', $tag)
                 ->addMoreInfo('template_tags', array_diff(array_keys($this->tagTrees), [self::TOP_TAG]));
         }

--- a/src/ItemsPerPageSelector.php
+++ b/src/ItemsPerPageSelector.php
@@ -72,20 +72,21 @@ class ItemsPerPageSelector extends View
         foreach ($this->pageLengthItems as $key => $item) {
             $menuItems[] = ['name' => $item, 'value' => $item];
         }
-        // set Fomantic-UI dropdown onChange function.
-        $function = 'function (value, text, item) {
-            if (value === undefined || value === \'\' || value === null) return;
-            $(this)
-            .api({
-                on:\'now\',
-                url:\'' . $this->cb->getUrl() . '\',
-                data:{ipp:value}
+
+        $function = new JsExpression('function (value, text, item) {
+            if (value === undefined || value === \'\' || value === null) {
+                return;
+            }
+            $(this).api({
+                on: \'now\',
+                url: \'' . $this->cb->getUrl() . '\',
+                data: {ipp:value}
             });
-        }';
+        }');
 
         $this->js(true)->dropdown([
             'values' => $menuItems,
-            'onChange' => new JsExpression($function),
+            'onChange' => $function,
         ]);
 
         parent::renderView();

--- a/src/Js/JsExpression.php
+++ b/src/Js/JsExpression.php
@@ -42,7 +42,7 @@ class JsExpression implements JsExpressionable
                 }
 
                 if (!isset($this->args[$identifier])) {
-                    throw (new Exception('Tag not defined in template for JsExpression'))
+                    throw (new Exception('Tag is not defined in template'))
                         ->addMoreInfo('tag', $identifier)
                         ->addMoreInfo('template', $this->template);
                 }

--- a/src/Js/JsFunction.php
+++ b/src/Js/JsFunction.php
@@ -14,10 +14,10 @@ class JsFunction implements JsExpressionable
     use WarnDynamicPropertyTrait;
 
     /** @var array */
-    public $fxArgs;
+    public $args;
 
     /** @var array<int, JsExpressionable> */
-    public $fxStatements = [];
+    public $statements = [];
 
     /** @var bool add preventDefault(event) to generated method */
     public $preventDefault = false;
@@ -33,7 +33,7 @@ class JsFunction implements JsExpressionable
      */
     public function __construct(array $args, array $statements)
     {
-        $this->fxArgs = $args;
+        $this->args = $args;
 
         foreach ($statements as $key => $value) {
             if (is_int($key)) {
@@ -41,7 +41,7 @@ class JsFunction implements JsExpressionable
                     continue;
                 }
 
-                $this->fxStatements[] = $value;
+                $this->statements[] = $value;
             } else {
                 $this->{$key} = $value;
             }
@@ -52,17 +52,17 @@ class JsFunction implements JsExpressionable
     {
         $pre = '';
         if ($this->preventDefault) {
-            $this->fxArgs = ['event'];
+            $this->args = ['event'];
             $pre .= "\n" . $this->indent . '    event.preventDefault();';
         }
         if ($this->stopPropagation) {
-            $this->fxArgs = ['event'];
+            $this->args = ['event'];
             $pre .= "\n" . $this->indent . '    event.stopPropagation();';
         }
 
-        $output = 'function (' . implode(', ', $this->fxArgs) . ') {'
+        $output = 'function (' . implode(', ', $this->args) . ') {'
             . $pre;
-        foreach ($this->fxStatements as $statement) {
+        foreach ($this->statements as $statement) {
             $js = $statement->jsRender();
 
             $output .= "\n" . $this->indent . '    ' . $js . (!preg_match('~[;}]\s*$~', $js) ? ';' : '');

--- a/src/Js/JsFunction.php
+++ b/src/Js/JsFunction.php
@@ -13,20 +13,20 @@ class JsFunction implements JsExpressionable
 {
     use WarnDynamicPropertyTrait;
 
-    /** @var array */
-    public $args;
+    /** @var list<string> */
+    public array $args;
 
     /** @var array<int, JsExpressionable> */
-    public $statements = [];
+    public array $statements;
 
-    /** @var bool add preventDefault(event) to generated method */
-    public $preventDefault = false;
+    /** Add event.preventDefault() to generated method */
+    public bool $preventDefault = false;
 
-    /** @var bool add stopPropagation(event) to generated method */
-    public $stopPropagation = false;
+    /** Add event.stopPropagation() to generated method */
+    public bool $stopPropagation = false;
 
-    /** @var string Indent of target code (not one indent level) */
-    public $indent = '    ';
+    /** Indent of target code (not one indent level) */
+    public string $indent = '    ';
 
     /**
      * @param array<int, JsExpressionable|null>|array<string, mixed> $statements
@@ -35,6 +35,7 @@ class JsFunction implements JsExpressionable
     {
         $this->args = $args;
 
+        $this->statements = [];
         foreach ($statements as $key => $value) {
             if (is_int($key)) {
                 if ($value === null) { // TODO this should be not needed

--- a/src/Js/JsReload.php
+++ b/src/Js/JsReload.php
@@ -20,10 +20,7 @@ class JsReload implements JsExpressionable
     /** @var JsExpression|null A Js function to execute after reload is complete and onSuccess is execute. */
     public $afterSuccess;
 
-    /**
-     * If defined, they will be added at the end of your URL.
-     * Value in ARG can be either string or JsExpressionable.
-     */
+    /** @var array<string, string|JsExpressionable> Added at the end of your URL. */
     public array $args = [];
 
     /**

--- a/src/Js/JsReload.php
+++ b/src/Js/JsReload.php
@@ -17,7 +17,7 @@ class JsReload implements JsExpressionable
     /** Specifies which view to reload. Use constructor to set. */
     public View $view;
 
-    /** @var JsExpression|null A Js function to execute after reload is complete and onSuccess is execute. */
+    /** @var JsExpressionable|null A Js function to execute after reload is complete and onSuccess is execute. */
     public $afterSuccess;
 
     /** @var array<string, string|JsExpressionable> Added at the end of your URL. */
@@ -32,7 +32,7 @@ class JsReload implements JsExpressionable
     /** @var bool */
     public $includeStorage = false;
 
-    public function __construct(View $view, array $args = [], JsExpression $afterSuccess = null, array $apiConfig = [], bool $includeStorage = false)
+    public function __construct(View $view, array $args = [], JsExpressionable $afterSuccess = null, array $apiConfig = [], bool $includeStorage = false)
     {
         $this->view = $view;
         $this->args = $args;

--- a/src/JsCallback.php
+++ b/src/JsCallback.php
@@ -181,7 +181,7 @@ class JsCallback extends Callback
     {
         if ($response instanceof View) {
             $response = $this->_jsRenderIntoModal($response);
-        } elseif (is_string($response)) {
+        } elseif (is_string($response)) { // TODO alert() should be removed
             $response = new JsExpression('alert([])', [$response]);
         }
 

--- a/src/JsCallback.php
+++ b/src/JsCallback.php
@@ -96,6 +96,7 @@ class JsCallback extends Callback
                 $values[] = $_POST[$key] ?? null;
             }
 
+            /** @var JsExpressionable|View|string|list<JsExpressionable|View|string>|null */
             $response = $fx($chain, ...$values);
 
             if (count($chain->_chain) === 0) {
@@ -137,8 +138,8 @@ class JsCallback extends Callback
     /**
      * Provided with a $response from callbacks convert it into a JavaScript code.
      *
-     * @param array|JsExpressionable $response response from callbacks,
-     * @param JsChain                $chain
+     * @param JsExpressionable|View|string|list<JsExpressionable|View|string>|null $response response from callbacks,
+     * @param JsChain                                                              $chain
      */
     public function getAjaxec($response, $chain = null): string
     {

--- a/src/JsPaginator.php
+++ b/src/JsPaginator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atk4\Ui;
 
 use Atk4\Ui\Js\Jquery;
+use Atk4\Ui\Js\JsExpressionable;
 
 /**
  * Paginate content using scroll event in JS.
@@ -46,11 +47,11 @@ class JsPaginator extends JsCallback
     }
 
     /**
-     * Set jsPagiantor in idle mode.
+     * Set JsPaginator in idle mode.
      *
      * @return Jquery
      */
-    public function jsIdle()
+    public function jsIdle(): JsExpressionable
     {
         return $this->view->js(true)->atkScroll('idle');
     }

--- a/src/JsSortable.php
+++ b/src/JsSortable.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atk4\Ui;
 
 use Atk4\Ui\Js\JsChain;
+use Atk4\Ui\Js\JsExpressionable;
 
 class JsSortable extends JsCallback
 {
@@ -82,7 +83,7 @@ class JsSortable extends JsCallback
      *
      * @return JsChain
      */
-    public function jsSendSortOrders($urlOptions = null)
+    public function jsSendSortOrders($urlOptions = null): JsExpressionable
     {
         return $this->view->js()->atkJsSortable('sendSortOrders', [$urlOptions]);
     }

--- a/src/JsSse.php
+++ b/src/JsSse.php
@@ -58,10 +58,8 @@ class JsSse extends JsCallback
 
     /**
      * Sending an SSE action.
-     *
-     * @param JsExpressionable $action
      */
-    public function send($action, bool $success = true): void
+    public function send(JsExpressionable $action, bool $success = true): void
     {
         if ($this->browserSupport) {
             $ajaxec = $this->getAjaxec($action);

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atk4\Ui;
 
 use Atk4\Ui\Js\JsChain;
+use Atk4\Ui\Js\JsExpressionable;
 
 /**
  * Dynamically render it's content.
@@ -111,7 +112,7 @@ class Loader extends View
      *
      * @return JsChain
      */
-    public function jsLoad(array $args = [], array $apiConfig = [], $storeName = null)
+    public function jsLoad(array $args = [], array $apiConfig = [], $storeName = null): JsExpressionable
     {
         return $this->js()->atkReloadView([
             'url' => $this->cb->getUrl(),

--- a/src/Modal.php
+++ b/src/Modal.php
@@ -131,7 +131,7 @@ class Modal extends View
      *
      * @return JsChain
      */
-    public function jsShow(array $args = [])
+    public function jsShow(array $args = []): JsExpressionable
     {
         $chain = $this->js();
         if ($args !== []) {
@@ -146,7 +146,7 @@ class Modal extends View
      *
      * @return JsChain
      */
-    public function jsHide()
+    public function jsHide(): JsExpressionable
     {
         return $this->js()->modal('hide');
     }
@@ -182,11 +182,11 @@ class Modal extends View
      * Add a deny action to modal.
      *
      * @param string           $label
-     * @param JsExpressionable $jsAction javascript action that will run when deny is click
+     * @param JsExpressionable $jsAction will run when deny is click
      *
      * @return $this
      */
-    public function addDenyAction($label, $jsAction)
+    public function addDenyAction($label, JsExpressionable $jsAction)
     {
         $button = new Button();
         $button->set($label)->addClass('red cancel');
@@ -200,11 +200,11 @@ class Modal extends View
      * Add an approve action button to modal.
      *
      * @param string           $label
-     * @param JsExpressionable $jsAction javascript action that will run when deny is click
+     * @param JsExpressionable $jsAction will run when deny is click
      *
      * @return $this
      */
-    public function addApproveAction($label, $jsAction)
+    public function addApproveAction($label, JsExpressionable $jsAction)
     {
         $b = new Button();
         $b->set($label)->addClass('green ok');

--- a/src/Panel/Right.php
+++ b/src/Panel/Right.php
@@ -8,7 +8,7 @@ use Atk4\Core\Factory;
 use Atk4\Ui\Button;
 use Atk4\Ui\Js\Jquery;
 use Atk4\Ui\Js\JsChain;
-use Atk4\Ui\Js\JsExpression;
+use Atk4\Ui\Js\JsExpressionable;
 use Atk4\Ui\Modal;
 use Atk4\Ui\View;
 
@@ -95,12 +95,12 @@ class Right extends View implements Loadable
     /**
      * Return js expression need to open panel via js panelService.
      *
-     * @param array        $urlArgs       the argument to include when dynamic content panel open
-     * @param array        $dataAttribute the data attribute name to include in reload from the triggering element
-     * @param string|null  $activeCss     the css class name to apply on triggering element when panel is open
-     * @param JsExpression $jsTrigger     JsExpression that trigger panel to open. Default = $(this).
+     * @param array            $urlArgs       the argument to include when dynamic content panel open
+     * @param array            $dataAttribute the data attribute name to include in reload from the triggering element
+     * @param string|null      $activeCss     the css class name to apply on triggering element when panel is open
+     * @param JsExpressionable $jsTrigger     JS expression that trigger panel to open. Default = $(this).
      */
-    public function jsOpen(array $urlArgs = [], array $dataAttribute = [], string $activeCss = null, JsExpression $jsTrigger = null): JsExpression
+    public function jsOpen(array $urlArgs = [], array $dataAttribute = [], string $activeCss = null, JsExpressionable $jsTrigger = null): JsExpressionable
     {
         return $this->service()->openPanel([
             'triggered' => $jsTrigger ?? new Jquery(),
@@ -114,7 +114,7 @@ class Right extends View implements Loadable
     /**
      * Will reload panel passing args as Get param via js flyoutService.
      */
-    public function jsPanelReload(array $args = []): JsExpression
+    public function jsPanelReload(array $args = []): JsExpressionable
     {
         return $this->service()->reloadPanel($this->name, $args);
     }
@@ -122,7 +122,7 @@ class Right extends View implements Loadable
     /**
      * Return js expression need to close panel via js panelService.
      */
-    public function jsClose(): JsExpression
+    public function jsClose(): JsExpressionable
     {
         return $this->service()->closePanel($this->name);
     }
@@ -163,7 +163,7 @@ class Right extends View implements Loadable
      *
      * @return Jquery
      */
-    public function jsDisplayWarning(bool $state = true): JsExpression
+    public function jsDisplayWarning(bool $state = true): JsExpressionable
     {
         $chain = new Jquery('#' . $this->name . ' ' . $this->warningSelector);
 
@@ -175,7 +175,7 @@ class Right extends View implements Loadable
      *
      * @return Jquery
      */
-    public function jsToggleWarning(): JsExpression
+    public function jsToggleWarning(): JsExpressionable
     {
         return (new Jquery('#' . $this->name . ' ' . $this->warningSelector))->toggleClass($this->warningTrigger);
     }

--- a/src/Popup.php
+++ b/src/Popup.php
@@ -6,6 +6,7 @@ namespace Atk4\Ui;
 
 use Atk4\Ui\Js\Jquery;
 use Atk4\Ui\Js\JsExpression;
+use Atk4\Ui\Js\JsExpressionable;
 
 /**
  * Implement popup view.
@@ -215,7 +216,7 @@ class Popup extends View
      *
      * @return Jquery
      */
-    public function jsPopup()
+    public function jsPopup(): JsExpressionable
     {
         $selector = $this->triggerBy;
         if ($this->triggerBy instanceof Form\Control) {

--- a/src/ProgressBar.php
+++ b/src/ProgressBar.php
@@ -48,20 +48,16 @@ class ProgressBar extends View
 
     /**
      * Return js action for incrementing progress by one.
-     *
-     * @return JsExpressionable
      */
-    public function jsIncrement()
+    public function jsIncrement(): JsExpressionable
     {
         return $this->js()->progress('increment');
     }
 
     /**
      * Return js action for setting value (client-side).
-     *
-     * @return JsExpressionable
      */
-    public function jsValue(int $value)
+    public function jsValue(int $value): JsExpressionable
     {
         return $this->js()->progress(['percent' => $value]);
     }

--- a/src/Table.php
+++ b/src/Table.php
@@ -536,7 +536,7 @@ class Table extends Lister
      *
      * @return Jquery
      */
-    public function jsRow()
+    public function jsRow(): JsExpressionable
     {
         return (new Jquery())->closest('tr');
     }
@@ -549,7 +549,7 @@ class Table extends Lister
      *
      * @return Jquery
      */
-    public function jsRemoveRow($id, $transition = 'fade left')
+    public function jsRemoveRow($id, $transition = 'fade left'): JsExpressionable
     {
         return $this->js()->find('tr[data-id=' . $id . ']')->transition($transition);
     }

--- a/src/Table/Column.php
+++ b/src/Table/Column.php
@@ -147,11 +147,11 @@ class Column
      * This method return a callback where you can detect
      * menu item change via $cb->onMenuItem($item) function.
      *
-     * @param array $items
+     * @param array<int, array> $items
      *
-     * @return JsCallback
+     * @return Column\JsHeader
      */
-    public function setHeaderDropdown($items, string $icon = 'caret square down', string $menuId = null)
+    public function setHeaderDropdown($items, string $icon = 'caret square down', string $menuId = null): JsCallback
     {
         $this->hasHeaderAction = true;
         $id = $this->name . '_ac';

--- a/src/Table/Column.php
+++ b/src/Table/Column.php
@@ -164,7 +164,7 @@ class Column
 
         $cb = Column\JsHeader::addTo($this->table);
 
-        $function = 'function (value, text, item) {
+        $function = new JsExpression('function (value, text, item) {
             if (value === undefined || value === \'\' || value === null) {
                 return;
             }
@@ -173,13 +173,13 @@ class Column
                 url: \'' . $cb->getJsUrl() . '\',
                 data: { item: value, id: $(this).data(\'menu-id\') }
             });
-         }';
+        }');
 
         $chain = new Jquery('#' . $id);
         $chain->dropdown([
             'action' => 'hide',
             'values' => $items,
-            'onChange' => new JsExpression($function),
+            'onChange' => $function,
         ]);
 
         // will stop grid column from being sorted.

--- a/src/Table/Column/ActionButtons.php
+++ b/src/Table/Column/ActionButtons.php
@@ -35,8 +35,6 @@ class ActionButtons extends Table\Column
     /**
      * Adds a new button which will execute $callback when clicked.
      *
-     * Returns button object
-     *
      * @param string|array|View                  $button
      * @param JsChain|\Closure|ExecutorInterface $action
      * @param bool|\Closure                      $isDisabled

--- a/src/Table/Column/Checkbox.php
+++ b/src/Table/Column/Checkbox.php
@@ -8,6 +8,7 @@ use Atk4\Data\Field;
 use Atk4\Ui\Exception;
 use Atk4\Ui\Js\Jquery;
 use Atk4\Ui\Js\JsExpression;
+use Atk4\Ui\Js\JsExpressionable;
 use Atk4\Ui\Table;
 
 /**
@@ -22,10 +23,8 @@ class Checkbox extends Table\Column
      * Return action which will calculate and return array of all Checkbox IDs, e.g.
      *
      * [3, 5, 20]
-     *
-     * @return JsExpression
      */
-    public function jsChecked()
+    public function jsChecked(): JsExpressionable
     {
         return (new Jquery($this->table))->find('.checked.' . $this->class)->closest('tr')
             ->map(new \Atk4\Ui\Js\JsFunction([], [new JsExpression('return $(this).data(\'id\')')]))

--- a/src/UserAction/BasicExecutor.php
+++ b/src/UserAction/BasicExecutor.php
@@ -44,7 +44,7 @@ class BasicExecutor extends View implements ExecutorInterface
     /** @var array list of validated arguments */
     protected $validArguments = [];
 
-    /** @var JsExpressionable|\Closure JsExpression to return if action was successful, e.g "new JsToast('Thank you')" */
+    /** @var JsExpressionable|\Closure JS expression to return if action was successful, e.g "new JsToast('Thank you')" */
     protected $jsSuccess;
 
     public function getAction(): Model\UserAction

--- a/src/UserAction/ConfirmationExecutor.php
+++ b/src/UserAction/ConfirmationExecutor.php
@@ -35,7 +35,7 @@ class ConfirmationExecutor extends Modal implements JsExecutorInterface
     public $loaderUi = 'basic segment';
     /** @var array|View|null Loader shim object or seed. */
     public $loaderShim;
-    /** @var JsExpressionable|\Closure JsExpression to return if action was successful, e.g "new JsToast('Thank you')" */
+    /** @var JsExpressionable|\Closure JS expression to return if action was successful, e.g "new JsToast('Thank you')" */
     public $jsSuccess;
 
     /** @var string css class for modal size. */

--- a/src/UserAction/JsCallbackExecutor.php
+++ b/src/UserAction/JsCallbackExecutor.php
@@ -34,7 +34,7 @@ class JsCallbackExecutor extends JsCallback implements ExecutorInterface
     /** @var Model\UserAction The model user action */
     public $action;
 
-    /** @var JsExpressionable|\Closure JsExpression to return if action was successful, e.g "new JsToast('Thank you')" */
+    /** @var JsExpressionable|\Closure JS expression to return if action was successful, e.g "new JsToast('Thank you')" */
     public $jsSuccess;
 
     public function getAction(): Model\UserAction

--- a/src/UserAction/StepExecutorTrait.php
+++ b/src/UserAction/StepExecutorTrait.php
@@ -54,7 +54,7 @@ trait StepExecutorTrait
     /** @var bool */
     protected $actionInitialized = false;
 
-    /** @var JsExpressionable|\Closure JsExpression to return if action was successful, e.g "new JsToast('Thank you')" */
+    /** @var JsExpressionable|\Closure JS expression to return if action was successful, e.g "new JsToast('Thank you')" */
     public $jsSuccess;
 
     /** @var array A seed for creating form in order to edit arguments/fields user entry. */

--- a/src/View.php
+++ b/src/View.php
@@ -867,10 +867,8 @@ class View extends AbstractView
     /**
      * Get Local and Session web storage associated with this view.
      * Web storage can be retrieved using a $view->jsReload() request.
-     *
-     * @return mixed
      */
-    public function jsGetStoreData()
+    public function jsGetStoreData(): array
     {
         $data = [];
         $data['local'] = $this->getApp()->decodeJson($_GET[$this->name . '_local_store'] ?? $_POST[$this->name . '_local_store'] ?? 'null');
@@ -881,10 +879,8 @@ class View extends AbstractView
 
     /**
      * Clear Web storage data associated with this view.
-     *
-     * @return mixed
      */
-    public function jsClearStoreData(bool $useSession = false)
+    public function jsClearStoreData(bool $useSession = false): JsExpressionable
     {
         $type = $useSession ? 'session' : 'local';
 
@@ -906,10 +902,8 @@ class View extends AbstractView
      *  $v->jsAddStoreData(['args' => ['path' => '/'], 'fields' => ['name' => 'test']]]);
      *
      *  Final store value will be: ['args' => ['path' => '/'], 'fields' => ['name' => 'test']];
-     *
-     * @return mixed
      */
-    public function jsAddStoreData(array $data, bool $useSession = false)
+    public function jsAddStoreData(array $data, bool $useSession = false): JsExpressionable
     {
         $type = $useSession ? 'session' : 'local';
 
@@ -924,13 +918,13 @@ class View extends AbstractView
     /**
      * Returns JS for reloading View.
      *
-     * @param array             $args
-     * @param JsExpression|null $afterSuccess
-     * @param array             $apiConfig
+     * @param array                 $args
+     * @param JsExpressionable|null $afterSuccess
+     * @param array                 $apiConfig
      *
      * @return JsReload
      */
-    public function jsReload($args = [], $afterSuccess = null, $apiConfig = [])
+    public function jsReload($args = [], $afterSuccess = null, $apiConfig = []): JsExpressionable
     {
         return new JsReload($this, $args, $afterSuccess, $apiConfig);
     }

--- a/src/VueComponent/InlineEdit.php
+++ b/src/VueComponent/InlineEdit.php
@@ -7,6 +7,7 @@ namespace Atk4\Ui\VueComponent;
 use Atk4\Data\Model;
 use Atk4\Data\ValidationException;
 use Atk4\Ui\Exception;
+use Atk4\Ui\Js\JsExpressionable;
 use Atk4\Ui\Js\JsToast;
 use Atk4\Ui\JsCallback;
 use Atk4\Ui\View;
@@ -133,7 +134,7 @@ class InlineEdit extends View
      *
      * @return JsToast
      */
-    public function jsSuccess(string $message)
+    public function jsSuccess(string $message): JsExpressionable
     {
         return new JsToast([
             'title' => 'Success',
@@ -149,7 +150,7 @@ class InlineEdit extends View
      *
      * @return JsToast
      */
-    public function jsError($message)
+    public function jsError($message): JsExpressionable
     {
         return new JsToast([
             'title' => 'Validation error:',

--- a/src/Wizard.php
+++ b/src/Wizard.php
@@ -6,6 +6,7 @@ namespace Atk4\Ui;
 
 use Atk4\Core\Factory;
 use Atk4\Ui\Js\JsExpression;
+use Atk4\Ui\Js\JsExpressionable;
 
 class Wizard extends View
 {
@@ -143,7 +144,7 @@ class Wizard extends View
     }
 
     /**
-     * Get URL to next step. Will respect stickyGET.
+     * Get URL to next step. Will respect stickyGet.
      */
     public function urlNext(): string
     {
@@ -151,11 +152,9 @@ class Wizard extends View
     }
 
     /**
-     * Generate a js that will navigate to next step URL.
-     *
-     * @return JsExpression
+     * Generate JS that will navigate to next step URL.
      */
-    public function jsNext()
+    public function jsNext(): JsExpressionable
     {
         return new JsExpression('document.location = []', [$this->urlNext()]);
     }


### PR DESCRIPTION
passing JS code as string is dangerous

BC break should be minimal as used in `Form\Control::onChange()` method only