### PR TITLE
Fix DockerFile read-only SQLite error in demos

### DIFF
--- a/demos/Dockerfile
+++ b/demos/Dockerfile
@@ -43,6 +43,5 @@ RUN echo "<?php header('Location: /demos/');" > index.php
 RUN sed -E "s/(\\\$minified = )true;/\\1false;/g" -i src/App.php
 
 RUN php demos/_demo-data/create-db.php
+RUN chown -R www-data:www-data demos/_demo-data
 RUN sed -E "s/\(('sqlite:.+)\);/(\$_ENV['DB_DSN'] ?? \\1, \$_ENV['DB_USER'] ?? null, \$_ENV['DB_PASSWORD'] ?? null);/g" -i demos/db.default.php
-
-RUN chown www-data:www-data demos/_demo-data -R

--- a/demos/Dockerfile
+++ b/demos/Dockerfile
@@ -44,3 +44,5 @@ RUN sed -E "s/(\\\$minified = )true;/\\1false;/g" -i src/App.php
 
 RUN php demos/_demo-data/create-db.php
 RUN sed -E "s/\(('sqlite:.+)\);/(\$_ENV['DB_DSN'] ?? \\1, \$_ENV['DB_USER'] ?? null, \$_ENV['DB_PASSWORD'] ?? null);/g" -i demos/db.default.php
+
+RUN chown www-data:www-data demos/_demo-data -R


### PR DESCRIPTION
I have been running the command directly on the deploy server. However, I believe it is correct to merge this PR and test the usual deployment flow via webhook.

As pointed out by @mvorisek, the root cause of the issue lies in incorrect permissions. To resolve this, it is essential to set the correct owner for the folder where the SQLite database is located. I hope this adjustment will effectively address the problem.