### PR TITLE
Form onChange handler for clearing prompts is not needed

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -530,11 +530,6 @@ class Form extends View
             'serializeForm' => true,
         ], $this->apiConfig));
 
-        // fix remove prompt for dropdown
-        // https://github.com/fomantic/Fomantic-UI/issues/2797
-        // [name] in selector is to suppress https://github.com/fomantic/Fomantic-UI/commit/facbca003cf0da465af7d44af41462e736d3eb8b console errors from Multiline/vue fields
-        $this->on('change', '.field input[name], .field textarea[name], .field select[name]', $this->js()->form('remove prompt', new JsExpression('$(this).attr(\'name\')')));
-
         if (!$this->canLeave) {
             $this->js(true, (new JsChain('atk.formService'))->preventFormLeave($this->name));
         }


### PR DESCRIPTION
form prompts are removed by https://github.com/atk4/ui/blob/4.0.0/src/Form.php#L554

but not for form dropdowns - https://github.com/fomantic/Fomantic-UI/issues/2797 needs to be fixed first

introduced in https://github.com/atk4/ui/commit/90b0fcecdcf527254563943eea7917ae958d79ca#diff-92886d01da016b7104e7ce311d6bed7236b2b6dfae8e378f9a4e53d568b8aae1R120