### PR TITLE
Remove default html type from Input control class

### DIFF
--- a/demos/basic/menu.php
+++ b/demos/basic/menu.php
@@ -34,12 +34,12 @@ $submenu->addItem('two');
 $menu = Menu::addTo($app, ['vertical pointing']);
 $menu->addItem(['Inbox', 'label' => ['123', 'class.teal left pointing' => true]]);
 $menu->addItem('Spam');
-Form\Control\Input::addTo($menu->addItem(), ['placeholder' => 'Search', 'icon' => 'search'])->addClass('transparent');
+Form\Control\Line::addTo($menu->addItem(), ['placeholder' => 'Search', 'icon' => 'search'])->addClass('transparent');
 
 $menu = Menu::addTo($app, ['secondary vertical pointing']);
 $menu->addItem(['Inbox', 'label' => ['123', 'class.teal left pointing' => true]]);
 $menu->addItem('Spam');
-Form\Control\Input::addTo($menu->addItem(), ['placeholder' => 'Search', 'icon' => 'search'])->addClass('transparent');
+Form\Control\Line::addTo($menu->addItem(), ['placeholder' => 'Search', 'icon' => 'search'])->addClass('transparent');
 $menu = Menu::addTo($app, ['vertical']);
 $group = $menu->addGroup('Products');
 $group->addItem('Enterprise');

--- a/docs/form-control.rst
+++ b/docs/form-control.rst
@@ -224,7 +224,7 @@ element. For example, `icon` property:
     Adds icon into the input form control. Default - `icon` will appear on the right, while `leftIcon`
     will display icon on the left.
 
-Here are few ways to specify `icon` to an Input::
+Here are few ways to specify `icon` to an Input/Line::
 
     // compact
     Line::addTo($page, ['icon' => 'search']);

--- a/src/Form/Control/Calendar.php
+++ b/src/Form/Control/Calendar.php
@@ -15,7 +15,7 @@ class Calendar extends Input
     public string $inputType = 'text';
 
     /**
-     * Set this to 'date', 'time', 'datetime'.
+     * @var 'date'|'time'|'datetime'
      */
     public string $type = 'date';
 

--- a/src/Form/Control/Calendar.php
+++ b/src/Form/Control/Calendar.php
@@ -15,6 +15,8 @@ use Atk4\Ui\Js\JsFunction;
  */
 class Calendar extends Input
 {
+    public string $inputType = 'text';
+
     /**
      * Set this to 'date', 'time', 'datetime'.
      */

--- a/src/Form/Control/Calendar.php
+++ b/src/Form/Control/Calendar.php
@@ -10,9 +10,6 @@ use Atk4\Ui\Js\JsChain;
 use Atk4\Ui\Js\JsExpressionable;
 use Atk4\Ui\Js\JsFunction;
 
-/**
- * Date/Time picker attached to a form control.
- */
 class Calendar extends Input
 {
     public string $inputType = 'text';

--- a/src/Form/Control/Input.php
+++ b/src/Form/Control/Input.php
@@ -12,9 +12,6 @@ use Atk4\Ui\Label;
 use Atk4\Ui\UserAction\ExecutorFactory;
 use Atk4\Ui\UserAction\JsCallbackExecutor;
 
-/**
- * Input element for a form control.
- */
 class Input extends Form\Control
 {
     public $ui = 'input';

--- a/src/Form/Control/Input.php
+++ b/src/Form/Control/Input.php
@@ -20,7 +20,7 @@ class Input extends Form\Control
     public $ui = 'input';
     public $defaultTemplate = 'form/control/input.html';
 
-    public string $inputType = 'text';
+    public string $inputType;
 
     /** @var string */
     public $placeholder = '';

--- a/src/Form/Control/Line.php
+++ b/src/Form/Control/Line.php
@@ -6,4 +6,5 @@ namespace Atk4\Ui\Form\Control;
 
 class Line extends Input
 {
+    public string $inputType = 'text';
 }

--- a/src/Form/Control/Money.php
+++ b/src/Form/Control/Money.php
@@ -6,6 +6,8 @@ namespace Atk4\Ui\Form\Control;
 
 class Money extends Input
 {
+    public string $inputType = 'text';
+
     public function getValue()
     {
         $res = parent::getValue();

--- a/src/Js/JsBlock.php
+++ b/src/Js/JsBlock.php
@@ -61,7 +61,7 @@ class JsBlock implements JsExpressionable
             $js = $statement->jsRender();
             if ($js === '') {
                 continue;
-            } elseif (!$statement instanceof self && !preg_match('~;\s*$~s', $js)) {
+            } elseif (!$statement instanceof self && !preg_match('~;\s*$~', $js)) {
                 $js .= ';';
             }
 

--- a/src/Js/JsChain.php
+++ b/src/Js/JsChain.php
@@ -110,7 +110,7 @@ class JsChain extends JsExpression
                 $args = $chain[1];
             }
 
-            $res .= preg_match('~^(?!\d)\w+$~su', $name) ? '.' . $name : '[' . $this->_jsEncode($name) . ']';
+            $res .= preg_match('~^(?!\d)\w+$~Du', $name) ? '.' . $name : '[' . $this->_jsEncode($name) . ']';
             if ($args !== null) {
                 $res .= $this->_renderArgs($args);
             }

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -218,10 +218,9 @@ class FormTest extends TestCase
         static::assertStringContainsString(' disabled="disabled"', $input->render());
         static::assertStringContainsString(' readonly="readonly"', $input->render());
 
-        $input = new Form\Control\Line();
+        $input = new Form\Control\Hidden();
         $input->disabled = true;
         $input->readOnly = true;
-        $input->inputType = 'hidden';
         $input->setApp($this->createApp());
         static::assertStringNotContainsString('disabled', $input->render());
         static::assertStringNotContainsString('readonly', $input->render());

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -211,14 +211,14 @@ class FormTest extends TestCase
 
     public function testNoDisabledAttrWithHiddenType(): void
     {
-        $input = new Form\Control\Input();
+        $input = new Form\Control\Line();
         $input->disabled = true;
         $input->readOnly = true;
         $input->setApp($this->createApp());
         static::assertStringContainsString(' disabled="disabled"', $input->render());
         static::assertStringContainsString(' readonly="readonly"', $input->render());
 
-        $input = new Form\Control\Input();
+        $input = new Form\Control\Line();
         $input->disabled = true;
         $input->readOnly = true;
         $input->inputType = 'hidden';


### PR DESCRIPTION
use `Line` control instead of `Input` if `<input type="text"` is desired