### PR TITLE
Fix UploadImage::clearThumbnail default image reset

### DIFF
--- a/demos/form-control/upload.php
+++ b/demos/form-control/upload.php
@@ -21,7 +21,7 @@ $control = $form->addControl('file', [Form\Control\Upload::class, ['accept' => [
 // $control->set('a_generated_token');
 
 $img->onDelete(function (string $fileId) use ($img) {
-    $img->clearThumbnail('./images/default.png');
+    $img->clearThumbnail();
 
     return new JsToast([
         'title' => 'Delete successfully',

--- a/docs/fileupload.rst
+++ b/docs/fileupload.rst
@@ -140,7 +140,7 @@ UploadImage form control inherits all of the Upload properties plus these ones:
 
 The thumbnail view associated with the form control.
 
-.. php:attr:: thumnailRegion
+.. php:attr:: thumbnailRegion
 
 The region in input template where to add the thumbnail view, default to AfterAfterInput region.
 

--- a/src/Behat/Context.php
+++ b/src/Behat/Context.php
@@ -561,18 +561,6 @@ class Context extends RawMinkContext implements BehatContext
             EOF, [$element, array_map('ord', str_split($fileContent)), $fileName]);
     }
 
-    /**
-     * @Then Element :arg1 attribute :arg2 should contain text :arg3
-     */
-    public function elementAttributeShouldContainText(string $selector, string $attribute, string $text): void
-    {
-        $element = $this->findElement(null, $selector);
-        $attr = $element->getAttribute($attribute);
-        if (!str_contains($attr, $text)) {
-            throw new \Exception('Element " . $selector . " attribute "' . $attribute . '" does not contain "' . $text . '"');
-        }
-    }
-
     private function getScopeBuilderRuleElem(string $ruleName): NodeElement
     {
         return $this->findElement(null, '.vqb-rule[data-name=' . $ruleName . ']');
@@ -818,6 +806,18 @@ class Context extends RawMinkContext implements BehatContext
 
         if (!preg_match($regex, $this->findElement(null, $selector)->getText())) {
             throw new \Exception('Container with selector: ' . $selector . ' does not match regex: ' . $regex);
+        }
+    }
+
+    /**
+     * @Then Element :arg1 attribute :arg2 should contain text :arg3
+     */
+    public function elementAttributeShouldContainText(string $selector, string $attribute, string $text): void
+    {
+        $element = $this->findElement(null, $selector);
+        $attr = $element->getAttribute($attribute);
+        if (!str_contains($attr, $text)) {
+            throw new \Exception('Element " . $selector . " attribute "' . $attribute . '" does not contain "' . $text . '"');
         }
     }
 

--- a/src/Behat/Context.php
+++ b/src/Behat/Context.php
@@ -561,6 +561,18 @@ class Context extends RawMinkContext implements BehatContext
             EOF, [$element, array_map('ord', str_split($fileContent)), $fileName]);
     }
 
+    /**
+     * @Then Element :arg1 attribute :arg2 should contain text :arg3
+     */
+    public function elementAttributeShouldContainText(string $selector, string $attribute, string $text): void
+    {
+        $element = $this->findElement(null, $selector);
+        $attr = $element->getAttr($attribute);
+        if (!str_contains($attr, $text)) {
+            throw new \Exception('Element " . $selector . " attribute "' . $attribute . '" does not contain "' . $text . '"');
+        }
+    }
+
     private function getScopeBuilderRuleElem(string $ruleName): NodeElement
     {
         return $this->findElement(null, '.vqb-rule[data-name=' . $ruleName . ']');

--- a/src/Behat/Context.php
+++ b/src/Behat/Context.php
@@ -567,7 +567,7 @@ class Context extends RawMinkContext implements BehatContext
     public function elementAttributeShouldContainText(string $selector, string $attribute, string $text): void
     {
         $element = $this->findElement(null, $selector);
-        $attr = $element->getAttr($attribute);
+        $attr = $element->getAttribute($attribute);
         if (!str_contains($attr, $text)) {
             throw new \Exception('Element " . $selector . " attribute "' . $attribute . '" does not contain "' . $text . '"');
         }

--- a/src/Form/Control/UploadImage.php
+++ b/src/Form/Control/UploadImage.php
@@ -17,7 +17,7 @@ class UploadImage extends Upload
      *
      * @var string
      */
-    public $thumnailRegion = 'AfterAfterInput';
+    public $thumbnailRegion = 'AfterAfterInput';
 
     /** @var string|null The default thumbnail source. */
     public $defaultSrc;
@@ -30,16 +30,23 @@ class UploadImage extends Upload
             $this->accept = ['.jpg', '.jpeg', '.png'];
         }
 
-        if (!$this->thumbnail) {
-            $this->thumbnail = (new View(['element' => 'img', 'class' => ['right', 'floated', 'image'], 'ui' => true]))
-                ->setAttr(['width' => 36, 'height' => 36]);
+        $this->add($this->getThumbnail(), $this->thumnailRegion);
+    }
+
+    public function getThumbnail(): View
+    {
+        if ($this->thumbnail) {
+            return $this->thumbnail;
         }
+
+        $this->thumbnail = (new View(['element' => 'img', 'class' => ['right', 'floated', 'image'], 'ui' => true]))
+            ->setAttr(['width' => 36, 'height' => 36]);
 
         if ($this->defaultSrc) {
             $this->thumbnail->setAttr(['src' => $this->defaultSrc]);
         }
 
-        $this->add($this->thumbnail, $this->thumnailRegion);
+        return $this->thumbnail;
     }
 
     /**

--- a/src/Form/Control/UploadImage.php
+++ b/src/Form/Control/UploadImage.php
@@ -30,7 +30,7 @@ class UploadImage extends Upload
             $this->accept = ['.jpg', '.jpeg', '.png'];
         }
 
-        $this->add($this->getThumbnail(), $this->thumnailRegion);
+        $this->add($this->getThumbnail(), $this->thumbnailRegion);
     }
 
     public function getThumbnail(): View

--- a/src/Form/Control/UploadImage.php
+++ b/src/Form/Control/UploadImage.php
@@ -59,7 +59,9 @@ class UploadImage extends Upload
      */
     public function clearThumbnail(string $defaultThumbnail = null): void
     {
-        $defaultThumbnail ??= $this->defaultSrc;
+        if ($defaultThumbnail === null) {
+            $defaultThumbnail = $this->defaultSrc;
+        }
 
         $action = $this->thumbnail->js();
         if ($defaultThumbnail !== null) {

--- a/src/Form/Control/UploadImage.php
+++ b/src/Form/Control/UploadImage.php
@@ -59,7 +59,7 @@ class UploadImage extends Upload
      */
     public function clearThumbnail(string $defaultThumbnail = null): void
     {
-        $defaultThumbnail = defaultThumbnail ?? $this->defaultSrc;
+        $defaultThumbnail = $defaultThumbnail ?? $this->defaultSrc;
 
         $action = $this->thumbnail->js();
         if ($defaultThumbnail !== null) {

--- a/src/Form/Control/UploadImage.php
+++ b/src/Form/Control/UploadImage.php
@@ -59,7 +59,7 @@ class UploadImage extends Upload
      */
     public function clearThumbnail(string $defaultThumbnail = null): void
     {
-        $defaultThumbnail = $defaultThumbnail ?? $this->defaultSrc;
+        $defaultThumbnail ??= $this->defaultSrc;
 
         $action = $this->thumbnail->js();
         if ($defaultThumbnail !== null) {

--- a/src/Form/Control/UploadImage.php
+++ b/src/Form/Control/UploadImage.php
@@ -44,10 +44,8 @@ class UploadImage extends Upload
 
     /**
      * Set the thumbnail img src value.
-     *
-     * @param string $src
      */
-    public function setThumbnailSrc($src): void
+    public function setThumbnailSrc(string $src): void
     {
         $this->thumbnail->setAttr(['src' => $src]);
         $action = $this->thumbnail->js();
@@ -58,11 +56,11 @@ class UploadImage extends Upload
     /**
      * Clear the thumbnail src.
      * You can also supply a default thumbnail src.
-     *
-     * @param string $defaultThumbnail
      */
-    public function clearThumbnail($defaultThumbnail = null): void
+    public function clearThumbnail(string $defaultThumbnail = null): void
     {
+        $defaultThumbnail = defaultThumbnail ?? $this->defaultSrc;
+
         $action = $this->thumbnail->js();
         if ($defaultThumbnail !== null) {
             $action->attr('src', $defaultThumbnail);

--- a/src/Form/Control/UploadImage.php
+++ b/src/Form/Control/UploadImage.php
@@ -39,7 +39,7 @@ class UploadImage extends Upload
             $this->thumbnail = (new View(['element' => 'img', 'class' => ['right', 'floated', 'image'], 'ui' => true]))
                 ->setAttr(['width' => 36, 'height' => 36]);
 
-            if ($this->defaultSrc) {
+            if ($this->defaultSrc !== null) {
                 $this->thumbnail->setAttr(['src' => $this->defaultSrc]);
             }
         }

--- a/src/Form/Control/UploadImage.php
+++ b/src/Form/Control/UploadImage.php
@@ -35,15 +35,13 @@ class UploadImage extends Upload
 
     public function getThumbnail(): View
     {
-        if ($this->thumbnail) {
-            return $this->thumbnail;
-        }
+        if ($this->thumbnail === null) {
+            $this->thumbnail = (new View(['element' => 'img', 'class' => ['right', 'floated', 'image'], 'ui' => true]))
+                ->setAttr(['width' => 36, 'height' => 36]);
 
-        $this->thumbnail = (new View(['element' => 'img', 'class' => ['right', 'floated', 'image'], 'ui' => true]))
-            ->setAttr(['width' => 36, 'height' => 36]);
-
-        if ($this->defaultSrc) {
-            $this->thumbnail->setAttr(['src' => $this->defaultSrc]);
+            if ($this->defaultSrc) {
+                $this->thumbnail->setAttr(['src' => $this->defaultSrc]);
+            }
         }
 
         return $this->thumbnail;
@@ -62,17 +60,12 @@ class UploadImage extends Upload
 
     /**
      * Clear the thumbnail src.
-     * You can also supply a default thumbnail src.
      */
-    public function clearThumbnail(string $defaultThumbnail = null): void
+    public function clearThumbnail(): void
     {
-        if ($defaultThumbnail === null) {
-            $defaultThumbnail = $this->defaultSrc;
-        }
-
         $action = $this->thumbnail->js();
-        if ($defaultThumbnail !== null) {
-            $action->attr('src', $defaultThumbnail);
+        if ($this->defaultSrc !== null) {
+            $action->attr('src', $this->defaultSrc);
         } else {
             $action->removeAttr('src');
         }

--- a/src/Form/Control/UploadImage.php
+++ b/src/Form/Control/UploadImage.php
@@ -19,7 +19,7 @@ class UploadImage extends Upload
      */
     public $thumnailRegion = 'AfterAfterInput';
 
-    /** @var string The default thumbnail source. */
+    /** @var string|null The default thumbnail source. */
     public $defaultSrc;
 
     protected function init(): void

--- a/tests-behat/upload.feature
+++ b/tests-behat/upload.feature
@@ -8,12 +8,12 @@ Feature: Upload
     When I select file input "file" with "Žlutý kůň" as "$kůň"
     Then Toast display should contain text "(name: $kůň, md5: b047fb155be776f5bbae061c7b08cdf0)"
 
-    When I click using selector "#atk_layout_maestro_form_form_layout_file_button"
+    When I click using selector "div[id$='file'] .action .button"
     Then Toast display should contain text "has been removed"
 
     When I select file input "img" with "Foo" as "bar.png"
     Then Toast display should contain text "is uploaded"
 
-    When I click using selector "#atk_layout_maestro_form_form_layout_img_button"
+    When I click using selector "div[id$='img'] .action .button"
     Then Toast display should contain text "has been removed"
     Then Element "#atk_layout_maestro_form_form_layout_img_view" attribute "src" should contain text "default.png"

--- a/tests-behat/upload.feature
+++ b/tests-behat/upload.feature
@@ -8,12 +8,12 @@ Feature: Upload
     When I select file input "file" with "Žlutý kůň" as "$kůň"
     Then Toast display should contain text "(name: $kůň, md5: b047fb155be776f5bbae061c7b08cdf0)"
 
-    When I click using selector "xpath(//div.action[.//div//input[@name='file']]//.button[1])"
+    When I click using selector "xpath(//div.action[.//div//input[@name='file']]//div.button[1])"
     Then Toast display should contain text "has been removed"
 
     When I select file input "img" with "Foo" as "bar.png"
     Then Toast display should contain text "is uploaded"
 
-    When I click using selector "xpath(//div.action[.//div//input[@name='img']]//.button[1])"
+    When I click using selector "xpath(//div.action[.//div//input[@name='img']]//div.button[1])"
     Then Toast display should contain text "has been removed"
-    Then Element "xpath(//div.action[.//div//input[@name='img']]//.img[1])" attribute "src" should contain text "default.png"
+    Then Element "xpath(//div.action[.//div//input[@name='img']]//img[1])" attribute "src" should contain text "default.png"

--- a/tests-behat/upload.feature
+++ b/tests-behat/upload.feature
@@ -8,12 +8,12 @@ Feature: Upload
     When I select file input "file" with "Žlutý kůň" as "$kůň"
     Then Toast display should contain text "(name: $kůň, md5: b047fb155be776f5bbae061c7b08cdf0)"
 
-    When I click using selector "xpath(//div.action[.//input[@name='file']]//*[contains(concat(' ', normalize-space(@class), ' '), ' button ')][1])"
+    When I click using selector "xpath(//div.action[.//input[@name='file']]//div.button)"
     Then Toast display should contain text "has been removed"
 
     When I select file input "img" with "Foo" as "bar.png"
     Then Toast display should contain text "is uploaded"
 
-    When I click using selector "xpath(//div.action[.//input[@name='img']]//*[contains(concat(' ', normalize-space(@class), ' '), ' button ')][1])"
+    When I click using selector "xpath(//div.action[.//input[@name='img']]//div.button)"
     Then Toast display should contain text "has been removed"
-    Then Element "xpath(//div.action[.//div//input[@name='img']]//img[1])" attribute "src" should contain text "default.png"
+    Then Element "xpath(//div.action[.//div//input[@name='img']]//img)" attribute "src" should contain text "default.png"

--- a/tests-behat/upload.feature
+++ b/tests-behat/upload.feature
@@ -8,12 +8,12 @@ Feature: Upload
     When I select file input "file" with "Žlutý kůň" as "$kůň"
     Then Toast display should contain text "(name: $kůň, md5: b047fb155be776f5bbae061c7b08cdf0)"
 
-    When I click using selector "div.action[.//div//input[@name='file']]//.button"
+    When I click using selector "xpath(//div.action[.//div//input[@name='file']]//.button[1])"
     Then Toast display should contain text "has been removed"
 
     When I select file input "img" with "Foo" as "bar.png"
     Then Toast display should contain text "is uploaded"
 
-    When I click using selector "div.action[.//div//input[@name='img']]//.button"
+    When I click using selector "xpath(//div.action[.//div//input[@name='img']]//.button[1])"
     Then Toast display should contain text "has been removed"
-    Then Element "div.action[.//div//input[@name='foo']]//img" attribute "src" should contain text "default.png"
+    Then Element "xpath(//div.action[.//div//input[@name='img']]//.img[1])" attribute "src" should contain text "default.png"

--- a/tests-behat/upload.feature
+++ b/tests-behat/upload.feature
@@ -8,12 +8,12 @@ Feature: Upload
     When I select file input "file" with "Žlutý kůň" as "$kůň"
     Then Toast display should contain text "(name: $kůň, md5: b047fb155be776f5bbae061c7b08cdf0)"
 
-    When I click using selector "div.action[./div/input[@name='file']]/.button"
+    When I click using selector "div.action[.//div//input[@name='file']]//.button"
     Then Toast display should contain text "has been removed"
 
     When I select file input "img" with "Foo" as "bar.png"
     Then Toast display should contain text "is uploaded"
 
-    When I click using selector "div.action[./div/input[@name='img']]/.button"
+    When I click using selector "div.action[.//div//input[@name='img']]//.button"
     Then Toast display should contain text "has been removed"
-    Then Element "div.action[./div/input[@name='foo']]/img" attribute "src" should contain text "default.png"
+    Then Element "div.action[.//div//input[@name='foo']]//img" attribute "src" should contain text "default.png"

--- a/tests-behat/upload.feature
+++ b/tests-behat/upload.feature
@@ -16,4 +16,4 @@ Feature: Upload
 
     When I click using selector "div[id$='img'] .action .button"
     Then Toast display should contain text "has been removed"
-    Then Element "#atk_layout_maestro_form_form_layout_img_view" attribute "src" should contain text "default.png"
+    Then Element "div[id$='img'] .action img" attribute "src" should contain text "default.png"

--- a/tests-behat/upload.feature
+++ b/tests-behat/upload.feature
@@ -16,4 +16,4 @@ Feature: Upload
 
     When I click using selector "#atk_layout_maestro_form_form_layout_img_button"
     Then Toast display should contain text "has been removed"
-    Then Element "#atk_layout_maestro_form_form_layout_img_view" attribute "src" contain text "default.png"
+    Then Element "#atk_layout_maestro_form_form_layout_img_view" attribute "src" should contain text "default.png"

--- a/tests-behat/upload.feature
+++ b/tests-behat/upload.feature
@@ -8,12 +8,12 @@ Feature: Upload
     When I select file input "file" with "Žlutý kůň" as "$kůň"
     Then Toast display should contain text "(name: $kůň, md5: b047fb155be776f5bbae061c7b08cdf0)"
 
-    When I click using selector "xpath(//div.action[.//div//input[@name='file']]//div.button[1])"
+    When I click using selector "xpath(//div.action[.//input[@name='file']]//*[contains(concat(' ', normalize-space(@class), ' '), ' button ')][1])"
     Then Toast display should contain text "has been removed"
 
     When I select file input "img" with "Foo" as "bar.png"
     Then Toast display should contain text "is uploaded"
 
-    When I click using selector "xpath(//div.action[.//div//input[@name='img']]//div.button[1])"
+    When I click using selector "xpath(//div.action[.//input[@name='img']]//*[contains(concat(' ', normalize-space(@class), ' '), ' button ')][1])"
     Then Toast display should contain text "has been removed"
     Then Element "xpath(//div.action[.//div//input[@name='img']]//img[1])" attribute "src" should contain text "default.png"

--- a/tests-behat/upload.feature
+++ b/tests-behat/upload.feature
@@ -7,3 +7,6 @@ Feature: Upload
 
     When I select file input "file" with "Žlutý kůň" as "$kůň"
     Then Toast display should contain text "(name: $kůň, md5: b047fb155be776f5bbae061c7b08cdf0)"
+
+    When I click using selector "#atk_layout_maestro_form_form_layout_file_button"
+    Then Toast display should contain text "has been removed"

--- a/tests-behat/upload.feature
+++ b/tests-behat/upload.feature
@@ -8,12 +8,12 @@ Feature: Upload
     When I select file input "file" with "Žlutý kůň" as "$kůň"
     Then Toast display should contain text "(name: $kůň, md5: b047fb155be776f5bbae061c7b08cdf0)"
 
-    When I click using selector "div[id$='file'] .action .button"
+    When I click using selector "div.action[./div/input[@name='file']]/.button"
     Then Toast display should contain text "has been removed"
 
     When I select file input "img" with "Foo" as "bar.png"
     Then Toast display should contain text "is uploaded"
 
-    When I click using selector "div[id$='img'] .action .button"
+    When I click using selector "div.action[./div/input[@name='img']]/.button"
     Then Toast display should contain text "has been removed"
-    Then Element "div[id$='img'] .action img" attribute "src" should contain text "default.png"
+    Then Element "div.action[./div/input[@name='foo']]/img" attribute "src" should contain text "default.png"

--- a/tests-behat/upload.feature
+++ b/tests-behat/upload.feature
@@ -10,3 +10,10 @@ Feature: Upload
 
     When I click using selector "#atk_layout_maestro_form_form_layout_file_button"
     Then Toast display should contain text "has been removed"
+
+    When I select file input "img" with "Foo" as "bar.png"
+    Then Toast display should contain text "is uploaded"
+
+    When I click using selector "#atk_layout_maestro_form_form_layout_img_button"
+    Then Toast display should contain text "has been removed"
+    Then Element "#atk_layout_maestro_form_form_layout_img_view" attribute "src" contain text "default.png"


### PR DESCRIPTION
`defaultSrc` property should also be used in `clearThumbnail` method if no thumbnail is passed as method argument.
