### PR TITLE
Add cross-request RW demos Behat testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ cache
 *.cache.*
 
 /demos/db.php
+/demos/db-behat-rw.txt
 /demos/_demo-data/db.sqlite
 /demos/_demo-data/db.sqlite-journal
 /phpunit.xml

--- a/demos/init-db.php
+++ b/demos/init-db.php
@@ -26,7 +26,7 @@ try {
 
 trait ModelPreventModificationTrait
 {
-    protected function allowDbModifications(): bool
+    protected function isAllowDbModifications(): bool
     {
         static $rw = null;
         if ($rw === null) {
@@ -44,7 +44,7 @@ trait ModelPreventModificationTrait
             parent::atomic(function () use ($fx, $eRollback, &$res) {
                 $res = $fx();
 
-                if (!$this->allowDbModifications()) {
+                if (!$this->isAllowDbModifications()) {
                     throw $eRollback;
                 }
             });
@@ -74,7 +74,7 @@ trait ModelPreventModificationTrait
                 $action->callback = $originalCallback;
                 $res = $action->execute(...$args);
 
-                if ($this->allowDbModifications()) {
+                if ($this->isAllowDbModifications()) {
                     return $res;
                 }
             } finally {

--- a/src/Behat/Context.php
+++ b/src/Behat/Context.php
@@ -17,6 +17,7 @@ use Behat\MinkExtension\Context\RawMinkContext;
 class Context extends RawMinkContext implements BehatContext
 {
     use JsCoverageContextTrait;
+    use RwDemosContextTrait;
     use WarnDynamicPropertyTrait;
 
     public function getSession($name = null): MinkSession
@@ -71,6 +72,10 @@ class Context extends RawMinkContext implements BehatContext
      */
     public function waitUntilLoadingAndAnimationFinished(AfterStepScope $event): void
     {
+        if (!$this->getSession()->getDriver()->isStarted()) {
+            return;
+        }
+
         $this->jqueryWait();
         $this->disableAnimations();
 

--- a/src/Behat/RwDemosContextTrait.php
+++ b/src/Behat/RwDemosContextTrait.php
@@ -47,7 +47,7 @@ trait RwDemosContextTrait
         return $db;
     }
 
-    protected function createDatabaseModelsSingle(string $table): Model
+    protected function createDatabaseModelFromTable(string $table): Model
     {
         $db = $this->getDemosDb();
         $schemaManager = $db->getConnection()->createSchemaManager();
@@ -68,12 +68,12 @@ trait RwDemosContextTrait
 
     protected function createDatabaseModels(): void
     {
-        $models = [];
+        $modelByTable = [];
         foreach ($this->databaseBackupTables as $table) {
-            $models[$table] = $this->createDatabaseModelsSingle($table);
+            $modelByTable[$table] = $this->createDatabaseModelFromTable($table);
         }
 
-        $this->databaseBackupModels = $models;
+        $this->databaseBackupModels = $modelByTable;
     }
 
     protected function createDatabaseBackup(): void

--- a/src/Behat/RwDemosContextTrait.php
+++ b/src/Behat/RwDemosContextTrait.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atk4\Ui\Behat;
+
+use Atk4\Data\Model;
+use Atk4\Data\Persistence;
+
+trait RwDemosContextTrait
+{
+    protected string $demosDir = __DIR__ . '/../../demos';
+
+    protected bool $needDatabaseRestore = false;
+
+    /** @var list<string> */
+    protected array $databaseBackupTables = [
+        'client',
+        'country',
+        'file',
+        'stat',
+        'product_category',
+        'product_sub_category',
+        'product',
+        'multiline_item',
+        'multiline_delivery',
+    ];
+
+    /** @var array<string, Model>|null */
+    protected ?array $databaseBackupModels = null;
+
+    /** @var array<string, array<int, array<string, mixed>>>|null */
+    protected ?array $databaseBackupData = null;
+
+    protected function getDemosDb(): Persistence\Sql
+    {
+        static $db = null;
+        if ($db === null) {
+            try {
+                /** @var Persistence\Sql $db */
+                require_once $this->demosDir . '/init-db.php'; // @phpstan-ignore-line
+            } catch (\Throwable $e) {
+                throw new \Exception('Database error: ' . $e->getMessage());
+            }
+        }
+
+        return $db;
+    }
+
+    protected function createDatabaseModelsSingle(string $table): Model
+    {
+        $db = $this->getDemosDb();
+        $schemaManager = $db->getConnection()->createSchemaManager();
+        $tableColumns = $schemaManager->listTableColumns($table);
+
+        $model = new Model($db, ['table' => $table]);
+        $model->removeField('id');
+        foreach ($tableColumns as $tableColumn) {
+            $model->addField($tableColumn->getName(), [
+                'type' => $tableColumn->getType()->getName(), // @phpstan-ignore-line Type::getName() is deprecated in DBAL 4.0
+                'nullable' => !$tableColumn->getNotnull(),
+            ]);
+        }
+        $model->idField = array_key_first($model->getFields());
+
+        return $model;
+    }
+
+    protected function createDatabaseModels(): void
+    {
+        $models = [];
+        foreach ($this->databaseBackupTables as $table) {
+            $models[$table] = $this->createDatabaseModelsSingle($table);
+        }
+
+        $this->databaseBackupModels = $models;
+    }
+
+    protected function createDatabaseBackup(): void
+    {
+        $dataByTable = [];
+        foreach ($this->databaseBackupTables as $table) {
+            $model = $this->databaseBackupModels[$table];
+
+            $data = [];
+            foreach ($model as $entity) {
+                $data[$entity->getId()] = $entity->get();
+            }
+
+            $dataByTable[$table] = $data;
+        }
+
+        $this->databaseBackupData = $dataByTable;
+    }
+
+    /**
+     * @return array<string, \stdClass&object{ addedIds: list<int>, changedIds: list<int>, deletedIds: list<int> }>
+     */
+    protected function discoverDatabaseChanges(): array
+    {
+        $changesByTable = [];
+        foreach ($this->databaseBackupTables as $table) {
+            $model = $this->databaseBackupModels[$table];
+            $data = $this->databaseBackupData[$table];
+
+            $changes = new \stdClass();
+            $changes->addedIds = [];
+            $changes->changedIds = [];
+            $changes->deletedIds = array_fill_keys(array_keys($data), true);
+            foreach ($model as $entity) {
+                $id = $entity->getId();
+                if (!isset($data[$id])) {
+                    $changes->addedIds[] = $id;
+                } else {
+                    $isChanged = false;
+                    foreach ($data[$id] as $k => $v) {
+                        if (!$entity->compare($k, $v)) {
+                            $isChanged = true;
+
+                            break;
+                        }
+                    }
+
+                    if ($isChanged) {
+                        $changes->changedIds[] = $id;
+                    }
+
+                    unset($changes->deletedIds[$id]);
+                }
+            }
+            $changes->deletedIds = array_keys($changes->deletedIds);
+
+            if (count($changes->addedIds) > 0 || count($changes->changedIds) > 0 || count($changes->deletedIds) > 0) {
+                $changesByTable[$table] = $changes;
+            }
+        }
+
+        return $changesByTable; // @phpstan-ignore-line https://github.com/phpstan/phpstan/issues/9252
+    }
+
+    protected function restoreDatabaseBackup(): void
+    {
+        $changesByTable = $this->discoverDatabaseChanges();
+
+        if (count($changesByTable) > 0) {
+            // TODO disable FK checks
+            // unfortunately there is no DBAL API - https://github.com/doctrine/dbal/pull/2620
+            try {
+                $this->getDemosDb()->atomic(function () use ($changesByTable) {
+                    foreach ($changesByTable as $table => $changes) {
+                        $model = $this->databaseBackupModels[$table];
+                        $data = $this->databaseBackupData[$table];
+
+                        foreach ($changes->addedIds as $id) {
+                            $model->delete($id);
+                        }
+
+                        foreach ([...$changes->changedIds, ...$changes->deletedIds] as $id) {
+                            $entity = in_array($id, $changes->changedIds, true) ? $model->load($id) : $model->createEntity();
+                            $entity->setMulti($data[$id]);
+                            $entity->save();
+                        }
+                    }
+                });
+            } finally {
+                // TODO enable FK checks
+            }
+        }
+    }
+
+    /**
+     * @AfterScenario
+     */
+    public function restoreDatabase(): void
+    {
+        if ($this->needDatabaseRestore) {
+            $this->needDatabaseRestore = false;
+            unlink($this->demosDir . '/db-behat-rw.txt');
+
+            $this->restoreDatabaseBackup();
+        }
+    }
+
+    /**
+     * @When I allow cross-request DB modifications
+     */
+    public function allowDbModifications(): void
+    {
+        if ($this->databaseBackupData === null) {
+            if (file_exists($this->demosDir . '/db-behat-rw.txt')) {
+                throw new \Exception('Database was not restored cleanly');
+            }
+
+            $this->createDatabaseModels();
+            $this->createDatabaseBackup();
+        }
+
+        $this->needDatabaseRestore = true;
+        file_put_contents($this->demosDir . '/db-behat-rw.txt', '');
+    }
+}

--- a/src/Behat/RwDemosContextTrait.php
+++ b/src/Behat/RwDemosContextTrait.php
@@ -182,9 +182,9 @@ trait RwDemosContextTrait
     }
 
     /**
-     * @When I allow cross-request DB modifications
+     * @When I persist DB changes across requests
      */
-    public function allowDbModifications(): void
+    public function iPersistDbChangesAcrossRequests(): void
     {
         if ($this->databaseBackupData === null) {
             if (file_exists($this->demosDir . '/db-behat-rw.txt')) {

--- a/src/CardSection.php
+++ b/src/CardSection.php
@@ -70,9 +70,10 @@ class CardSection extends View
             if ($model->titleField === $field) {
                 continue;
             }
-            $label = $model->getField($field)->getCaption();
+
             $value = $this->getApp()->uiPersistence->typecastSaveField($model->getField($field), $model->get($field));
             if ($useLabel) {
+                $label = $model->getField($field)->getCaption();
                 $value = $label . $this->glue . $value;
             }
 

--- a/tests-behat/card-deck.feature
+++ b/tests-behat/card-deck.feature
@@ -30,8 +30,8 @@ Feature: CardDeck
     Then I press Modal button "Ok"
     Then Toast display should contain text 'Country action "delete" with "United Kingdom" entity was executed.'
 
-  Scenario: delete - with cross-request DB modifications
-    When I allow cross-request DB modifications
+  Scenario: delete - with unlocked DB
+    When I persist DB changes across requests
     Then I press button "Delete"
     Then I press Modal button "Ok"
     Then Toast display should contain text 'Record has been deleted!'

--- a/tests-behat/card-deck.feature
+++ b/tests-behat/card-deck.feature
@@ -29,6 +29,8 @@ Feature: CardDeck
     Then I press button "Delete"
     Then I press Modal button "Ok"
     Then Toast display should contain text 'Country action "delete" with "United Kingdom" entity was executed.'
+
+  Scenario: delete - with cross-request DB modifications
     When I allow cross-request DB modifications
     Then I press button "Delete"
     Then I press Modal button "Ok"

--- a/tests-behat/card-deck.feature
+++ b/tests-behat/card-deck.feature
@@ -29,6 +29,8 @@ Feature: CardDeck
     Then I press button "Delete"
     Then I press Modal button "Ok"
     Then Toast display should contain text 'Country action "delete" with "United Kingdom" entity was executed.'
-    # TODO CardDeck reload is fired in separate AJAX request, thus the changes
-    # cannot be tested with Behat, as reverted in the first request
-    # Then I should not see "United Kingdom"
+    When I allow cross-request DB modifications
+    Then I press button "Delete"
+    Then I press Modal button "Ok"
+    Then Toast display should contain text 'Record has been deleted!'
+    Then I should not see "United Kingdom"

--- a/tests-behat/crud.feature
+++ b/tests-behat/crud.feature
@@ -27,10 +27,6 @@ Feature: Crud
     Then I should see "United Kingdom"
 
   Scenario: edit - with unlocked DB
-    # TODO hotfix "element not interactable"
-    Given I am on "_unit-test/crud.php"
-    Then I search grid for "united kingdom"
-
     Then I should not see "My United Kingdom"
     When I persist DB changes across requests
     Then I press button "Edit"

--- a/tests-behat/crud.feature
+++ b/tests-behat/crud.feature
@@ -27,13 +27,17 @@ Feature: Crud
     Then I should see "United Kingdom"
 
   Scenario: edit - with cross-request DB modifications
+    # TODO hotfix "element not interactable"
+    Given I am on "_unit-test/crud.php"
+    Then I search grid for "united kingdom"
+
     Then I should not see "My United Kingdom"
     When I allow cross-request DB modifications
     Then I press button "Edit"
     Then Modal is open with text "Edit Country"
     Then I fill in "atk_fp_country__name" with "My United Kingdom"
     Then I press Modal button "Save"
-    Then Toast display should contain text 'Country action "edit" with "United Kingdom" entity was executed.'
+    Then Toast display should contain text 'Record has been saved!'
     Then I should see "My United Kingdom"
 
   Scenario: delete

--- a/tests-behat/crud.feature
+++ b/tests-behat/crud.feature
@@ -27,6 +27,12 @@ Feature: Crud
     Then I should see "United Kingdom"
 
   Scenario: edit - with unlocked DB
+    # hotfix "element not interactable"
+    # TODO modal should be always fully (re)loaded on open and fully destroyed once it is closed
+    # https://github.com/atk4/ui/issues/1928
+    Given I am on "_unit-test/crud.php"
+    Then I search grid for "united kingdom"
+
     Then I should not see "My United Kingdom"
     When I persist DB changes across requests
     Then I press button "Edit"

--- a/tests-behat/crud.feature
+++ b/tests-behat/crud.feature
@@ -26,13 +26,13 @@ Feature: Crud
     # make sure search query stick
     Then I should see "United Kingdom"
 
-  Scenario: edit - with cross-request DB modifications
+  Scenario: edit - with unlocked DB
     # TODO hotfix "element not interactable"
     Given I am on "_unit-test/crud.php"
     Then I search grid for "united kingdom"
 
     Then I should not see "My United Kingdom"
-    When I allow cross-request DB modifications
+    When I persist DB changes across requests
     Then I press button "Edit"
     Then Modal is open with text "Edit Country"
     Then I fill in "atk_fp_country__name" with "My United Kingdom"

--- a/tests-behat/crud.feature
+++ b/tests-behat/crud.feature
@@ -26,6 +26,16 @@ Feature: Crud
     # make sure search query stick
     Then I should see "United Kingdom"
 
+  Scenario: edit - with cross-request DB modifications
+    Then I should not see "My United Kingdom"
+    When I allow cross-request DB modifications
+    Then I press button "Edit"
+    Then Modal is open with text "Edit Country"
+    Then I fill in "atk_fp_country__name" with "My United Kingdom"
+    Then I press Modal button "Save"
+    Then Toast display should contain text 'Country action "edit" with "United Kingdom" entity was executed.'
+    Then I should see "My United Kingdom"
+
   Scenario: delete
     Then I press button "Delete"
     Then I press Modal button "Ok"


### PR DESCRIPTION
Currently all changes are tested to be made and returned within the same DB transaction which is great to enforce the atk4/ui to made as less server requests possible and always work with fresh data for each Behat scenario, but this imply we cannot test advanced features - like CardDeck or more than one change per test scenario.