### PR TITLE
Narrow URL array phpdoc types

### DIFF
--- a/demos/form/html-layout.php
+++ b/demos/form/html-layout.php
@@ -16,7 +16,7 @@ use Atk4\Ui\View;
 /** @var \Atk4\Ui\App $app */
 require_once __DIR__ . '/../init-app.php';
 
-Header::addTo($app, ['Display form using Html template', 'subHeader' => 'Fully control how to display fields.']);
+Header::addTo($app, ['Display form using HTML template', 'subHeader' => 'Fully control how to display fields.']);
 
 $tabs = Tabs::addTo($app);
 

--- a/demos/others/sticky.php
+++ b/demos/others/sticky.php
@@ -37,7 +37,6 @@ Header::addTo($app, ['URLs presented by a blank app']);
 Button::addTo($app, [$app->url()]);
 Button::addTo($app, [$app->url(['b' => 2])]);
 Button::addTo($app, [$app->url(['b' => 2, 'c' => false])]);
-Button::addTo($app, [$app->url(['b' => 2, 'c' => null])]);
 Button::addTo($app, [$app->url(['b' => 2, 'c' => 'abc'])]);
 
 // Sticky for xx=
@@ -45,7 +44,6 @@ Header::addTo($app, ['Now add sticky for xx=' . $app->stickyGet('xx')]);
 Button::addTo($app, [$app->url()]);
 Button::addTo($app, [$app->url(['b' => 2])]);
 Button::addTo($app, [$app->url(['b' => 2, 'c' => false])]);
-Button::addTo($app, [$app->url(['b' => 2, 'c' => null])]);
 Button::addTo($app, [$app->url(['b' => 2, 'c' => 'abc'])]);
 
 // Sticky for c=
@@ -53,7 +51,6 @@ Header::addTo($app, ['Now also add sticky for c=' . $app->stickyGet('c')]);
 Button::addTo($app, [$app->url()]);
 Button::addTo($app, [$app->url(['b' => 2])]);
 Button::addTo($app, [$app->url(['b' => 2, 'c' => false])]);
-Button::addTo($app, [$app->url(['b' => 2, 'c' => null])]);
 Button::addTo($app, [$app->url(['b' => 2, 'c' => 'abc'])]);
 
 // Various ways to build links

--- a/docs/multiline.rst
+++ b/docs/multiline.rst
@@ -12,7 +12,7 @@ multiple Model fields related to a single record reference into another Model.
 
 A good example is a user who can have many addresses.
 In this example, the Model `User` containsMany `Addresses`. Since the Model field addresses is defined with containsMany()
-inside the main model, Multiline will store addresses content as Json value inside the table blobl addresses field.
+inside the main model, Multiline will store addresses content as JSON value inside the table blobl addresses field.
 
 For example::
 

--- a/src/App.php
+++ b/src/App.php
@@ -687,9 +687,9 @@ class App
     /**
      * Build a URL that application can use for loading HTML data.
      *
-     * @param string|array<0|string, string> $page                URL as string or array with page name as first element and other GET arguments
-     * @param bool                           $useRequestUrl       Simply return $_SERVER['REQUEST_URI'] if needed
-     * @param array<string, string>          $extraRequestUrlArgs additional URL arguments, deleting sticky can delete them
+     * @param array|string $page                URL as string or array with page name as first element and other GET arguments
+     * @param bool         $useRequestUrl       Simply return $_SERVER['REQUEST_URI'] if needed
+     * @param array        $extraRequestUrlArgs additional URL arguments, deleting sticky can delete them
      */
     public function url($page = [], $useRequestUrl = false, $extraRequestUrlArgs = []): string
     {
@@ -751,9 +751,9 @@ class App
      * Build a URL that application can use for JS callbacks. Some framework integration will use a different routing
      * mechanism for NON-HTML response.
      *
-     * @param string|array<0|string, string> $page                URL as string or array with page name as first element and other GET arguments
-     * @param bool                           $useRequestUrl       Simply return $_SERVER['REQUEST_URI'] if needed
-     * @param array<string, string>          $extraRequestUrlArgs additional URL arguments, deleting sticky can delete them
+     * @param array|string $page                URL as string or array with page name as first element and other GET arguments
+     * @param bool         $useRequestUrl       Simply return $_SERVER['REQUEST_URI'] if needed
+     * @param array        $extraRequestUrlArgs additional URL arguments, deleting sticky can delete them
      */
     public function jsUrl($page = [], $useRequestUrl = false, $extraRequestUrlArgs = []): string
     {
@@ -804,7 +804,7 @@ class App
     /**
      * A convenient wrapper for sending user to another page.
      *
-     * @param string|array<0|string, string> $page
+     * @param array|string $page Destination page
      */
     public function redirect($page, bool $permanent = false): void
     {
@@ -816,7 +816,7 @@ class App
     /**
      * Generate action for redirecting user to another page.
      *
-     * @param string|array<0|string, string> $page
+     * @param string|array $page Destination URL or page/arguments
      */
     public function jsRedirect($page, bool $newWindow = false): JsExpressionable
     {

--- a/src/App.php
+++ b/src/App.php
@@ -687,9 +687,9 @@ class App
     /**
      * Build a URL that application can use for loading HTML data.
      *
-     * @param array|string $page                URL as string or array with page name as first element and other GET arguments
-     * @param bool         $useRequestUrl       Simply return $_SERVER['REQUEST_URI'] if needed
-     * @param array        $extraRequestUrlArgs additional URL arguments, deleting sticky can delete them
+     * @param string|array<0|string, string> $page                URL as string or array with page name as first element and other GET arguments
+     * @param bool                           $useRequestUrl       Simply return $_SERVER['REQUEST_URI'] if needed
+     * @param array<string, string>          $extraRequestUrlArgs additional URL arguments, deleting sticky can delete them
      */
     public function url($page = [], $useRequestUrl = false, $extraRequestUrlArgs = []): string
     {
@@ -751,9 +751,9 @@ class App
      * Build a URL that application can use for JS callbacks. Some framework integration will use a different routing
      * mechanism for NON-HTML response.
      *
-     * @param array|string $page                URL as string or array with page name as first element and other GET arguments
-     * @param bool         $useRequestUrl       Simply return $_SERVER['REQUEST_URI'] if needed
-     * @param array        $extraRequestUrlArgs additional URL arguments, deleting sticky can delete them
+     * @param string|array<0|string, string> $page                URL as string or array with page name as first element and other GET arguments
+     * @param bool                           $useRequestUrl       Simply return $_SERVER['REQUEST_URI'] if needed
+     * @param array<string, string>          $extraRequestUrlArgs additional URL arguments, deleting sticky can delete them
      */
     public function jsUrl($page = [], $useRequestUrl = false, $extraRequestUrlArgs = []): string
     {
@@ -804,7 +804,7 @@ class App
     /**
      * A convenient wrapper for sending user to another page.
      *
-     * @param array|string $page Destination page
+     * @param string|array<0|string, string> $page
      */
     public function redirect($page, bool $permanent = false): void
     {
@@ -816,7 +816,7 @@ class App
     /**
      * Generate action for redirecting user to another page.
      *
-     * @param string|array $page Destination URL or page/arguments
+     * @param string|array<0|string, string> $page
      */
     public function jsRedirect($page, bool $newWindow = false): JsExpressionable
     {

--- a/src/App.php
+++ b/src/App.php
@@ -687,9 +687,9 @@ class App
     /**
      * Build a URL that application can use for loading HTML data.
      *
-     * @param array|string $page                URL as string or array with page name as first element and other GET arguments
-     * @param bool         $useRequestUrl       Simply return $_SERVER['REQUEST_URI'] if needed
-     * @param array        $extraRequestUrlArgs additional URL arguments, deleting sticky can delete them
+     * @param string|array<0|string, mixed> $page                URL as string or array with page name as first element and other GET arguments
+     * @param bool                          $useRequestUrl       Simply return $_SERVER['REQUEST_URI'] if needed
+     * @param array<string, string>         $extraRequestUrlArgs additional URL arguments, deleting sticky can delete them
      */
     public function url($page = [], $useRequestUrl = false, $extraRequestUrlArgs = []): string
     {
@@ -751,9 +751,9 @@ class App
      * Build a URL that application can use for JS callbacks. Some framework integration will use a different routing
      * mechanism for NON-HTML response.
      *
-     * @param array|string $page                URL as string or array with page name as first element and other GET arguments
-     * @param bool         $useRequestUrl       Simply return $_SERVER['REQUEST_URI'] if needed
-     * @param array        $extraRequestUrlArgs additional URL arguments, deleting sticky can delete them
+     * @param string|array<0|string, mixed> $page                URL as string or array with page name as first element and other GET arguments
+     * @param bool                          $useRequestUrl       Simply return $_SERVER['REQUEST_URI'] if needed
+     * @param array<string, string>         $extraRequestUrlArgs additional URL arguments, deleting sticky can delete them
      */
     public function jsUrl($page = [], $useRequestUrl = false, $extraRequestUrlArgs = []): string
     {
@@ -804,7 +804,7 @@ class App
     /**
      * A convenient wrapper for sending user to another page.
      *
-     * @param array|string $page Destination page
+     * @param string|array<0|string, mixed> $page
      */
     public function redirect($page, bool $permanent = false): void
     {
@@ -816,7 +816,7 @@ class App
     /**
      * Generate action for redirecting user to another page.
      *
-     * @param string|array $page Destination URL or page/arguments
+     * @param string|array<0|string, mixed> $page
      */
     public function jsRedirect($page, bool $newWindow = false): JsExpressionable
     {

--- a/src/App.php
+++ b/src/App.php
@@ -123,9 +123,6 @@ class App
     /** @var bool Call exit in place of throw Exception when Application need to exit. */
     public $callExit = true;
 
-    /** @var string|null */
-    public $page;
-
     /** @var array global sticky arguments */
     protected array $stickyGetArguments = [
         '__atk_json' => false,
@@ -700,22 +697,23 @@ class App
             $page = $_SERVER['REQUEST_URI'];
         }
 
-        if ($this->page === null) {
-            $requestUrl = $this->getRequestUrl();
-            if (substr($requestUrl, -1, 1) === '/') {
-                $this->page = 'index';
-            } else {
-                $this->page = basename($requestUrl, $this->urlBuildingExt);
-            }
-        }
-
         $pagePath = '';
         if (is_string($page)) {
             $page_arr = explode('?', $page, 2);
             $pagePath = $page_arr[0];
             parse_str($page_arr[1] ?? '', $page);
         } else {
-            $pagePath = $page[0] ?? $this->page; // use current page by default
+            if (isset($page[0])) {
+                $pagePath = $page[0];
+            } else {
+                // use current page by default
+                $requestUrl = $this->getRequestUrl();
+                if (substr($requestUrl, -1, 1) === '/') {
+                    $pagePath = 'index';
+                } else {
+                    $pagePath = basename($requestUrl, $this->urlBuildingExt);
+                }
+            }
             unset($page[0]);
             if ($pagePath) {
                 $pagePath .= $this->urlBuildingExt;

--- a/src/App.php
+++ b/src/App.php
@@ -735,10 +735,8 @@ class App
         foreach ($page as $k => $v) {
             if ($v === false) {
                 unset($args[$k]);
-            } elseif (is_string($v) || is_int($v)) {
-                $args[$k] = $v;
             } else {
-                throw new \TypeError('Unexpected type: ' . get_debug_type($v));
+                $args[$k] = $v;
             }
         }
 

--- a/src/App.php
+++ b/src/App.php
@@ -733,10 +733,12 @@ class App
 
         // add arguments
         foreach ($page as $k => $v) {
-            if ($v === null || $v === false) {
+            if ($v === false) {
                 unset($args[$k]);
-            } else {
+            } elseif (is_string($v) || is_int($v)) {
                 $args[$k] = $v;
+            } else {
+                throw new \TypeError('Unexpected type: ' . get_debug_type($v));
             }
         }
 

--- a/src/App.php
+++ b/src/App.php
@@ -687,9 +687,9 @@ class App
     /**
      * Build a URL that application can use for loading HTML data.
      *
-     * @param string|array<0|string, mixed> $page                URL as string or array with page name as first element and other GET arguments
-     * @param bool                          $useRequestUrl       Simply return $_SERVER['REQUEST_URI'] if needed
-     * @param array<string, string>         $extraRequestUrlArgs additional URL arguments, deleting sticky can delete them
+     * @param string|array<0|string, string|int|false> $page                URL as string or array with page name as first element and other GET arguments
+     * @param bool                                     $useRequestUrl       Simply return $_SERVER['REQUEST_URI'] if needed
+     * @param array<string, string>                    $extraRequestUrlArgs additional URL arguments, deleting sticky can delete them
      */
     public function url($page = [], $useRequestUrl = false, $extraRequestUrlArgs = []): string
     {
@@ -751,9 +751,9 @@ class App
      * Build a URL that application can use for JS callbacks. Some framework integration will use a different routing
      * mechanism for NON-HTML response.
      *
-     * @param string|array<0|string, mixed> $page                URL as string or array with page name as first element and other GET arguments
-     * @param bool                          $useRequestUrl       Simply return $_SERVER['REQUEST_URI'] if needed
-     * @param array<string, string>         $extraRequestUrlArgs additional URL arguments, deleting sticky can delete them
+     * @param string|array<0|string, string|int|false> $page                URL as string or array with page name as first element and other GET arguments
+     * @param bool                                     $useRequestUrl       Simply return $_SERVER['REQUEST_URI'] if needed
+     * @param array<string, string>                    $extraRequestUrlArgs additional URL arguments, deleting sticky can delete them
      */
     public function jsUrl($page = [], $useRequestUrl = false, $extraRequestUrlArgs = []): string
     {
@@ -804,7 +804,7 @@ class App
     /**
      * A convenient wrapper for sending user to another page.
      *
-     * @param string|array<0|string, mixed> $page
+     * @param string|array<0|string, string|int|false> $page
      */
     public function redirect($page, bool $permanent = false): void
     {
@@ -816,7 +816,7 @@ class App
     /**
      * Generate action for redirecting user to another page.
      *
-     * @param string|array<0|string, mixed> $page
+     * @param string|array<0|string, string|int|false> $page
      */
     public function jsRedirect($page, bool $newWindow = false): JsExpressionable
     {

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -19,8 +19,8 @@ class Breadcrumb extends Lister
     /**
      * Adds a new link that will appear on the right.
      *
-     * @param string                        $section Title of link
-     * @param string|array<0|string, mixed> $link    Link itself
+     * @param string                                   $section Title of link
+     * @param string|array<0|string, string|int|false> $link    Link itself
      *
      * @return $this
      */

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -19,8 +19,8 @@ class Breadcrumb extends Lister
     /**
      * Adds a new link that will appear on the right.
      *
-     * @param string       $section Title of link
-     * @param string|array $link    Link itself
+     * @param string                        $section Title of link
+     * @param string|array<0|string, mixed> $link    Link itself
      *
      * @return $this
      */

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -19,8 +19,8 @@ class Breadcrumb extends Lister
     /**
      * Adds a new link that will appear on the right.
      *
-     * @param string                         $section Title of link
-     * @param string|array<0|string, string> $link    Link itself
+     * @param string       $section Title of link
+     * @param string|array $link    Link itself
      *
      * @return $this
      */

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -19,8 +19,8 @@ class Breadcrumb extends Lister
     /**
      * Adds a new link that will appear on the right.
      *
-     * @param string       $section Title of link
-     * @param string|array $link    Link itself
+     * @param string                         $section Title of link
+     * @param string|array<0|string, string> $link    Link itself
      *
      * @return $this
      */

--- a/src/Form.php
+++ b/src/Form.php
@@ -58,7 +58,7 @@ class Form extends View
     public $canLeave = true;
 
     /**
-     * Html <form> element, all inner form controls are linked to it on render
+     * HTML <form> element, all inner form controls are linked to it on render
      * with HTML form="form_id" attribute.
      *
      * @var View

--- a/src/Form/Control/Dropdown.php
+++ b/src/Form/Control/Dropdown.php
@@ -225,7 +225,6 @@ class Dropdown extends Input
         }
 
         if ($this->readOnly || $this->disabled) {
-            $this->setDropdownOption('allowTab', false);
             if ($this->multiple) {
                 $this->jsDropdown(true)->find('a i.delete.icon')->attr('class', 'disabled');
             }
@@ -238,7 +237,6 @@ class Dropdown extends Input
             $this->template->set('disabledClass', 'read-only');
             $this->template->dangerouslySetHtml('disabled', 'readonly="readonly"');
 
-            $this->setDropdownOption('allowTab', false);
             $this->setDropdownOption('onShow', new JsFunction([], [new JsExpression('return false')]));
         }
 

--- a/src/Form/Control/Lookup.php
+++ b/src/Form/Control/Lookup.php
@@ -365,13 +365,10 @@ class Lookup extends Input
         if ($this->disabled) {
             $this->template->set('disabledClass', 'disabled');
             $this->template->dangerouslySetHtml('disabled', 'disabled="disabled"');
-
-            $this->settings['allowTab'] = false;
         } elseif ($this->readOnly) {
             $this->template->set('disabledClass', 'read-only');
             $this->template->dangerouslySetHtml('disabled', 'readonly="readonly"');
 
-            $this->settings['allowTab'] = false;
             $this->settings['apiSettings'] = null;
             $this->settings['onShow'] = new JsFunction([], [new JsExpression('return false')]);
         }

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -186,8 +186,8 @@ class Grid extends View
      *
      * If an array is passed, it will also add an ItemPerPageSelector to paginator.
      *
-     * @param int|list<int> $ipp
-     * @param string        $label
+     * @param int|array $ipp
+     * @param string    $label
      */
     public function setIpp($ipp, $label = 'Items per page:'): void
     {
@@ -201,12 +201,12 @@ class Grid extends View
     /**
      * Add ItemsPerPageSelector View in grid menu or paginator in order to dynamically setup number of item per page.
      *
-     * @param list<int> $items an array of item's per page value
-     * @param string    $label the memu item label
+     * @param array  $items an array of item's per page value
+     * @param string $label the memu item label
      *
      * @return $this
      */
-    public function addItemsPerPageSelector(array $items = [10, 25, 50, 100], $label = 'Items per page:')
+    public function addItemsPerPageSelector($items = [10, 25, 50, 100], $label = 'Items per page:')
     {
         $ipp = (int) $this->container->stickyGet('ipp');
         if ($ipp) {

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -186,8 +186,8 @@ class Grid extends View
      *
      * If an array is passed, it will also add an ItemPerPageSelector to paginator.
      *
-     * @param int|array $ipp
-     * @param string    $label
+     * @param int|list<int> $ipp
+     * @param string        $label
      */
     public function setIpp($ipp, $label = 'Items per page:'): void
     {
@@ -201,12 +201,12 @@ class Grid extends View
     /**
      * Add ItemsPerPageSelector View in grid menu or paginator in order to dynamically setup number of item per page.
      *
-     * @param array  $items an array of item's per page value
-     * @param string $label the memu item label
+     * @param list<int> $items an array of item's per page value
+     * @param string    $label the memu item label
      *
      * @return $this
      */
-    public function addItemsPerPageSelector($items = [10, 25, 50, 100], $label = 'Items per page:')
+    public function addItemsPerPageSelector(array $items = [10, 25, 50, 100], $label = 'Items per page:')
     {
         $ipp = (int) $this->container->stickyGet('ipp');
         if ($ipp) {

--- a/src/ItemsPerPageSelector.php
+++ b/src/ItemsPerPageSelector.php
@@ -15,7 +15,7 @@ class ItemsPerPageSelector extends View
     public $defaultTemplate = 'pagelength.html';
     public $ui = 'selection compact dropdown';
 
-    /** @var array Default page length menu items. */
+    /** @var list<int> Default page length menu items. */
     public $pageLengthItems = [10, 25, 50, 100];
 
     /**

--- a/src/ItemsPerPageSelector.php
+++ b/src/ItemsPerPageSelector.php
@@ -15,7 +15,7 @@ class ItemsPerPageSelector extends View
     public $defaultTemplate = 'pagelength.html';
     public $ui = 'selection compact dropdown';
 
-    /** @var list<int> Default page length menu items. */
+    /** @var array Default page length menu items. */
     public $pageLengthItems = [10, 25, 50, 100];
 
     /**

--- a/src/JsSearch.php
+++ b/src/JsSearch.php
@@ -52,6 +52,11 @@ class JsSearch extends View
      */
     public $useAjax = true;
 
+    public function link($url, $target = null)
+    {
+        return parent::link($url, $target);
+    }
+
     /** @var string ui CSS classes */
     public $button = 'ui mini transparent basic button';
     /** @var string */

--- a/src/JsSearch.php
+++ b/src/JsSearch.php
@@ -52,11 +52,6 @@ class JsSearch extends View
      */
     public $useAjax = true;
 
-    public function link($url, $target = null)
-    {
-        return parent::link($url, $target);
-    }
-
     /** @var string ui CSS classes */
     public $button = 'ui mini transparent basic button';
     /** @var string */

--- a/src/JsSortable.php
+++ b/src/JsSortable.php
@@ -81,7 +81,7 @@ class JsSortable extends JsCallback
     /**
      * Return JS action to retrieve order.
      *
-     * @param array|null $urlOptions
+     * @param array<string, string>|null $urlOptions
      *
      * @return JsChain
      */

--- a/src/JsSortable.php
+++ b/src/JsSortable.php
@@ -81,7 +81,7 @@ class JsSortable extends JsCallback
     /**
      * Return JS action to retrieve order.
      *
-     * @param array<string, string>|null $urlOptions
+     * @param array|null $urlOptions
      *
      * @return JsChain
      */

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -39,7 +39,7 @@ class Loader extends View
     /** @var Callback for triggering */
     public $cb;
 
-    /** @var array Url arguments. */
+    /** @var array URL arguments. */
     public $urlArgs = [];
 
     protected function init(): void

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -36,8 +36,8 @@ class Menu extends View
     /**
      * $seed can also be name here.
      *
-     * @param string|array|MenuItem                                            $item
-     * @param string|array<0|string, string>|JsExpressionable|Model\UserAction $action
+     * @param string|array|MenuItem                          $item
+     * @param string|array|JsExpressionable|Model\UserAction $action
      *
      * @return MenuItem
      */

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -36,8 +36,8 @@ class Menu extends View
     /**
      * $seed can also be name here.
      *
-     * @param string|array|MenuItem                                           $item
-     * @param string|array<0|string, mixed>|JsExpressionable|Model\UserAction $action
+     * @param string|array|MenuItem                                                      $item
+     * @param string|array<0|string, string|int|false>|JsExpressionable|Model\UserAction $action
      *
      * @return MenuItem
      */

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -36,8 +36,8 @@ class Menu extends View
     /**
      * $seed can also be name here.
      *
-     * @param string|array|MenuItem                          $item
-     * @param string|array|JsExpressionable|Model\UserAction $action
+     * @param string|array|MenuItem                                           $item
+     * @param string|array<0|string, mixed>|JsExpressionable|Model\UserAction $action
      *
      * @return MenuItem
      */

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -36,8 +36,8 @@ class Menu extends View
     /**
      * $seed can also be name here.
      *
-     * @param string|array|MenuItem                          $item
-     * @param string|array|JsExpressionable|Model\UserAction $action
+     * @param string|array|MenuItem                                            $item
+     * @param string|array<0|string, string>|JsExpressionable|Model\UserAction $action
      *
      * @return MenuItem
      */

--- a/src/Panel/Right.php
+++ b/src/Panel/Right.php
@@ -95,10 +95,10 @@ class Right extends View implements Loadable
     /**
      * Return JS expression need to open panel via JS panelService.
      *
-     * @param array            $urlArgs       the argument to include when dynamic content panel open
-     * @param array            $dataAttribute the data attribute name to include in reload from the triggering element
-     * @param string|null      $activeCss     the CSS class name to apply on triggering element when panel is open
-     * @param JsExpressionable $jsTrigger     JS expression that trigger panel to open. Default = $(this).
+     * @param array<string, string> $urlArgs       the argument to include when dynamic content panel open
+     * @param array                 $dataAttribute the data attribute name to include in reload from the triggering element
+     * @param string|null           $activeCss     the CSS class name to apply on triggering element when panel is open
+     * @param JsExpressionable      $jsTrigger     JS expression that trigger panel to open. Default = $(this).
      */
     public function jsOpen(array $urlArgs = [], array $dataAttribute = [], string $activeCss = null, JsExpressionable $jsTrigger = null): JsExpressionable
     {

--- a/src/Panel/Right.php
+++ b/src/Panel/Right.php
@@ -95,10 +95,10 @@ class Right extends View implements Loadable
     /**
      * Return JS expression need to open panel via JS panelService.
      *
-     * @param array<string, string> $urlArgs       the argument to include when dynamic content panel open
-     * @param array                 $dataAttribute the data attribute name to include in reload from the triggering element
-     * @param string|null           $activeCss     the CSS class name to apply on triggering element when panel is open
-     * @param JsExpressionable      $jsTrigger     JS expression that trigger panel to open. Default = $(this).
+     * @param array            $urlArgs       the argument to include when dynamic content panel open
+     * @param array            $dataAttribute the data attribute name to include in reload from the triggering element
+     * @param string|null      $activeCss     the CSS class name to apply on triggering element when panel is open
+     * @param JsExpressionable $jsTrigger     JS expression that trigger panel to open. Default = $(this).
      */
     public function jsOpen(array $urlArgs = [], array $dataAttribute = [], string $activeCss = null, JsExpressionable $jsTrigger = null): JsExpressionable
     {

--- a/src/Table/Column/Link.php
+++ b/src/Table/Column/Link.php
@@ -26,20 +26,20 @@ class Link extends Table\Column
      * If $url is set up, we will use pattern-matching to fill-in any part of this
      * with values of the model.
      *
-     * @var string|HtmlTemplate
+     * @var string|HtmlTemplate Destination definition
      */
     public $url;
 
     /**
      * If string 'example', then will be passed to $app->url('example') along with any defined arguments.
-     * If set as array, then non-0 key/values will be also passed to the URL:
+     * If set as arrray, then non-0 key/values will be also passed to the URL:
      *  $page = ['example', 'type' => '123'];.
      *
      * $url = $app->url(['example', 'type' => '123']);
      *
-     * In addition to above "args" refer to values picked up from a current row.
+     * In addition to abpove "args" refer to values picked up from a current row.
      *
-     * @var string|array<0|string, string>|null
+     * @var string|array|null
      */
     public $page;
 
@@ -57,7 +57,7 @@ class Link extends Table\Column
      * You can also pass non-key arguments ['id', 'title'] and they will be added up
      * as ?id=4&title=John%20Smith
      *
-     * @var array<int|string, string>
+     * @var array
      */
     public $args = [];
 
@@ -82,7 +82,7 @@ class Link extends Table\Column
     public $forceDownload = false;
 
     /**
-     * @param string|array<0|string, string> $page
+     * @param string|array $page
      */
     public function __construct($page = [], array $args = [], array $defaults = [])
     {
@@ -148,16 +148,16 @@ class Link extends Table\Column
             return ['c_' . $this->shortName => $this->url->set($rowValues)->renderToHtml()];
         }
 
-        $page = $this->page ?? [];
+        $p = $this->page ?? [];
 
         foreach ($this->args as $key => $val) {
             if (is_int($key)) {
                 $key = $val;
             }
 
-            $page[$key] = $row->get($val);
+            $p[$key] = $row->get($val);
         }
 
-        return ['c_' . $this->shortName => $this->table->url($page)];
+        return ['c_' . $this->shortName => $this->table->url($p)];
     }
 }

--- a/src/Table/Column/Link.php
+++ b/src/Table/Column/Link.php
@@ -87,16 +87,16 @@ class Link extends Table\Column
     public function __construct($page = [], array $args = [], array $defaults = [])
     {
         if (is_array($page)) {
-            $page = ['page' => $page];
+            $defaults['page'] = $page;
         } else {
-            $page = ['url' => $page];
+            $defaults['url'] = $page;
         }
 
         if ($args) {
-            $page['args'] = $args;
+            $defaults['args'] = $args;
         }
 
-        parent::__construct(array_replace($defaults, $page));
+        parent::__construct($defaults);
     }
 
     protected function init(): void

--- a/src/Table/Column/Link.php
+++ b/src/Table/Column/Link.php
@@ -26,20 +26,20 @@ class Link extends Table\Column
      * If $url is set up, we will use pattern-matching to fill-in any part of this
      * with values of the model.
      *
-     * @var string|HtmlTemplate Destination definition
+     * @var string|HtmlTemplate
      */
     public $url;
 
     /**
      * If string 'example', then will be passed to $app->url('example') along with any defined arguments.
-     * If set as arrray, then non-0 key/values will be also passed to the URL:
+     * If set as array, then non-0 key/values will be also passed to the URL:
      *  $page = ['example', 'type' => '123'];.
      *
      * $url = $app->url(['example', 'type' => '123']);
      *
-     * In addition to abpove "args" refer to values picked up from a current row.
+     * In addition to above "args" refer to values picked up from a current row.
      *
-     * @var string|array|null
+     * @var string|array<0|string, mixed>|null
      */
     public $page;
 
@@ -57,7 +57,7 @@ class Link extends Table\Column
      * You can also pass non-key arguments ['id', 'title'] and they will be added up
      * as ?id=4&title=John%20Smith
      *
-     * @var array
+     * @var array<int|string, string>
      */
     public $args = [];
 
@@ -82,7 +82,8 @@ class Link extends Table\Column
     public $forceDownload = false;
 
     /**
-     * @param string|array $page
+     * @param string|array<0|string, string> $page
+     * @param array<int|string, string>      $args
      */
     public function __construct($page = [], array $args = [], array $defaults = [])
     {
@@ -92,9 +93,7 @@ class Link extends Table\Column
             $defaults['url'] = $page;
         }
 
-        if ($args) {
-            $defaults['args'] = $args;
-        }
+        $defaults['args'] = $args;
 
         parent::__construct($defaults);
     }
@@ -148,16 +147,16 @@ class Link extends Table\Column
             return ['c_' . $this->shortName => $this->url->set($rowValues)->renderToHtml()];
         }
 
-        $p = $this->page ?? [];
+        $page = $this->page ?? [];
 
         foreach ($this->args as $key => $val) {
             if (is_int($key)) {
                 $key = $val;
             }
 
-            $p[$key] = $row->get($val);
+            $page[$key] = $row->get($val);
         }
 
-        return ['c_' . $this->shortName => $this->table->url($p)];
+        return ['c_' . $this->shortName => $this->table->url($page)];
     }
 }

--- a/src/Table/Column/Link.php
+++ b/src/Table/Column/Link.php
@@ -39,7 +39,7 @@ class Link extends Table\Column
      *
      * In addition to above "args" refer to values picked up from a current row.
      *
-     * @var string|array<0|string, mixed>|null
+     * @var string|array<0|string, string|int|false>|null
      */
     public $page;
 
@@ -82,8 +82,7 @@ class Link extends Table\Column
     public $forceDownload = false;
 
     /**
-     * @param string|array<0|string, string> $page
-     * @param array<int|string, string>      $args
+     * @param string|array<0|string, string|int|false> $page
      */
     public function __construct($page = [], array $args = [], array $defaults = [])
     {

--- a/src/Table/Column/Link.php
+++ b/src/Table/Column/Link.php
@@ -26,20 +26,20 @@ class Link extends Table\Column
      * If $url is set up, we will use pattern-matching to fill-in any part of this
      * with values of the model.
      *
-     * @var string|HtmlTemplate Destination definition
+     * @var string|HtmlTemplate
      */
     public $url;
 
     /**
      * If string 'example', then will be passed to $app->url('example') along with any defined arguments.
-     * If set as arrray, then non-0 key/values will be also passed to the URL:
+     * If set as array, then non-0 key/values will be also passed to the URL:
      *  $page = ['example', 'type' => '123'];.
      *
      * $url = $app->url(['example', 'type' => '123']);
      *
-     * In addition to abpove "args" refer to values picked up from a current row.
+     * In addition to above "args" refer to values picked up from a current row.
      *
-     * @var string|array|null
+     * @var string|array<0|string, string>|null
      */
     public $page;
 
@@ -57,7 +57,7 @@ class Link extends Table\Column
      * You can also pass non-key arguments ['id', 'title'] and they will be added up
      * as ?id=4&title=John%20Smith
      *
-     * @var array
+     * @var array<int|string, string>
      */
     public $args = [];
 
@@ -82,7 +82,7 @@ class Link extends Table\Column
     public $forceDownload = false;
 
     /**
-     * @param string|array $page
+     * @param string|array<0|string, string> $page
      */
     public function __construct($page = [], array $args = [], array $defaults = [])
     {
@@ -148,16 +148,16 @@ class Link extends Table\Column
             return ['c_' . $this->shortName => $this->url->set($rowValues)->renderToHtml()];
         }
 
-        $p = $this->page ?? [];
+        $page = $this->page ?? [];
 
         foreach ($this->args as $key => $val) {
             if (is_int($key)) {
                 $key = $val;
             }
 
-            $p[$key] = $row->get($val);
+            $page[$key] = $row->get($val);
         }
 
-        return ['c_' . $this->shortName => $this->table->url($p)];
+        return ['c_' . $this->shortName => $this->table->url($page)];
     }
 }

--- a/src/Tabs.php
+++ b/src/Tabs.php
@@ -40,15 +40,15 @@ class Tabs extends View
      * Adds dynamic tab in tabs widget which will load a separate
      * page/url when activated.
      *
-     * @param string|TabsTab $name
-     * @param string|array   $url  URL to open inside a tab
+     * @param string|TabsTab                 $name
+     * @param string|array<0|string, string> $page URL to open inside a tab
      */
-    public function addTabUrl($name, $url, array $settings = []): void
+    public function addTabUrl($name, $page, array $settings = []): void
     {
         $item = $this->addTabMenuItem($name, $settings);
         $this->addSubView($item->name);
 
-        $item->setPath($url);
+        $item->setPath($page);
     }
 
     /**

--- a/src/Tabs.php
+++ b/src/Tabs.php
@@ -40,8 +40,8 @@ class Tabs extends View
      * Adds dynamic tab in tabs widget which will load a separate
      * page/url when activated.
      *
-     * @param string|TabsTab                $name
-     * @param string|array<0|string, mixed> $page URL to open inside a tab
+     * @param string|TabsTab                           $name
+     * @param string|array<0|string, string|int|false> $page URL to open inside a tab
      */
     public function addTabUrl($name, $page, array $settings = []): void
     {

--- a/src/Tabs.php
+++ b/src/Tabs.php
@@ -40,15 +40,15 @@ class Tabs extends View
      * Adds dynamic tab in tabs widget which will load a separate
      * page/url when activated.
      *
-     * @param string|TabsTab $name
-     * @param string|array   $url  URL to open inside a tab
+     * @param string|TabsTab                $name
+     * @param string|array<0|string, mixed> $page URL to open inside a tab
      */
-    public function addTabUrl($name, $url, array $settings = []): void
+    public function addTabUrl($name, $page, array $settings = []): void
     {
         $item = $this->addTabMenuItem($name, $settings);
         $this->addSubView($item->name);
 
-        $item->setPath($url);
+        $item->setPath($page);
     }
 
     /**

--- a/src/Tabs.php
+++ b/src/Tabs.php
@@ -40,15 +40,15 @@ class Tabs extends View
      * Adds dynamic tab in tabs widget which will load a separate
      * page/url when activated.
      *
-     * @param string|TabsTab                 $name
-     * @param string|array<0|string, string> $page URL to open inside a tab
+     * @param string|TabsTab $name
+     * @param string|array   $url  URL to open inside a tab
      */
-    public function addTabUrl($name, $page, array $settings = []): void
+    public function addTabUrl($name, $url, array $settings = []): void
     {
         $item = $this->addTabMenuItem($name, $settings);
         $this->addSubView($item->name);
 
-        $item->setPath($page);
+        $item->setPath($url);
     }
 
     /**

--- a/src/TabsTab.php
+++ b/src/TabsTab.php
@@ -16,7 +16,7 @@ class TabsTab extends MenuItem
     public $settings = [];
 
     /**
-     * @param string|array<0|string, mixed> $page
+     * @param string|array<0|string, string|int|false> $page
      *
      * @return $this
      */

--- a/src/TabsTab.php
+++ b/src/TabsTab.php
@@ -16,15 +16,13 @@ class TabsTab extends MenuItem
     public $settings = [];
 
     /**
-     * Sets path for tab.
-     *
-     * @param string $path
+     * @param string|array<0|string, string> $page
      *
      * @return $this
      */
-    public function setPath($path)
+    public function setPath($page)
     {
-        $this->path = $this->getApp()->url($path) . '#';
+        $this->path = $this->getApp()->url($page) . '#';
 
         return $this;
     }

--- a/src/TabsTab.php
+++ b/src/TabsTab.php
@@ -16,13 +16,15 @@ class TabsTab extends MenuItem
     public $settings = [];
 
     /**
-     * @param string|array<0|string, string> $page
+     * Sets path for tab.
+     *
+     * @param string $path
      *
      * @return $this
      */
-    public function setPath($page)
+    public function setPath($path)
     {
-        $this->path = $this->getApp()->url($page) . '#';
+        $this->path = $this->getApp()->url($path) . '#';
 
         return $this;
     }

--- a/src/TabsTab.php
+++ b/src/TabsTab.php
@@ -16,15 +16,13 @@ class TabsTab extends MenuItem
     public $settings = [];
 
     /**
-     * Sets path for tab.
-     *
-     * @param string $path
+     * @param string|array<0|string, mixed> $page
      *
      * @return $this
      */
-    public function setPath($path)
+    public function setPath($page)
     {
-        $this->path = $this->getApp()->url($path) . '#';
+        $this->path = $this->getApp()->url($page) . '#';
 
         return $this;
     }

--- a/src/UserAction/ConfirmationExecutor.php
+++ b/src/UserAction/ConfirmationExecutor.php
@@ -74,7 +74,10 @@ class ConfirmationExecutor extends Modal implements JsExecutorInterface
         $this->loader->addClass('atk-hide-loading-content');
     }
 
-    private function jsShowAndLoad(array $urlArgs, array $apiConfig): JsBlock
+    /**
+     * @param array<string, string> $urlArgs
+     */
+    private function jsShowAndLoad(array $urlArgs): JsBlock
     {
         return new JsBlock([
             $this->jsShow(),
@@ -92,7 +95,7 @@ class ConfirmationExecutor extends Modal implements JsExecutorInterface
             throw new Exception('Action must be set prior to assign trigger');
         }
 
-        return $this->jsShowAndLoad($urlArgs, ['method' => 'POST']);
+        return $this->jsShowAndLoad($urlArgs);
     }
 
     public function getAction(): UserAction

--- a/src/UserAction/ConfirmationExecutor.php
+++ b/src/UserAction/ConfirmationExecutor.php
@@ -74,10 +74,7 @@ class ConfirmationExecutor extends Modal implements JsExecutorInterface
         $this->loader->addClass('atk-hide-loading-content');
     }
 
-    /**
-     * @param array<string, string> $urlArgs
-     */
-    private function jsShowAndLoad(array $urlArgs): JsBlock
+    private function jsShowAndLoad(array $urlArgs, array $apiConfig): JsBlock
     {
         return new JsBlock([
             $this->jsShow(),
@@ -95,7 +92,7 @@ class ConfirmationExecutor extends Modal implements JsExecutorInterface
             throw new Exception('Action must be set prior to assign trigger');
         }
 
-        return $this->jsShowAndLoad($urlArgs);
+        return $this->jsShowAndLoad($urlArgs, ['method' => 'POST']);
     }
 
     public function getAction(): UserAction

--- a/src/UserAction/JsCallbackExecutor.php
+++ b/src/UserAction/JsCallbackExecutor.php
@@ -53,7 +53,8 @@ class JsCallbackExecutor extends JsCallback implements ExecutorInterface
     }
 
     /**
-     * @param \Closure(): mixed $fx
+     * @param \Closure(): mixed     $fx
+     * @param array<string, string> $urlArgs
      *
      * @return mixed
      */
@@ -68,6 +69,9 @@ class JsCallbackExecutor extends JsCallback implements ExecutorInterface
         }
     }
 
+    /**
+     * @param array<string, string> $urlArgs
+     */
     public function jsExecute(array $urlArgs = []): JsBlock
     {
         return $this->invokeFxWithUrlArgs(function () { // backup/restore $this->args and merge them with $urlArgs

--- a/src/UserAction/JsCallbackExecutor.php
+++ b/src/UserAction/JsCallbackExecutor.php
@@ -53,8 +53,7 @@ class JsCallbackExecutor extends JsCallback implements ExecutorInterface
     }
 
     /**
-     * @param \Closure(): mixed     $fx
-     * @param array<string, string> $urlArgs
+     * @param \Closure(): mixed $fx
      *
      * @return mixed
      */
@@ -69,9 +68,6 @@ class JsCallbackExecutor extends JsCallback implements ExecutorInterface
         }
     }
 
-    /**
-     * @param array<string, string> $urlArgs
-     */
     public function jsExecute(array $urlArgs = []): JsBlock
     {
         return $this->invokeFxWithUrlArgs(function () { // backup/restore $this->args and merge them with $urlArgs

--- a/src/UserAction/JsExecutorInterface.php
+++ b/src/UserAction/JsExecutorInterface.php
@@ -13,8 +13,6 @@ interface JsExecutorInterface extends ExecutorInterface
 {
     /**
      * Return JS expression that will trigger action executor.
-     *
-     * @param array<string, string> $urlArgs
      */
     public function jsExecute(array $urlArgs): JsBlock;
 }

--- a/src/UserAction/JsExecutorInterface.php
+++ b/src/UserAction/JsExecutorInterface.php
@@ -13,6 +13,8 @@ interface JsExecutorInterface extends ExecutorInterface
 {
     /**
      * Return JS expression that will trigger action executor.
+     *
+     * @param array<string, string> $urlArgs
      */
     public function jsExecute(array $urlArgs): JsBlock;
 }

--- a/src/UserAction/ModalExecutor.php
+++ b/src/UserAction/ModalExecutor.php
@@ -101,10 +101,7 @@ class ModalExecutor extends Modal implements JsExecutorInterface
         $this->runSteps();
     }
 
-    /**
-     * @param array<string, string> $urlArgs
-     */
-    private function jsShowAndLoad(array $urlArgs): JsBlock
+    private function jsShowAndLoad(array $urlArgs, array $apiConfig): JsBlock
     {
         return new JsBlock([
             $this->jsShow(),
@@ -121,8 +118,6 @@ class ModalExecutor extends Modal implements JsExecutorInterface
      * If action require steps, it will automatically initialize
      * proper step to execute first.
      *
-     * @param array<string, string> $urlArgs
-     *
      * @return $this
      */
     public function assignTrigger(View $view, array $urlArgs = [], string $when = 'click', string $selector = null): self
@@ -135,7 +130,7 @@ class ModalExecutor extends Modal implements JsExecutorInterface
             // use modal for stepping action.
             $urlArgs['step'] = $this->step;
             if ($this->action->enabled) {
-                $view->on($when, $selector, $this->jsShowAndLoad($urlArgs));
+                $view->on($when, $selector, $this->jsShowAndLoad($urlArgs, ['method' => 'POST']));
             } else {
                 $view->addClass('disabled');
             }
@@ -152,7 +147,7 @@ class ModalExecutor extends Modal implements JsExecutorInterface
 
         $urlArgs['step'] = $this->step;
 
-        return $this->jsShowAndLoad($urlArgs);
+        return $this->jsShowAndLoad($urlArgs, ['method' => 'POST']);
     }
 
     /**

--- a/src/UserAction/ModalExecutor.php
+++ b/src/UserAction/ModalExecutor.php
@@ -101,7 +101,10 @@ class ModalExecutor extends Modal implements JsExecutorInterface
         $this->runSteps();
     }
 
-    private function jsShowAndLoad(array $urlArgs, array $apiConfig): JsBlock
+    /**
+     * @param array<string, string> $urlArgs
+     */
+    private function jsShowAndLoad(array $urlArgs): JsBlock
     {
         return new JsBlock([
             $this->jsShow(),
@@ -118,6 +121,8 @@ class ModalExecutor extends Modal implements JsExecutorInterface
      * If action require steps, it will automatically initialize
      * proper step to execute first.
      *
+     * @param array<string, string> $urlArgs
+     *
      * @return $this
      */
     public function assignTrigger(View $view, array $urlArgs = [], string $when = 'click', string $selector = null): self
@@ -130,7 +135,7 @@ class ModalExecutor extends Modal implements JsExecutorInterface
             // use modal for stepping action.
             $urlArgs['step'] = $this->step;
             if ($this->action->enabled) {
-                $view->on($when, $selector, $this->jsShowAndLoad($urlArgs, ['method' => 'POST']));
+                $view->on($when, $selector, $this->jsShowAndLoad($urlArgs));
             } else {
                 $view->addClass('disabled');
             }
@@ -147,7 +152,7 @@ class ModalExecutor extends Modal implements JsExecutorInterface
 
         $urlArgs['step'] = $this->step;
 
-        return $this->jsShowAndLoad($urlArgs, ['method' => 'POST']);
+        return $this->jsShowAndLoad($urlArgs);
     }
 
     /**

--- a/src/UserAction/SharedExecutor.php
+++ b/src/UserAction/SharedExecutor.php
@@ -31,6 +31,9 @@ class SharedExecutor
         return $this->executor;
     }
 
+    /**
+     * @param array<string, string> $urlArgs
+     */
     public function jsExecute(array $urlArgs): JsBlock
     {
         // TODO executor::jsExecute() should be called only once, registered as a custom jQuery event and then

--- a/src/UserAction/SharedExecutor.php
+++ b/src/UserAction/SharedExecutor.php
@@ -31,9 +31,6 @@ class SharedExecutor
         return $this->executor;
     }
 
-    /**
-     * @param array<string, string> $urlArgs
-     */
     public function jsExecute(array $urlArgs): JsBlock
     {
         // TODO executor::jsExecute() should be called only once, registered as a custom jQuery event and then

--- a/src/View.php
+++ b/src/View.php
@@ -183,7 +183,7 @@ class View extends AbstractView
     /**
      * Makes view into a "<a>" element with a link.
      *
-     * @param string|array<0|string, mixed> $url
+     * @param string|array<0|string, string|int|false> $url
      *
      * @return $this
      */
@@ -491,7 +491,7 @@ class View extends AbstractView
     /**
      * Build an URL which this view can use for callbacks.
      *
-     * @param string|array<0|string, mixed> $page URL as string or array with page name as first element and other GET arguments
+     * @param string|array<0|string, string|int|false> $page URL as string or array with page name as first element and other GET arguments
      */
     public function url($page = []): string
     {
@@ -501,7 +501,7 @@ class View extends AbstractView
     /**
      * Build an URL which this view can use for JS callbacks.
      *
-     * @param string|array<0|string, mixed> $page URL as string or array with page name as first element and other GET arguments
+     * @param string|array<0|string, string|int|false> $page URL as string or array with page name as first element and other GET arguments
      */
     public function jsUrl($page = []): string
     {

--- a/src/View.php
+++ b/src/View.php
@@ -183,12 +183,11 @@ class View extends AbstractView
     /**
      * Makes view into a "<a>" element with a link.
      *
-     * @param string|array $url
-     * @param string       $target
+     * @param string|array<0|string, mixed> $url
      *
      * @return $this
      */
-    public function link($url, $target = null)
+    public function link($url, string $target = null)
     {
         $this->setElement('a');
 
@@ -490,23 +489,23 @@ class View extends AbstractView
     public $stickyArgs = [];
 
     /**
-     * Build an URL which this view can use for JS callbacks.
-     *
-     * @param array $page
-     */
-    public function jsUrl($page = []): string
-    {
-        return $this->getApp()->jsUrl($page, false, $this->_getStickyArgs());
-    }
-
-    /**
      * Build an URL which this view can use for callbacks.
      *
-     * @param string|array $page URL as string or array with page name as first element and other GET arguments
+     * @param string|array<0|string, mixed> $page URL as string or array with page name as first element and other GET arguments
      */
     public function url($page = []): string
     {
         return $this->getApp()->url($page, false, $this->_getStickyArgs());
+    }
+
+    /**
+     * Build an URL which this view can use for JS callbacks.
+     *
+     * @param string|array<0|string, mixed> $page URL as string or array with page name as first element and other GET arguments
+     */
+    public function jsUrl($page = []): string
+    {
+        return $this->getApp()->jsUrl($page, false, $this->_getStickyArgs());
     }
 
     /**

--- a/src/View.php
+++ b/src/View.php
@@ -183,12 +183,11 @@ class View extends AbstractView
     /**
      * Makes view into a "<a>" element with a link.
      *
-     * @param string|array $url
-     * @param string       $target
+     * @param string|array<0|string, string> $url
      *
      * @return $this
      */
-    public function link($url, $target = null)
+    public function link($url, string $target = null)
     {
         $this->setElement('a');
 
@@ -490,23 +489,23 @@ class View extends AbstractView
     public $stickyArgs = [];
 
     /**
-     * Build an URL which this view can use for JS callbacks.
-     *
-     * @param array $page
-     */
-    public function jsUrl($page = []): string
-    {
-        return $this->getApp()->jsUrl($page, false, $this->_getStickyArgs());
-    }
-
-    /**
      * Build an URL which this view can use for callbacks.
      *
-     * @param string|array $page URL as string or array with page name as first element and other GET arguments
+     * @param string|array<0|string, string> $page URL as string or array with page name as first element and other GET arguments
      */
     public function url($page = []): string
     {
         return $this->getApp()->url($page, false, $this->_getStickyArgs());
+    }
+
+    /**
+     * Build an URL which this view can use for JS callbacks.
+     *
+     * @param string|array<0|string, string> $page URL as string or array with page name as first element and other GET arguments
+     */
+    public function jsUrl($page = []): string
+    {
+        return $this->getApp()->jsUrl($page, false, $this->_getStickyArgs());
     }
 
     /**

--- a/src/View.php
+++ b/src/View.php
@@ -183,11 +183,12 @@ class View extends AbstractView
     /**
      * Makes view into a "<a>" element with a link.
      *
-     * @param string|array<0|string, string> $url
+     * @param string|array $url
+     * @param string       $target
      *
      * @return $this
      */
-    public function link($url, string $target = null)
+    public function link($url, $target = null)
     {
         $this->setElement('a');
 
@@ -489,23 +490,23 @@ class View extends AbstractView
     public $stickyArgs = [];
 
     /**
-     * Build an URL which this view can use for callbacks.
-     *
-     * @param string|array<0|string, string> $page URL as string or array with page name as first element and other GET arguments
-     */
-    public function url($page = []): string
-    {
-        return $this->getApp()->url($page, false, $this->_getStickyArgs());
-    }
-
-    /**
      * Build an URL which this view can use for JS callbacks.
      *
-     * @param string|array<0|string, string> $page URL as string or array with page name as first element and other GET arguments
+     * @param array $page
      */
     public function jsUrl($page = []): string
     {
         return $this->getApp()->jsUrl($page, false, $this->_getStickyArgs());
+    }
+
+    /**
+     * Build an URL which this view can use for callbacks.
+     *
+     * @param string|array $page URL as string or array with page name as first element and other GET arguments
+     */
+    public function url($page = []): string
+    {
+        return $this->getApp()->url($page, false, $this->_getStickyArgs());
     }
 
     /**


### PR DESCRIPTION
also drop `App::$page` introduced in https://github.com/atk4/ui/pull/131, ~it seems to be used internally only to cache the current page~ - reintroduced in #2096 as `App::$urlBuildingIndexPage` because of https://github.com/atk4/ui/pull/2095#issuecomment-1691185566