### PR TITLE
Card with entity UA must not reload data again

### DIFF
--- a/demos/_includes/DemoActionsUtil.php
+++ b/demos/_includes/DemoActionsUtil.php
@@ -13,23 +13,7 @@ class DemoActionsUtil
 {
     public static function setupDemoActions(Country $country): void
     {
-        // standard UserAction class without dirty fields check
-        // needed for card.feature Behat test and data-action/factory-view.php demo
-        $modelUserActionWithoutDirtyCheckClass = AnonymousClassNameCache::get_class(fn () => new class() extends UserAction {
-            protected function validateBeforeExecute(): void
-            {
-                $fieldOrig = $this->fields;
-                $this->fields = false;
-                try {
-                    parent::validateBeforeExecute();
-                } finally {
-                    $this->fields = $fieldOrig;
-                }
-            }
-        });
-
         $country->addUserAction('callback', [
-            $modelUserActionWithoutDirtyCheckClass,
             'description' => 'Callback',
             'callback' => function (Country $model) {
                 return 'callback execute using country ' . $model->getTitle();
@@ -37,7 +21,6 @@ class DemoActionsUtil
         ]);
 
         $country->addUserAction('preview', [
-            $modelUserActionWithoutDirtyCheckClass,
             'description' => 'Display Preview prior to run the action',
             'preview' => function (Country $model) {
                 return 'Previewing country ' . $model->getTitle();
@@ -48,7 +31,6 @@ class DemoActionsUtil
         ]);
 
         $country->addUserAction('disabled_action', [
-            $modelUserActionWithoutDirtyCheckClass,
             'description' => 'This action is disabled.',
             'caption' => 'Disabled',
             'enabled' => false,
@@ -58,7 +40,6 @@ class DemoActionsUtil
         ]);
 
         $country->addUserAction('edit_argument', [
-            $modelUserActionWithoutDirtyCheckClass,
             'caption' => 'Argument',
             'description' => 'Ask for argument "Age" prior to execute the action.',
             'args' => [
@@ -76,7 +57,6 @@ class DemoActionsUtil
         ]);
 
         $country->addUserAction('edit_argument_prev', [
-            $modelUserActionWithoutDirtyCheckClass,
             'caption' => 'Argument/Preview',
             'description' => 'Ask for argument "Age" and display preview prior to execute',
             'args' => [
@@ -91,7 +71,6 @@ class DemoActionsUtil
         ]);
 
         $country->addUserAction('edit_iso', [
-            $modelUserActionWithoutDirtyCheckClass,
             'caption' => 'Edit ISO3',
             'description' => function (UserAction $action) {
                 return 'Edit ISO3 for country: ' /* TODO . $action->getEntity()->getTitle() */;
@@ -103,7 +82,6 @@ class DemoActionsUtil
         ]);
 
         $country->addUserAction('Ouch', [
-            $modelUserActionWithoutDirtyCheckClass,
             'caption' => 'Exception',
             'description' => 'Throw an exception when executing an action',
             'args' => [
@@ -118,7 +96,6 @@ class DemoActionsUtil
         ]);
 
         $country->addUserAction('confirm', [
-            $modelUserActionWithoutDirtyCheckClass,
             'caption' => 'User Confirmation',
             'description' => 'Confirm the action using a ConfirmationExecutor',
             'confirmation' => function (UserAction $a) {
@@ -132,7 +109,6 @@ class DemoActionsUtil
         ]);
 
         $country->addUserAction('multi_step', [
-            $modelUserActionWithoutDirtyCheckClass,
             'caption' => 'Multi Step',
             'description' => 'Ask for Arguments and field and display preview prior to run the action',
             'args' => [

--- a/demos/_includes/DemoActionsUtil.php
+++ b/demos/_includes/DemoActionsUtil.php
@@ -13,7 +13,23 @@ class DemoActionsUtil
 {
     public static function setupDemoActions(Country $country): void
     {
+        // standard UserAction class without dirty fields check
+        // needed for card.feature Behat test and data-action/factory-view.php demo
+        $modelUserActionWithoutDirtyCheckClass = AnonymousClassNameCache::get_class(fn () => new class() extends UserAction {
+            protected function validateBeforeExecute(): void
+            {
+                $fieldOrig = $this->fields;
+                $this->fields = false;
+                try {
+                    parent::validateBeforeExecute();
+                } finally {
+                    $this->fields = $fieldOrig;
+                }
+            }
+        });
+
         $country->addUserAction('callback', [
+            $modelUserActionWithoutDirtyCheckClass,
             'description' => 'Callback',
             'callback' => function (Country $model) {
                 return 'callback execute using country ' . $model->getTitle();
@@ -21,6 +37,7 @@ class DemoActionsUtil
         ]);
 
         $country->addUserAction('preview', [
+            $modelUserActionWithoutDirtyCheckClass,
             'description' => 'Display Preview prior to run the action',
             'preview' => function (Country $model) {
                 return 'Previewing country ' . $model->getTitle();
@@ -31,6 +48,7 @@ class DemoActionsUtil
         ]);
 
         $country->addUserAction('disabled_action', [
+            $modelUserActionWithoutDirtyCheckClass,
             'description' => 'This action is disabled.',
             'caption' => 'Disabled',
             'enabled' => false,
@@ -40,6 +58,7 @@ class DemoActionsUtil
         ]);
 
         $country->addUserAction('edit_argument', [
+            $modelUserActionWithoutDirtyCheckClass,
             'caption' => 'Argument',
             'description' => 'Ask for argument "Age" prior to execute the action.',
             'args' => [
@@ -57,6 +76,7 @@ class DemoActionsUtil
         ]);
 
         $country->addUserAction('edit_argument_prev', [
+            $modelUserActionWithoutDirtyCheckClass,
             'caption' => 'Argument/Preview',
             'description' => 'Ask for argument "Age" and display preview prior to execute',
             'args' => [
@@ -71,6 +91,7 @@ class DemoActionsUtil
         ]);
 
         $country->addUserAction('edit_iso', [
+            $modelUserActionWithoutDirtyCheckClass,
             'caption' => 'Edit ISO3',
             'description' => function (UserAction $action) {
                 return 'Edit ISO3 for country: ' /* TODO . $action->getEntity()->getTitle() */;
@@ -82,6 +103,7 @@ class DemoActionsUtil
         ]);
 
         $country->addUserAction('Ouch', [
+            $modelUserActionWithoutDirtyCheckClass,
             'caption' => 'Exception',
             'description' => 'Throw an exception when executing an action',
             'args' => [
@@ -96,6 +118,7 @@ class DemoActionsUtil
         ]);
 
         $country->addUserAction('confirm', [
+            $modelUserActionWithoutDirtyCheckClass,
             'caption' => 'User Confirmation',
             'description' => 'Confirm the action using a ConfirmationExecutor',
             'confirmation' => function (UserAction $a) {
@@ -109,6 +132,7 @@ class DemoActionsUtil
         ]);
 
         $country->addUserAction('multi_step', [
+            $modelUserActionWithoutDirtyCheckClass,
             'caption' => 'Multi Step',
             'description' => 'Ask for Arguments and field and display preview prior to run the action',
             'args' => [

--- a/demos/data-action/factory-view.php
+++ b/demos/data-action/factory-view.php
@@ -56,6 +56,9 @@ $country = new Country($app->db);
 DemoActionsUtil::setupDemoActions($country);
 $country = $country->loadBy($country->fieldName()->iso, 'fr');
 $country->name .= ' NO RELOAD';
+// suppress dirty field exception
+// https://github.com/atk4/data/blob/35dd7b7d95909cfe574b15e32b7cc57c39a16a58/src/Model/UserAction.php#L164
+unset($country->getDirtyRef()[$country->fieldName()->name]);
 
 $cardActions = Card::addTo($app, ['useLabel' => true, 'executorFactory' => new $myFactory()]);
 $cardActions->setModel($country);

--- a/demos/data-action/factory-view.php
+++ b/demos/data-action/factory-view.php
@@ -62,7 +62,6 @@ $cardActions->setModel($country);
 foreach ($country->getModel()->getUserActions() as $action) {
     $showActions = ['callback', 'preview', 'edit_argument', 'edit_argument_prev', 'edit_iso', 'confirm', 'multi_step'];
     if (in_array($action->shortName, $showActions, true)) {
-        $action->fields = false; // disable dirty check for Behat
         $cardActions->addClickAction($action);
     }
 }

--- a/demos/data-action/factory-view.php
+++ b/demos/data-action/factory-view.php
@@ -62,6 +62,7 @@ $cardActions->setModel($country);
 foreach ($country->getModel()->getUserActions() as $action) {
     $showActions = ['callback', 'preview', 'edit_argument', 'edit_argument_prev', 'edit_iso', 'confirm', 'multi_step'];
     if (in_array($action->shortName, $showActions, true)) {
+        $action->fields = false; // disable dirty check for Behat
         $cardActions->addClickAction($action);
     }
 }

--- a/src/Card.php
+++ b/src/Card.php
@@ -216,11 +216,16 @@ class Card extends View
     {
         $btn = $this->addButton($button ?? $this->getExecutorFactory()->createTrigger($action, ExecutorFactory::CARD_BUTTON));
 
+        $cardDeck = $this->getClosestOwner(CardDeck::class);
+
         $defaults = [];
 
         // Setting arg for model id. $args[0] is consider to hold a model id, i.e. as a js expression.
         if ($this->model && $this->model->isLoaded() && !isset($args[0])) {
             $defaults[] = $this->model->getId();
+            if ($cardDeck === null && !$action->isOwnerEntity()) {
+                $action = $action->getActionForEntity($this->model);
+            }
         }
 
         if ($args !== []) {
@@ -231,7 +236,6 @@ class Card extends View
             $defaults['confirm'] = $confirm;
         }
 
-        $cardDeck = $this->getClosestOwner(CardDeck::class);
         if ($cardDeck !== null) {
             // mimic https://github.com/atk4/ui/blob/3c592b8f10fe67c61f179c5c8723b07f8ab754b9/src/Crud.php#L140
             // based on https://github.com/atk4/ui/blob/3c592b8f10fe67c61f179c5c8723b07f8ab754b9/src/UserAction/SharedExecutorsContainer.php#L24

--- a/tests-behat/card.feature
+++ b/tests-behat/card.feature
@@ -4,8 +4,7 @@ Feature: Card
     Given I am on "data-action/factory-view.php"
     Then I click using selector "i.eye.icon"
     Then Modal is open with text "Display Preview prior to run the action"
-    # TODO fix
-    # Then Modal is open with text "Previewing country France NO RELOAD"
+    Then Modal is open with text "Previewing country France NO RELOAD"
     Then I press Modal button "Preview"
     Then Toast display should contain text "Success: Done previewing France"
 


### PR DESCRIPTION
entity represents loaded record, so when passed, the entity data should be used instead loading the entity by its ID again