### PR TITLE
Rename Form\Control\Dropdown::isMultiple property

### DIFF
--- a/demos/form-control/dropdown-plus.php
+++ b/demos/form-control/dropdown-plus.php
@@ -101,7 +101,7 @@ $form->addControl('multi', [
     Form\Control\Dropdown::class,
     'caption' => 'Multiple selection',
     'empty' => 'Choose has many options needed',
-    'isMultiple' => true,
+    'multiple' => true,
     'values' => ['default' => 'Default', 'option1' => 'Option 1', 'option2' => 'Option 2'],
 ]);
 

--- a/demos/form-control/lookup-dep.php
+++ b/demos/form-control/lookup-dep.php
@@ -23,7 +23,7 @@ $form->addControl('starts_with', [
         'b' => 'Letter B',
         'c' => 'Letter C',
     ],
-    'isMultiple' => true,
+    'multiple' => true,
     'hint' => 'Select start letter that lookup selection of Country will depend on.',
     'placeholder' => 'Search for country starting with ...',
 ]);

--- a/docs/form-control.rst
+++ b/docs/form-control.rst
@@ -439,7 +439,7 @@ Here you can pass an array of Fomantic-UI dropdown options (https://fomantic-ui.
         'selectOnKeydown' => false,
     ]]);
 
-.. php:attr:: isMultiple
+.. php:attr:: multiple
 
 If set to true, multiple items can be selected in Dropdown. They will be sent comma seperated (value1,value2,value3) on form submit.
 
@@ -452,7 +452,7 @@ See this example from Model class init method::
         'ui' => [
             'form' => [
                 \Atk4\Ui\Form\Control\Dropdown::class,
-                'isMultiple' => true,
+                'multiple' => true,
                 'model' => $expr_model,
             ],
             'table' => [

--- a/src/Form/Control/Dropdown.php
+++ b/src/Form/Control/Dropdown.php
@@ -53,7 +53,7 @@ class Dropdown extends Input
      *
      * @var bool
      */
-    public $isMultiple = false;
+    public $multiple = false;
 
     /**
      * Here a custom function for creating the HTML of each dropdown option
@@ -189,7 +189,7 @@ class Dropdown extends Input
     protected function htmlRenderValue(): void
     {
         // add selection only if no value is required and Dropdown has no multiple selections enabled
-        if ($this->entityField !== null && !$this->entityField->getField()->required && !$this->isMultiple) {
+        if ($this->entityField !== null && !$this->entityField->getField()->required && !$this->multiple) {
             $this->_tItem->set('value', '');
             $this->_tItem->set('title', $this->empty);
             $this->template->dangerouslyAppendHtml('Item', $this->_tItem->renderToHtml());
@@ -219,14 +219,14 @@ class Dropdown extends Input
 
     protected function renderView(): void
     {
-        if ($this->isMultiple) {
+        if ($this->multiple) {
             $this->addClass('multiple');
         }
 
         if ($this->readOnly || $this->disabled) {
             $this->setDropdownOption('allowTab', false);
             $this->removeClass('search');
-            if ($this->isMultiple) {
+            if ($this->multiple) {
                 $this->js(true)->find('a i.delete.icon')->attr('class', 'disabled');
             }
         }

--- a/src/Form/Control/DropdownCascade.php
+++ b/src/Form/Control/DropdownCascade.php
@@ -114,7 +114,7 @@ class DropdownCascade extends Dropdown
     protected function renderView(): void
     {
         // multiple selection is not supported
-        $this->isMultiple = false;
+        $this->multiple = false;
 
         parent::renderView();
     }

--- a/src/Form/Control/Radio.php
+++ b/src/Form/Control/Radio.php
@@ -38,10 +38,6 @@ class Radio extends Form\Control
 
         $this->lister->setModel($this->model);
 
-        if ($this->disabled) {
-            $this->addClass('disabled');
-        }
-
         $this->lister->onHook(Lister::HOOK_BEFORE_ROW, function (Lister $lister) use ($value) {
             if ($this->readOnly) {
                 $lister->tRow->dangerouslySetHtml('disabled', $value !== (string) $lister->model->getId() ? 'disabled="disabled"' : '');


### PR DESCRIPTION
To unify the naming with `Lookup` and other properties like `readOnly` which does not use `is` prefix neither.

related with #1020