### PR TITLE
Rename Form::error/success methods to jsError/jsSuccess

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $form->addField('email');
 $form->onSubmit(function (Form $form) {
     // implement subscribe here
 
-    return $form->success('Subscribed ' . $form->model->get('email') . ' to newsletter.');
+    return $form->jsSuccess('Subscribed ' . $form->model->get('email') . ' to newsletter.');
 });
 
 // decorate anything

--- a/demos/form-control/upload.php
+++ b/demos/form-control/upload.php
@@ -32,7 +32,7 @@ $img->onDelete(function (string $fileId) use ($img) {
 
 $img->onUpload(function (array $postFile) use ($form, $img) {
     if ($postFile['error'] !== 0) {
-        return $form->error('img', 'Error uploading image.');
+        return $form->jsError('img', 'Error uploading image.');
     }
 
     $img->setThumbnailSrc($img->getApp()->cdn['atk'] . '/logo.png');
@@ -45,7 +45,7 @@ $img->onUpload(function (array $postFile) use ($form, $img) {
 
     // js Action can be return.
     // if using form, can return an error to form control directly.
-    // return $form->error('file', 'Unable to upload file.');
+    // return $form->jsError('file', 'Unable to upload file.');
 
     // can also return a notifier.
     return new JsToast([
@@ -65,7 +65,7 @@ $control->onDelete(function (string $fileId) {
 
 $control->onUpload(function (array $postFile) use ($form, $control) {
     if ($postFile['error'] !== 0) {
-        return $form->error('file', 'Error uploading file.');
+        return $form->jsError('file', 'Error uploading file.');
     }
     $control->setFileId('a_token');
 
@@ -87,5 +87,5 @@ $control->onUpload(function (array $postFile) use ($form, $control) {
 
 $form->onSubmit(function (Form $form) {
     // implement submission here
-    return $form->success('Thanks for submitting file: ' . $form->model->get('img') . ' / ' . $form->model->get('file'));
+    return $form->jsSuccess('Thanks for submitting file: ' . $form->model->get('img') . ' / ' . $form->model->get('file'));
 });

--- a/demos/form/form-section-accordion.php
+++ b/demos/form/form-section-accordion.php
@@ -66,5 +66,5 @@ $form->addControl('term', [Form\Control\Checkbox::class, 'caption' => 'Accept te
 $accordionLayout->activate($contactSection);
 
 $form->onSubmit(function (Form $form) {
-    return $form->success('Yey!', 'You did well by filling out this form');
+    return $form->jsSuccess('Yey!', 'You did well by filling out this form');
 });

--- a/demos/form/form.php
+++ b/demos/form/form.php
@@ -43,7 +43,7 @@ $form->addControl('email');
 $form->onSubmit(function (Form $form) {
     // implement subscribe here
 
-    return $form->success('Subscribed ' . $form->model->get('email') . ' to newsletter.');
+    return $form->jsSuccess('Subscribed ' . $form->model->get('email') . ' to newsletter.');
 });
 
 $form->buttonSave->set('Subscribe');
@@ -96,7 +96,7 @@ $form = Form::addTo($tab);
 $form->addControl('email1');
 $form->buttonSave->set('Save1');
 $form->onSubmit(function (Form $form) {
-    return $form->error('email1', 'some error action ' . random_int(1, 100));
+    return $form->jsError('email1', 'some error action ' . random_int(1, 100));
 });
 
 Header::addTo($tab, ['..or success message']);
@@ -104,7 +104,7 @@ $form = Form::addTo($tab);
 $form->addControl('email2');
 $form->buttonSave->set('Save2');
 $form->onSubmit(function (Form $form) {
-    return $form->success('form was successful');
+    return $form->jsSuccess('form was successful');
 });
 
 Header::addTo($tab, ['Any other view can be output']);
@@ -202,7 +202,7 @@ $form->setModel($modelRegister);
 
 $form->onSubmit(function (Form $form) {
     if ($form->model->get('name') !== 'John') {
-        return $form->error('name', 'Your name is not John! It is "' . $form->model->get('name') . '". It should be John. Pleeease!');
+        return $form->jsError('name', 'Your name is not John! It is "' . $form->model->get('name') . '". It should be John. Pleeease!');
     }
 
     return [
@@ -246,9 +246,9 @@ $form->onSubmit(function (Form $form) {
         }
 
         if ($form->model->get($name) !== 'a') {
-            $errors[] = $form->error($name, 'Field ' . $name . ' should contain exactly "a", but contains ' . $form->model->get($name));
+            $errors[] = $form->jsError($name, 'Field ' . $name . ' should contain exactly "a", but contains ' . $form->model->get($name));
         }
     }
 
-    return $errors !== [] ? $errors : $form->success('No more errors', 'so we have saved everything into the database');
+    return $errors !== [] ? $errors : $form->jsSuccess('No more errors', 'so we have saved everything into the database');
 });

--- a/demos/form/form2.php
+++ b/demos/form/form2.php
@@ -64,15 +64,15 @@ $form->onSubmit(function (Form $form) {
     // In-form validation
     $errors = [];
     if (mb_strlen($form->model->get('first_name')) < 3) {
-        $errors[] = $form->error('first_name', 'too short, ' . $form->model->get('first_name'));
+        $errors[] = $form->jsError('first_name', 'too short, ' . $form->model->get('first_name'));
     }
     if (mb_strlen($form->model->get('last_name')) < 5) {
-        $errors[] = $form->error('last_name', 'too short');
+        $errors[] = $form->jsError('last_name', 'too short');
     }
 
     // Model validation. We do it manually because we are not using Model::save() method in demo mode.
     foreach ($countryEntity->validate('save') as $k => $error) {
-        $errors[] = $form->error($k, $error);
+        $errors[] = $form->jsError($k, $error);
     }
 
     if ($errors) {

--- a/demos/form/form3.php
+++ b/demos/form/form3.php
@@ -39,7 +39,7 @@ $form->onSubmit(function (Form $form) {
     foreach ($modelDirty as $field => $value) {
         // we should care only about editable fields
         if ($form->model->getField($field)->isEditable()) {
-            $errors[] = $form->error($field, 'Value was changed, ' . $form->getApp()->encodeJson($value) . ' to ' . $form->getApp()->encodeJson($form->model->get($field)));
+            $errors[] = $form->jsError($field, 'Value was changed, ' . $form->getApp()->encodeJson($value) . ' to ' . $form->getApp()->encodeJson($form->model->get($field)));
         }
     }
 

--- a/demos/interactive/accordion-nested.php
+++ b/demos/interactive/accordion-nested.php
@@ -41,7 +41,7 @@ $addAccordionFunc = function ($view, int $maxDepth, int $level = 0) use (&$addAc
         $form = Form::addTo($vp);
         $form->addControl('email');
         $form->onSubmit(function (Form $form) {
-            return $form->success('Subscribed ' . $form->model->get('email') . ' to newsletter.');
+            return $form->jsSuccess('Subscribed ' . $form->model->get('email') . ' to newsletter.');
         });
 
         $addAccordionFunc($vp, $maxDepth, $level + 1);

--- a/demos/interactive/accordion.php
+++ b/demos/interactive/accordion.php
@@ -49,7 +49,7 @@ $i3 = $accordion->addSection('Dynamic Form', function (VirtualPage $vp) {
     $form = Form::addTo($vp);
     $form->addControl('Email');
     $form->onSubmit(function (Form $form) {
-        return $form->success('Subscribed ' . $form->model->get('Email') . ' to newsletter.');
+        return $form->jsSuccess('Subscribed ' . $form->model->get('Email') . ' to newsletter.');
     });
 });
 

--- a/demos/interactive/modal.php
+++ b/demos/interactive/modal.php
@@ -200,14 +200,14 @@ $stepModal->set(function (View $p) use ($session, $prevAction, $nextAction) {
 
         $form->onSubmit(function (Form $form) use ($nextAction, $session) {
             if ($form->model->get('name') !== 'John') {
-                return $form->error('name', 'Your name is not John! It is "' . $form->model->get('name') . '". It should be John. Pleeease!');
+                return $form->jsError('name', 'Your name is not John! It is "' . $form->model->get('name') . '". It should be John. Pleeease!');
             }
 
             $session->memorize('success', true);
             $session->memorize('name', $form->model->get('name'));
 
             $js = [];
-            $js[] = $form->success('Thank you, ' . $form->model->get('name') . ' you can go on!');
+            $js[] = $form->jsSuccess('Thank you, ' . $form->model->get('name') . ' you can go on!');
             $js[] = $nextAction->js()->removeClass('disabled');
 
             return $js;

--- a/demos/interactive/popup.php
+++ b/demos/interactive/popup.php
@@ -258,7 +258,7 @@ $signup->set(function (View $pop) {
         // perfectly inside a popup.
         $form->onSubmit(function (Form $form) {
             if ($form->model->get('password') !== '123') {
-                return $form->error('password', 'Please use password "123"');
+                return $form->jsError('password', 'Please use password "123"');
             }
 
             // refreshes entire page

--- a/demos/interactive/tabs.php
+++ b/demos/interactive/tabs.php
@@ -56,7 +56,7 @@ $tabs->addTab('Dynamic Form', function (VirtualPage $vp) {
     $form->setModel($modelRegister->createEntity());
     $form->onSubmit(function (Form $form) {
         if ($form->model->get('name') !== 'John') {
-            return $form->error('name', 'Your name is not John! It is "' . $form->model->get('name') . '". It should be John. Pleeease!');
+            return $form->jsError('name', 'Your name is not John! It is "' . $form->model->get('name') . '". It should be John. Pleeease!');
         }
     });
 });

--- a/demos/layout/layouts_admin.php
+++ b/demos/layout/layouts_admin.php
@@ -57,9 +57,9 @@ $form->onSubmit(function (Form $form) {
     $errors = [];
     foreach (['first_name', 'last_name', 'address'] as $field) {
         if (!$form->model->get($field)) {
-            $errors[] = $form->error($field, 'Field ' . $field . ' is mandatory');
+            $errors[] = $form->jsError($field, 'Field ' . $field . ' is mandatory');
         }
     }
 
-    return $errors !== [] ? $errors : $form->success('No more errors', 'so we have saved everything into the database');
+    return $errors !== [] ? $errors : $form->jsSuccess('No more errors', 'so we have saved everything into the database');
 });

--- a/docs/fileupload.rst
+++ b/docs/fileupload.rst
@@ -77,7 +77,7 @@ Example showing the onUpload callback on the UploadImage field::
 
     $img->onUpload(function (array $postFile) use ($form, $img) {
         if ($postFile['error'] !== 0) {
-            return $form->error('img', 'Error uploading image.');
+            return $form->jsError('img', 'Error uploading image.');
         }
 
         // Do file processing here...
@@ -97,7 +97,7 @@ The fileId is set to file name by default if omitted::
 
     $form->onSubmit(function (Form $form) {
         // implement submission here
-        return $form->success('Thanks for submitting file: ' . $form->model->get('img'));
+        return $form->jsSuccess('Thanks for submitting file: ' . $form->model->get('img'));
     });
 
 onDelete

--- a/docs/form.rst
+++ b/docs/form.rst
@@ -297,16 +297,16 @@ example displays a registration form for a User::
     // submit event
     $form->onSubmit(function (Form $form) {
         if ($form->model->get('password') != $form->model->get('password_verify')) {
-            return $form->error('password_verify', 'Passwords do not match');
+            return $form->jsError('password_verify', 'Passwords do not match');
         }
 
         if (!$form->model->get('accept_terms')) {
-            return $form->error('accept_terms', 'Read and accept terms');
+            return $form->jsError('accept_terms', 'Read and accept terms');
         }
 
         $form->model->save(); // will only store email / password
 
-        return $form->success('Thank you. Check your email now');
+        return $form->jsSuccess('Thank you. Check your email now');
     });
 
 Field Type vs Form Control
@@ -471,7 +471,7 @@ As far as form is concerned:
 - Form submit handler will rely on ``Model::save()`` (https://agile-data.readthedocs.io/en/develop/persistence.html#Model::save)
   not to throw validation exception.
 
-- Form submit handler will also interpret use of :php:meth:`Form::error` by displaying errors that
+- Form submit handler will also interpret use of :php:meth:`Form::jsError` by displaying errors that
   do not originate inside Model save logic.
 
 Example use of Model's validate() method::
@@ -518,11 +518,11 @@ Form Submit Handling
 
     Specify a PHP call-back that will be executed on successful form submission.
 
-.. php:method:: error($field, $message)
+.. php:method:: jsError($field, $message)
 
     Create and return :php:class:`JsChain` action that will indicate error on a form control.
 
-.. php:method:: success($title, [$sub_title])
+.. php:method:: jsSuccess($title, [$sub_title])
 
     Create and return :php:class:`JsChain` action, that will replace form with a success message.
 
@@ -545,16 +545,16 @@ that would perform the check can be defined displaying error or success messages
 
     $form->onSubmit(function (Form $form) {
         if (!$form->model->get('terms')) {
-            return $form->error('terms', 'You must accept terms and conditions');
+            return $form->jsError('terms', 'You must accept terms and conditions');
         }
 
         $form->model->save();
 
-        return $form->success('Registration Successful', 'We will call you soon.');
+        return $form->jsSuccess('Registration Successful', 'We will call you soon.');
     });
 
 Callback function can return one or multiple JavaScript actions. Methods such as
-:php:meth:`error()` or :php:meth:`success()` will help initialize those actions for your form.
+:php:meth:`jsError()` or :php:meth:`jsSuccess()` will help initialize those actions for your form.
 Here is a code that can be used to output multiple errors at once. Errors were intentionally not grouped
 with a message about failure to accept of terms and conditions::
 
@@ -562,11 +562,11 @@ with a message about failure to accept of terms and conditions::
         $errors = [];
 
         if (!$form->model->get('name')) {
-            $errors[] = $form->error('name', 'Name must be specified');
+            $errors[] = $form->jsError('name', 'Name must be specified');
         }
 
         if (!$form->model->get('surname')) {
-            $errors[] = $form->error('surname', 'Surname must be specified');
+            $errors[] = $form->jsError('surname', 'Surname must be specified');
         }
 
         if ($errors) {
@@ -574,12 +574,12 @@ with a message about failure to accept of terms and conditions::
         }
 
         if (!$form->model->get('terms')) {
-            return $form->error('terms', 'You must accept terms and conditions');
+            return $form->jsError('terms', 'You must accept terms and conditions');
         }
 
         $form->model->save();
 
-        return $form->success('Registration Successful', 'We will call you soon.');
+        return $form->jsSuccess('Registration Successful', 'We will call you soon.');
     });
 
 So far Agile UI / Agile Data does not come with a validation library but

--- a/docs/js.rst
+++ b/docs/js.rst
@@ -526,7 +526,7 @@ The following will **not** work::
 
         return [
             $table->jsReload(),
-            $form->success('ok'),
+            $form->jsSuccess('ok'),
         ];
     });
 
@@ -551,7 +551,7 @@ Table needs to be first! The following works::
 
         return [
             $table->jsReload(),
-            $form->success('ok'),
+            $form->jsSuccess('ok'),
         ];
     });
 
@@ -572,7 +572,7 @@ VirtualPage content is rendered. To force yourself to put things in order you ca
 
             return [
                 $table->jsReload(),
-                $form->success('ok'),
+                $form->jsSuccess('ok'),
             ];
         });
     });

--- a/docs/tabs.rst
+++ b/docs/tabs.rst
@@ -70,7 +70,7 @@ Note that tab contents are refreshed including any values you put on the form::
         $form->setModel($m_register);
         $form->onSubmit(function (Form $form) {
             if ($form->model->get('name') !== 'John') {
-                return $form->error('name', 'Your name is not John! It is "' . $form->model->get('name') . '". It should be John. Pleeease!');
+                return $form->jsError('name', 'Your name is not John! It is "' . $form->model->get('name') . '". It should be John. Pleeease!');
             }
         });
     });

--- a/src/Form.php
+++ b/src/Form.php
@@ -81,7 +81,7 @@ class Form extends View
 
     /**
      * When form is submitted successfully, this template is used by method
-     * success() to replace form contents.
+     * jsSuccess() to replace form contents.
      *
      * WARNING: may be removed in the future as we refactor into using Message class
      *          and remove the form-success.html template then.
@@ -265,7 +265,7 @@ class Form extends View
                         throw $e;
                     }
 
-                    $response->addStatement($this->error($field, $error));
+                    $response->addStatement($this->jsError($field, $error));
                 }
 
                 return $response;
@@ -290,7 +290,7 @@ class Form extends View
      *
      * @param string $errorMessage
      */
-    public function error(string $fieldName, $errorMessage): JsExpressionable
+    public function jsError(string $fieldName, $errorMessage): JsExpressionable
     {
         // by using this hook you can overwrite default behavior of this method
         if ($this->hookHasCallbacks(self::HOOK_DISPLAY_ERROR)) {
@@ -307,7 +307,7 @@ class Form extends View
      * @param string      $subHeader   Sub-header
      * @param bool        $useTemplate Backward compatibility
      */
-    public function success($success = 'Success', $subHeader = null, bool $useTemplate = true): JsExpressionable
+    public function jsSuccess($success = 'Success', $subHeader = null, bool $useTemplate = true): JsExpressionable
     {
         $response = null;
         // by using this hook you can overwrite default behavior of this method


### PR DESCRIPTION
to improve naming consistency, all method returning JS should be named like `jsXxx`