### PR TITLE
Fix JsCallbackExecutor execute args

### DIFF
--- a/demos/data-action/actions.php
+++ b/demos/data-action/actions.php
@@ -30,7 +30,7 @@ $action = $files->addUserAction('import_from_filesystem', [
     'description' => 'Import file in a specify path.',
     // Display information prior to execute the action.
     // ModalExecutor or PreviewExecutor will display preview.
-    'preview' => function (Model $model, $path) {
+    'preview' => function (Model $model, string $path) {
         return 'Execute Import using path: "' . $path . '"';
     },
     // Argument needed to run the callback action method.

--- a/demos/data-action/actions.php
+++ b/demos/data-action/actions.php
@@ -64,10 +64,9 @@ $executor->setAction($action->getActionForEntity($files->createEntity()));
 $executor->onHook(UserAction\BasicExecutor::HOOK_AFTER_EXECUTE, function () {
     return new JsToast('Files imported');
 });
-$executor->executeModelAction(['path' => '.']);
 
 $button = Button::addTo($rightColumn, ['Import File']);
-$button->on('click', $executor, ['confirm' => 'This will import a lot of file. Are you sure?']);
+$button->on('click', $executor, ['args' => ['path' => '.'], 'confirm' => 'This will import a lot of file. Are you sure?']);
 
 Header::addTo($rightColumn, ['BasicExecutor']);
 $executor = UserAction\BasicExecutor::addTo($rightColumn, ['executorButton' => [Button::class, 'Import', 'class.primary' => true]]);

--- a/demos/data-action/jsactions.php
+++ b/demos/data-action/jsactions.php
@@ -48,7 +48,7 @@ $country->addUserAction('greet', [
             'required' => true,
         ],
     ],
-    'callback' => function (Country $model, $name) {
+    'callback' => function (Country $model, string $name) {
         return 'Hello ' . $name;
     },
 ]);

--- a/demos/form/form2.php
+++ b/demos/form/form2.php
@@ -38,7 +38,7 @@ $nameInput->addAction(['Check Duplicate', 'iconRight' => 'search'])
         }
 
         return new JsToast('This country name can be added.');
-    }, ['args' => ['_n' => $nameInput->jsInput()->val()]]);
+    }, ['args' => [$nameInput->jsInput()->val()]]);
 
 // form codes field group
 $formCodes = $form->addGroup(['Codes']);

--- a/demos/tutorial/actions.php
+++ b/demos/tutorial/actions.php
@@ -123,7 +123,7 @@ $wizard->addStep('Arguments', function (Wizard $page) {
                     'type' => 'string',
                 ],
             ],
-            'callback' => function (Model $model, $name) {
+            'callback' => function (Model $model, string $name) {
                 return 'Hi ' . $name;
             },
         ]);

--- a/src/Form.php
+++ b/src/Form.php
@@ -369,13 +369,11 @@ class Form extends View
      * Returns JS Chain that targets INPUT element of a specified field. This method is handy
      * if you wish to set a value to a certain field.
      *
-     * @param string $name Name of control
-     *
      * @return Jquery
      */
-    public function jsInput($name): JsExpressionable
+    public function jsInput(string $name): JsExpressionable
     {
-        return $this->layout->getControl($name)->js()->find('input');
+        return $this->layout->getControl($name)->jsInput();
     }
 
     // }}}

--- a/src/Form.php
+++ b/src/Form.php
@@ -545,8 +545,9 @@ class Form extends View
             'serializeForm' => true,
         ], $this->apiConfig));
 
-        // [name] in selector is to suppress https://github.com/fomantic/Fomantic-UI/commit/facbca003cf0da465af7d44af41462e736d3eb8b
-        // console errors from Multiline/vue fields
+        // fix remove prompt for dropdown
+        // https://github.com/fomantic/Fomantic-UI/issues/2797
+        // [name] in selector is to suppress https://github.com/fomantic/Fomantic-UI/commit/facbca003cf0da465af7d44af41462e736d3eb8b console errors from Multiline/vue fields
         $this->on('change', '.field input[name], .field textarea[name], .field select[name]', $this->js()->form('remove prompt', new JsExpression('$(this).attr(\'name\')')));
 
         if (!$this->canLeave) {

--- a/src/Form/Control/Calendar.php
+++ b/src/Form/Control/Calendar.php
@@ -28,10 +28,9 @@ class Calendar extends Input
     /**
      * Set Flatpickr option.
      *
-     * @param string $name
-     * @param mixed  $value
+     * @param mixed $value
      */
-    public function setOption($name, $value): void
+    public function setOption(string $name, $value): void
     {
         $this->options[$name] = $value;
     }

--- a/src/JsCallback.php
+++ b/src/JsCallback.php
@@ -12,7 +12,7 @@ use Atk4\Ui\Js\JsExpressionable;
 
 class JsCallback extends Callback
 {
-    /** @var array Holds information about arguments passed in to the callback. */
+    /** @var array<string, string|JsExpressionable> Holds information about arguments passed in to the callback. */
     public $args = [];
 
     /** @var string Text to display as a confirmation. Set with setConfirm(..). */
@@ -71,7 +71,7 @@ class JsCallback extends Callback
         $this->args = [];
         foreach ($args ?? [] as $key => $val) {
             if (is_int($key)) {
-                $key = 'c' . $key;
+                $key = $this->name . '_c' . $key;
             }
             $this->args[$key] = $val;
         }
@@ -80,7 +80,7 @@ class JsCallback extends Callback
             $chain = new Jquery();
 
             $values = [];
-            foreach ($this->args as $key => $value) {
+            foreach (array_keys($this->args) as $key) {
                 $values[] = $_POST[$key] ?? null;
             }
 

--- a/src/UserAction/ConfirmationExecutor.php
+++ b/src/UserAction/ConfirmationExecutor.php
@@ -60,7 +60,7 @@ class ConfirmationExecutor extends Modal implements JsExecutorInterface
     /**
      * Properly set element ID for this modal.
      */
-    protected function afterActionInit(Model\UserAction $action): void
+    protected function afterActionInit(): void
     {
         // Add buttons to modal for next and previous.
         $buttonsView = (new View())->setStyle(['min-height' => '24px']);
@@ -103,7 +103,7 @@ class ConfirmationExecutor extends Modal implements JsExecutorInterface
     public function setAction(Model\UserAction $action)
     {
         $this->action = $action;
-        $this->afterActionInit($action);
+        $this->afterActionInit();
 
         $this->title ??= $action->getDescription();
         $this->step = $this->stickyGet('step');

--- a/src/UserAction/JsCallbackExecutor.php
+++ b/src/UserAction/JsCallbackExecutor.php
@@ -66,7 +66,7 @@ class JsCallbackExecutor extends JsCallback implements ExecutorInterface
 
     public function executeModelAction(array $args = []): void
     {
-        $this->set(function (Jquery $j) {
+        $this->set(function (Jquery $j, ...$values) {
             $id = $this->getApp()->uiPersistence->typecastLoadField(
                 $this->action->getModel()->getField($this->action->getModel()->idField),
                 $_POST['c0'] ?? $_POST[$this->name] ?? null
@@ -87,12 +87,7 @@ class JsCallbackExecutor extends JsCallback implements ExecutorInterface
             if ($errors) {
                 $js = new JsToast(['title' => 'Error', 'message' => 'Missing Arguments: ' . implode(', ', $errors), 'class' => 'error']);
             } else {
-                $args = [];
-                foreach ($this->action->args as $key => $val) {
-                    $args[] = $_POST[$key] ?? $this->args[$key];
-                }
-
-                $return = $this->action->execute(...$args);
+                $return = $this->action->execute(...$values);
                 $success = $this->jsSuccess instanceof \Closure
                     ? ($this->jsSuccess)($this, $this->action->getModel(), $id, $return)
                     : $this->jsSuccess;

--- a/src/UserAction/JsCallbackExecutor.php
+++ b/src/UserAction/JsCallbackExecutor.php
@@ -52,47 +52,60 @@ class JsCallbackExecutor extends JsCallback implements ExecutorInterface
         return $this;
     }
 
-    public function jsExecute(array $urlArgs = []): JsBlock
+    /**
+     * @param \Closure(): mixed $fx
+     *
+     * @return mixed
+     */
+    protected function invokeFxWithUrlArgs(\Closure $fx, array $urlArgs = [])
     {
-        // TODO hack to parametrize parent::jsExecute() like JsExecutorInterface::jsExecute($urlArgs)
         $argsOrig = $this->args;
         $this->args = array_merge($this->args, $urlArgs);
         try {
-            return parent::jsExecute();
+            return $fx();
         } finally {
             $this->args = $argsOrig;
         }
     }
 
+    public function jsExecute(array $urlArgs = []): JsBlock
+    {
+        return $this->invokeFxWithUrlArgs(function () { // backup/restore $this->args and merge them with $urlArgs
+            return parent::jsExecute();
+        }, $urlArgs);
+    }
+
     public function executeModelAction(): void
     {
-        $this->set(function (Jquery $j, ...$values) {
-            $id = $this->getApp()->uiPersistence->typecastLoadField(
-                $this->action->getModel()->getField($this->action->getModel()->idField),
-                $_POST['c0'] ?? $_POST[$this->name] ?? null
-            );
-            if ($id && $this->action->appliesTo === Model\UserAction::APPLIES_TO_SINGLE_RECORD) {
-                if ($this->action->isOwnerEntity() && $this->action->getEntity()->getId()) {
-                    $this->action->getEntity()->setId($id); // assert ID is the same
-                } else {
-                    $this->action = $this->action->getActionForEntity($this->action->getModel()->load($id));
+        $this->invokeFxWithUrlArgs(function () { // backup/restore $this->args mutated in https://github.com/atk4/ui/blob/8926412a31bc17d3ed1e751e67770557fe865935/src/JsCallback.php#L71
+            $this->set(function (Jquery $j, ...$values) {
+                $id = $this->getApp()->uiPersistence->typecastLoadField(
+                    $this->action->getModel()->getField($this->action->getModel()->idField),
+                    $_POST['c0'] ?? $_POST[$this->name] ?? null
+                );
+                if ($id && $this->action->appliesTo === Model\UserAction::APPLIES_TO_SINGLE_RECORD) {
+                    if ($this->action->isOwnerEntity() && $this->action->getEntity()->getId()) {
+                        $this->action->getEntity()->setId($id); // assert ID is the same
+                    } else {
+                        $this->action = $this->action->getActionForEntity($this->action->getModel()->load($id));
+                    }
+                } elseif (!$this->action->isOwnerEntity()
+                    && in_array($this->action->appliesTo, [Model\UserAction::APPLIES_TO_NO_RECORDS, Model\UserAction::APPLIES_TO_SINGLE_RECORD], true)
+                ) {
+                    $this->action = $this->action->getActionForEntity($this->action->getModel()->createEntity());
                 }
-            } elseif (!$this->action->isOwnerEntity()
-                && in_array($this->action->appliesTo, [Model\UserAction::APPLIES_TO_NO_RECORDS, Model\UserAction::APPLIES_TO_SINGLE_RECORD], true)
-            ) {
-                $this->action = $this->action->getActionForEntity($this->action->getModel()->createEntity());
-            }
 
-            $return = $this->action->execute(...$values);
+                $return = $this->action->execute(...$values);
 
-            $success = $this->jsSuccess instanceof \Closure
-                ? ($this->jsSuccess)($this, $this->action->getModel(), $id, $return)
-                : $this->jsSuccess;
+                $success = $this->jsSuccess instanceof \Closure
+                    ? ($this->jsSuccess)($this, $this->action->getModel(), $id, $return)
+                    : $this->jsSuccess;
 
-            $js = JsBlock::fromHookResult($this->hook(BasicExecutor::HOOK_AFTER_EXECUTE, [$return, $id]) // @phpstan-ignore-line
-                ?: ($success ?? new JsToast('Success' . (is_string($return) ? (': ' . $return) : ''))));
+                $js = JsBlock::fromHookResult($this->hook(BasicExecutor::HOOK_AFTER_EXECUTE, [$return, $id]) // @phpstan-ignore-line
+                    ?: ($success ?? new JsToast('Success' . (is_string($return) ? (': ' . $return) : ''))));
 
-            return $js;
-        }, array_map(fn () => true, $this->action->args));
+                return $js;
+            }, array_map(fn () => true, $this->action->args));
+        });
     }
 }

--- a/src/UserAction/JsCallbackExecutor.php
+++ b/src/UserAction/JsCallbackExecutor.php
@@ -81,7 +81,7 @@ class JsCallbackExecutor extends JsCallback implements ExecutorInterface
             $this->set(function (Jquery $j, ...$values) {
                 $id = $this->getApp()->uiPersistence->typecastLoadField(
                     $this->action->getModel()->getField($this->action->getModel()->idField),
-                    $_POST['c0'] ?? $_POST[$this->name] ?? null
+                    $_POST[$this->name] ?? null
                 );
                 if ($id && $this->action->appliesTo === Model\UserAction::APPLIES_TO_SINGLE_RECORD) {
                     if ($this->action->isOwnerEntity() && $this->action->getEntity()->getId()) {

--- a/src/UserAction/JsCallbackExecutor.php
+++ b/src/UserAction/JsCallbackExecutor.php
@@ -83,35 +83,16 @@ class JsCallbackExecutor extends JsCallback implements ExecutorInterface
                 $this->action = $this->action->getActionForEntity($this->action->getModel()->createEntity());
             }
 
-            $errors = $this->_hasAllArguments();
-            if ($errors) {
-                $js = new JsToast(['title' => 'Error', 'message' => 'Missing Arguments: ' . implode(', ', $errors), 'class' => 'error']);
-            } else {
-                $return = $this->action->execute(...$values);
-                $success = $this->jsSuccess instanceof \Closure
-                    ? ($this->jsSuccess)($this, $this->action->getModel(), $id, $return)
-                    : $this->jsSuccess;
+            $return = $this->action->execute(...$values);
 
-                $js = JsBlock::fromHookResult($this->hook(BasicExecutor::HOOK_AFTER_EXECUTE, [$return, $id]) // @phpstan-ignore-line
-                    ?: ($success ?? new JsToast('Success' . (is_string($return) ? (': ' . $return) : ''))));
-            }
+            $success = $this->jsSuccess instanceof \Closure
+                ? ($this->jsSuccess)($this, $this->action->getModel(), $id, $return)
+                : $this->jsSuccess;
+
+            $js = JsBlock::fromHookResult($this->hook(BasicExecutor::HOOK_AFTER_EXECUTE, [$return, $id]) // @phpstan-ignore-line
+                ?: ($success ?? new JsToast('Success' . (is_string($return) ? (': ' . $return) : ''))));
 
             return $js;
         }, array_map(fn () => true, $this->action->args));
-    }
-
-    /**
-     * Check if all argument values have been provided.
-     */
-    private function _hasAllArguments(): array
-    {
-        $errors = [];
-        foreach ($this->action->args as $key => $val) {
-            if (!isset($this->args[$key])) {
-                $errors[] = $key;
-            }
-        }
-
-        return $errors;
     }
 }

--- a/src/UserAction/JsCallbackExecutor.php
+++ b/src/UserAction/JsCallbackExecutor.php
@@ -64,7 +64,7 @@ class JsCallbackExecutor extends JsCallback implements ExecutorInterface
         }
     }
 
-    public function executeModelAction(array $args = []): void
+    public function executeModelAction(): void
     {
         $this->set(function (Jquery $j, ...$values) {
             $id = $this->getApp()->uiPersistence->typecastLoadField(
@@ -97,7 +97,7 @@ class JsCallbackExecutor extends JsCallback implements ExecutorInterface
             }
 
             return $js;
-        }, $args);
+        }, array_map(fn () => true, $this->action->args));
     }
 
     /**

--- a/src/UserAction/ModalExecutor.php
+++ b/src/UserAction/ModalExecutor.php
@@ -61,7 +61,7 @@ class ModalExecutor extends Modal implements JsExecutorInterface
      * to make sure that view id is properly set for loader and button
      * JS action to run properly.
      */
-    protected function afterActionInit(Model\UserAction $action): void
+    protected function afterActionInit(): void
     {
         $this->loader = Loader::addTo($this, ['ui' => $this->loaderUi, 'shim' => $this->loaderShim]);
         $this->loader->loadEvent = false;
@@ -72,10 +72,10 @@ class ModalExecutor extends Modal implements JsExecutorInterface
     public function setAction(Model\UserAction $action)
     {
         $this->action = $action;
-        $this->afterActionInit($action);
+        $this->afterActionInit();
 
         // get necessary step need prior to execute action.
-        $this->steps = $this->getSteps($action);
+        $this->steps = $this->getSteps();
         if ($this->steps) {
             $this->title ??= $action->getDescription();
 
@@ -96,7 +96,7 @@ class ModalExecutor extends Modal implements JsExecutorInterface
         $this->action = $this->executeModelActionLoad($this->action);
 
         // Add buttons to modal for next and previous.
-        $this->addButtonAction($this->createButtonBar($this->action));
+        $this->addButtonAction($this->createButtonBar());
         $this->jsSetButtonsState($this->loader, $this->step);
         $this->runSteps();
     }

--- a/src/UserAction/PanelExecutor.php
+++ b/src/UserAction/PanelExecutor.php
@@ -64,7 +64,7 @@ class PanelExecutor extends Right implements JsExecutorInterface
      * to make sure that view id is properly set for loader and button
      * JS action to run properly.
      */
-    protected function afterActionInit(Model\UserAction $action): void
+    protected function afterActionInit(): void
     {
         $this->loader = Loader::addTo($this, ['ui' => $this->loaderUi, 'shim' => $this->loaderShim, 'loadEvent' => false]);
         $this->actionData = $this->loader->jsGetStoreData()['session'];
@@ -73,14 +73,14 @@ class PanelExecutor extends Right implements JsExecutorInterface
     public function setAction(Model\UserAction $action)
     {
         $this->action = $action;
-        $this->afterActionInit($action);
+        $this->afterActionInit();
 
         // get necessary step need prior to execute action.
-        $this->steps = $this->getSteps($action);
+        $this->steps = $this->getSteps();
         if ($this->steps) {
             $this->header->set($this->title ?? $action->getDescription());
             $this->step = $this->stickyGet('step') ?? $this->steps[0];
-            $this->add($this->createButtonBar($this->action)->setStyle(['text-align' => 'end']));
+            $this->add($this->createButtonBar()->setStyle(['text-align' => 'end']));
             $this->addStepList();
         }
 

--- a/src/UserAction/StepExecutorTrait.php
+++ b/src/UserAction/StepExecutorTrait.php
@@ -257,16 +257,16 @@ trait StepExecutorTrait
     /**
      * Get how many steps is required for this action.
      */
-    protected function getSteps(UserAction $action): array
+    protected function getSteps(): array
     {
         $steps = [];
-        if ($action->args) {
+        if ($this->action->args) {
             $steps[] = 'args';
         }
-        if ($action->fields) {
+        if ($this->action->fields) {
             $steps[] = 'fields';
         }
-        if ($action->preview) {
+        if ($this->action->preview) {
             $steps[] = 'preview';
         }
 
@@ -331,12 +331,12 @@ trait StepExecutorTrait
         return $this->step;
     }
 
-    protected function createButtonBar(Model\UserAction $action): View
+    protected function createButtonBar(): View
     {
         $this->buttonsView = (new View())->setStyle(['min-height' => '24px']);
         $this->prevStepButton = Button::addTo($this->buttonsView, ['Prev'])->setStyle(['float' => 'left !important']);
         $this->nextStepButton = Button::addTo($this->buttonsView, ['Next', 'class.blue' => true]);
-        $this->execActionButton = $this->getExecutorFactory()->createTrigger($action, ExecutorFactory::MODAL_BUTTON);
+        $this->execActionButton = $this->getExecutorFactory()->createTrigger($this->action, ExecutorFactory::MODAL_BUTTON);
         $this->buttonsView->add($this->execActionButton);
 
         return $this->buttonsView;

--- a/src/UserAction/VpExecutor.php
+++ b/src/UserAction/VpExecutor.php
@@ -75,7 +75,7 @@ class VpExecutor extends View implements JsExecutorInterface
      * to make sure that view id is properly set for loader and button
      * JS action to run properly.
      */
-    protected function afterActionInit(Model\UserAction $action): void
+    protected function afterActionInit(): void
     {
         $this->loader = Loader::addTo($this->vp, ['ui' => $this->loaderUi, 'shim' => $this->loaderShim]);
         $this->actionData = $this->loader->jsGetStoreData()['session'];
@@ -84,14 +84,14 @@ class VpExecutor extends View implements JsExecutorInterface
     public function setAction(Model\UserAction $action)
     {
         $this->action = $action;
-        $this->afterActionInit($action);
+        $this->afterActionInit();
 
         // get necessary step need prior to execute action.
-        $this->steps = $this->getSteps($action);
+        $this->steps = $this->getSteps();
         if ($this->steps) {
             $this->header->set($this->title ?? $action->getDescription());
             $this->step = $this->stickyGet('step') ?? $this->steps[0];
-            $this->vp->add($this->createButtonBar($this->action)->setStyle(['text-align' => 'end']));
+            $this->vp->add($this->createButtonBar()->setStyle(['text-align' => 'end']));
             $this->addStepList();
         }
 

--- a/tests-behat/sse.feature
+++ b/tests-behat/sse.feature
@@ -6,3 +6,10 @@ Feature: SSE
     When I press button "Turn Off"
     # TODO test SSE result compatible with Slow Chrome CI job
     # Then I should see "20%"
+
+  Scenario:
+    Then I should not see "This is my new text!"
+    When I press button "Click me to change my text"
+    When I press Modal button "Ok"
+    # TODO wait until SSE is complete
+    # Then I should see "This is my new text!"

--- a/tests-behat/useraction.feature
+++ b/tests-behat/useraction.feature
@@ -68,9 +68,7 @@ Feature: UserAction executor and UserConfirmation modal
     Then Toast display should contain text "Thank you Mr. at age 22"
 
   Scenario: testing JsCallbackExecutor with form input argument
-    Given I am on "tutorial/actions.php"
-    When I click link "Next"
-    When I click link "Next"
+    Given I am on "data-action/jsactions.php"
     When I fill field using "//input[../div[text()='Greet']]" with "Laura"
     When I press button "Greet"
-    Then Toast display should contain text "Hi Laura"
+    Then Toast display should contain text "Hello Laura"

--- a/tests-behat/useraction.feature
+++ b/tests-behat/useraction.feature
@@ -66,3 +66,11 @@ Feature: UserAction executor and UserConfirmation modal
     Then Panel is open with text "Gender = m / Age = 22"
     Then I press Panel button "Multi Step"
     Then Toast display should contain text "Thank you Mr. at age 22"
+
+  Scenario: testing JsCallbackExecutor with form input argument
+    Given I am on "tutorial/actions.php"
+    When I click link "Next"
+    When I click link "Next"
+    When I fill field using "//input[../div[text()='Greet']]" with "Laura"
+    When I press button "Greet"
+    Then Toast display should contain text "Hi Laura"


### PR DESCRIPTION
It was wrongly coded since ethernity (`JsCallbackExecutor::executeModelAction` does not accept args, args are defined by UA args) and since https://github.com/atk4/ui/pull/1980 (https://github.com/atk4/ui/commit/d2bfed8dae35366f1d3cf16cc4aca94bafad597a) a functional error was implied.