### PR TITLE
Always emit an exception when some expected POST param is not set

### DIFF
--- a/demos/interactive/sse.php
+++ b/demos/interactive/sse.php
@@ -56,9 +56,9 @@ Header::addTo($app, ['SSE operation with user confirmation']);
 $sse = JsSse::addTo($app);
 $button = Button::addTo($app, ['Click me to change my text']);
 
-$button->on('click', $sse->set(function (Jquery $jsChain) use ($sse, $button) {
+$button->on('click', $sse->set(function (Jquery $jsChain, string $newButtonText) use ($sse, $button) {
     $sse->send($button->js()->text('Please wait for 2 seconds...'));
     sleep(2);
 
-    return $button->js()->text($sse->args['newButtonText']);
+    return $button->js()->text($newButtonText);
 }, ['newButtonText' => 'This is my new text!']), ['confirm' => 'Please confirm that you wish to continue']);

--- a/src/Form.php
+++ b/src/Form.php
@@ -460,7 +460,7 @@ class Form extends View
             try {
                 // save field value only if field was editable in form at all
                 if (!$control->readOnly && !$control->disabled) {
-                    $control->set($this->getApp()->uiPersistence->typecastLoadField($control->entityField->getField(), $_POST[$k] ?? null));
+                    $control->set($this->getApp()->uiPersistence->typecastLoadField($control->entityField->getField(), $_POST[$k]));
                 }
             } catch (\Exception $e) {
                 $messages = [];

--- a/src/Form/Control/Multiline.php
+++ b/src/Form/Control/Multiline.php
@@ -681,7 +681,7 @@ class Multiline extends Form\Control
      */
     private function outputJson(): void
     {
-        switch ($_POST['__atkml_action'] ?? null) {
+        switch ($_POST['__atkml_action']) {
             case 'update-row':
                 $entity = $this->createDummyEntityFromPost($this->model);
                 $expressionValues = array_merge($this->getExpressionValues($entity), $this->getCallbackValues($entity));

--- a/src/Form/Control/Multiline.php
+++ b/src/Form/Control/Multiline.php
@@ -731,7 +731,7 @@ class Multiline extends Form\Control
 
             $field = $entity->getField($fieldName);
 
-            $value = $this->getApp()->uiPersistence->typecastLoadField($field, $_POST[$fieldName] ?? null);
+            $value = $this->getApp()->uiPersistence->typecastLoadField($field, $_POST[$fieldName]);
             if ($field->isEditable()) {
                 try {
                     $field->required = false;

--- a/src/Form/Control/ScopeBuilder.php
+++ b/src/Form/Control/ScopeBuilder.php
@@ -530,9 +530,9 @@ class ScopeBuilder extends Form\Control
      */
     public function queryToCondition(array $query): Scope\Condition
     {
-        $key = $query['rule'] ?? null;
-        $operator = $query['operator'] ?? null;
-        $value = $query['value'] ?? null;
+        $key = $query['rule'];
+        $operator = $query['operator'];
+        $value = $query['value'];
 
         switch ($operator) {
             case self::OPERATOR_EMPTY:

--- a/src/Form/Control/Upload.php
+++ b/src/Form/Control/Upload.php
@@ -185,7 +185,7 @@ class Upload extends Input
         $this->hasDeleteCb = true;
         if (($_POST['fUploadAction'] ?? null) === self::DELETE_ACTION) {
             $this->cb->set(function () use ($fx) {
-                $fileId = $_POST['fUploadId'] ?? null;
+                $fileId = $_POST['fUploadId'];
                 $this->addJsAction($fx($fileId));
 
                 return new JsBlock($this->jsActions);

--- a/src/JsCallback.php
+++ b/src/JsCallback.php
@@ -81,7 +81,7 @@ class JsCallback extends Callback
 
             $values = [];
             foreach (array_keys($this->args) as $key) {
-                $values[] = $_POST[$key] ?? null;
+                $values[] = $_POST[$key];
             }
 
             $response = $fx($chain, ...$values);

--- a/src/JsSse.php
+++ b/src/JsSse.php
@@ -56,6 +56,22 @@ class JsSse extends JsCallback
         return new JsBlock([(new Jquery($this->getOwner() /* TODO element and loader element should be passed explicitly */))->atkServerEvent($options)]);
     }
 
+    public function set($fx = null, $args = null)
+    {
+        if (!$fx instanceof \Closure) {
+            throw new \TypeError('$fx must be of type Closure');
+        }
+
+        return parent::set(function (Jquery $chain) use ($fx, $args) {
+            // TODO replace EventSource to support POST
+            // https://github.com/Yaffle/EventSource
+            // https://github.com/mpetazzoni/sse.js
+            // https://github.com/EventSource/eventsource
+            // https://github.com/byjg/jquery-sse
+            return $fx($chain, ...array_values($args ?? []));
+        });
+    }
+
     /**
      * Sending an SSE action.
      */

--- a/src/Table/Column/JsHeaderDropdownCallback.php
+++ b/src/Table/Column/JsHeaderDropdownCallback.php
@@ -18,7 +18,7 @@ class JsHeaderDropdownCallback extends JsCallback
     public function onSelectItem(\Closure $fx): void
     {
         $this->set(function () use ($fx) {
-            return $fx($_GET['id'] ?? null, $_GET['item'] ?? null);
+            return $fx($_GET['id'], $_GET['item']);
         });
     }
 }

--- a/src/View.php
+++ b/src/View.php
@@ -1028,7 +1028,7 @@ class View extends AbstractView
                 $cb->apiConfig = $defaults['apiConfig'];
             }
 
-            $cb->set(function ($chain, ...$args) use ($action) {
+            $cb->set(function (Jquery $chain, ...$args) use ($action) {
                 return $action($chain, ...$args);
             }, $arguments);
 

--- a/src/VueComponent/InlineEdit.php
+++ b/src/VueComponent/InlineEdit.php
@@ -95,10 +95,10 @@ class InlineEdit extends View
         }
 
         if ($this->autoSave && $this->model->isLoaded()) {
-            $value = $_POST['value'] ?? null;
-            $this->cb->set(function () use ($value) {
+            $this->cb->set(function () {
+                $postValue = $_POST['value'];
                 try {
-                    $this->model->set($this->fieldName, $this->getApp()->uiPersistence->typecastLoadField($this->model->getField($this->fieldName), $value));
+                    $this->model->set($this->fieldName, $this->getApp()->uiPersistence->typecastLoadField($this->model->getField($this->fieldName), $postValue));
                     $this->model->save();
 
                     return $this->jsSuccess('Update saved');
@@ -106,7 +106,7 @@ class InlineEdit extends View
                     $this->getApp()->terminateJson([
                         'success' => true,
                         'hasValidationError' => true,
-                        'atkjs' => $this->jsError(($this->formatErrorMsg)($e, $value))->jsRender(),
+                        'atkjs' => $this->jsError(($this->formatErrorMsg)($e, $postValue))->jsRender(),
                     ]);
                 }
             });

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -65,7 +65,7 @@ class FormTest extends TestCase
     public function assertFormSubmit(array $postData, \Closure $submitFx = null, \Closure $checkExpectedErrorsFx = null): void
     {
         $wasSubmitCalled = false;
-        $_POST = $postData;
+        $_POST = array_merge(array_map(fn () => '', $this->form->controls), $postData);
         try {
             // trigger callback
             $_GET[Callback::URL_QUERY_TRIGGER_PREFIX . 'atk_submit'] = 'ajax';
@@ -115,8 +115,8 @@ class FormTest extends TestCase
 
         // fake some POST data
         $this->assertFormSubmit(['email' => 'john@yahoo.com', 'is_admin' => '1'], function (Model $m) {
-            // field has default, but form didn't send value back
-            self::assertNull($m->get('name'));
+            // field has default, but form send back empty value
+            self::assertSame('', $m->get('name'));
 
             self::assertSame('john@yahoo.com', $m->get('email'));
 
@@ -148,7 +148,7 @@ class FormTest extends TestCase
         self::assertTrue($matched, 'Form control ' . $field . ' did not produce error');
     }
 
-    public function assertFromControlNoErrors(string $field): void
+    public function assertFormControlNoErrors(string $field): void
     {
         $n = preg_match_all('~\.form\(\'add prompt\', \'([^\']*)\', \'([^\']*)\'\)~', $this->formError, $matchesAll, \PREG_SET_ORDER);
         self::assertGreaterThan(0, $n);
@@ -159,7 +159,7 @@ class FormTest extends TestCase
         }
     }
 
-    public function testSubmitError(): void
+    public function testFormSubmitError(): void
     {
         $m = new Model();
 
@@ -180,11 +180,11 @@ class FormTest extends TestCase
             $this->assertFormControlError('opt1', 'not one of the allowed values');
 
             // user didn't select any option here
-            $this->assertFromControlNoErrors('opt2');
+            $this->assertFormControlNoErrors('opt2');
 
             // dropdown insists for value to be there
-            $this->assertFormControlError('opt3', 'Must not be null');
-            $this->assertFromControlNoErrors('opt3_z');
+            $this->assertFormControlNoErrors('opt3');
+            $this->assertFormControlNoErrors('opt3_z');
             $this->assertFormControlError('opt4', 'Must not be empty');
             $this->assertFormControlError('opt4_z', 'Must not be empty');
         });

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -11,6 +11,7 @@ use Atk4\Ui\Callback;
 use Atk4\Ui\Console;
 use Atk4\Ui\Exception;
 use Atk4\Ui\JsCallback;
+use Atk4\Ui\JsSse;
 use Atk4\Ui\Loader;
 use Atk4\Ui\Modal;
 use Atk4\Ui\Popup;
@@ -172,6 +173,7 @@ class ViewTest extends TestCase
         return [
             [Console::class],
             [JsCallback::class],
+            [JsSse::class],
             [Loader::class],
             [Modal::class],
             [Popup::class],


### PR DESCRIPTION
`$_POST[$k] ?? null` fallback is unwanted as it can signal some POST params not passed correctly.

(a php notice is emit and it is converted to exception by our error handler)

When form is generated using `Form` or other atk4/ui components, the params should be always set and no BC break should be implied.