### PR TITLE
Fix card section null description

### DIFF
--- a/src/CardSection.php
+++ b/src/CardSection.php
@@ -76,7 +76,9 @@ class CardSection extends View
                 $value = $label . $this->glue . $value;
             }
 
-            if ($value) { $this->addDescription($value); }
+            if ($value) {
+                $this->addDescription($value);
+            }
         }
     }
 

--- a/src/CardSection.php
+++ b/src/CardSection.php
@@ -76,7 +76,7 @@ class CardSection extends View
                 $value = $label . $this->glue . $value;
             }
 
-            $this->addDescription($value);
+            if ($value) { $this->addDescription($value); }
         }
     }
 


### PR DESCRIPTION
If $value is null, a seed type error is thrown on null, as seed is not interpreted as empty string.