### PR TITLE
Remove View::content property and View::set() method

### DIFF
--- a/demos/_includes/Demo.php
+++ b/demos/_includes/Demo.php
@@ -9,6 +9,7 @@ use Atk4\Ui\Exception;
 use Atk4\Ui\Js\JsExpression;
 use Atk4\Ui\Js\JsFunction;
 use Atk4\Ui\View;
+use Atk4\Ui\ViewWithContent;
 
 class Demo extends Columns
 {
@@ -66,7 +67,7 @@ class Demo extends Columns
         $code = $this->extractCodeFromClosure($fx);
 
         $this->highLightCode();
-        View::addTo(View::addTo($this->left, ['element' => 'pre']), ['element' => 'code'])
+        ViewWithContent::addTo(View::addTo($this->left, ['element' => 'pre']), ['element' => 'code'])
             ->addClass('language-' . $lang)
             ->set($code)
             ->js(true)->each(new JsFunction(['i, el'], [new JsExpression('hljs.highlightElement(el)')]));

--- a/demos/_unit-test/reload.php
+++ b/demos/_unit-test/reload.php
@@ -9,12 +9,12 @@ use Atk4\Ui\Button;
 use Atk4\Ui\Callback;
 use Atk4\Ui\Js\JsReload;
 use Atk4\Ui\Loader;
-use Atk4\Ui\View;
+use Atk4\Ui\ViewWithContent;
 
 /** @var App $app */
 require_once __DIR__ . '/../init-app.php';
 
-$v = View::addTo($app, ['ui' => 'segment']);
+$v = ViewWithContent::addTo($app, ['ui' => 'segment']);
 $v->set('Test');
 $v->name = 'reload';
 
@@ -25,5 +25,5 @@ $cb = Callback::addTo($app);
 $cb->setUrlTrigger('c_reload');
 
 Loader::addTo($app, ['cb' => $cb])->set(static function (Loader $p) {
-    $v = View::addTo($p, ['ui' => 'segment'])->set('loaded');
+    ViewWithContent::addTo($p, ['ui' => 'segment'])->set('loaded');
 });

--- a/demos/_unit-test/remove-observer.php
+++ b/demos/_unit-test/remove-observer.php
@@ -11,6 +11,7 @@ use Atk4\Ui\Js\JsBlock;
 use Atk4\Ui\Js\JsExpression;
 use Atk4\Ui\JsSse;
 use Atk4\Ui\View;
+use Atk4\Ui\ViewWithContent;
 
 /** @var App $app */
 require_once __DIR__ . '/../init-app.php';
@@ -21,7 +22,7 @@ $reloadUrlArgs = ['i' => new JsExpression('++atk.i')];
 $logInput = View::addTo($app, ['element' => 'input', 'name' => 'log']);
 $logInput->setStyle('width', '100%');
 
-$setBoxTextAndStyleFx = static function (View $view, string $text) {
+$setBoxTextAndStyleFx = static function (ViewWithContent $view, string $text) {
     $view->set($text);
     $view->setStyle('width', 'fit-content');
     $view->setStyle('padding', '5px');
@@ -30,7 +31,7 @@ $setBoxTextAndStyleFx = static function (View $view, string $text) {
 };
 
 $addBoxFx = static function ($owner, string $name) use ($setBoxTextAndStyleFx, $logInput) {
-    $box = View::addTo($owner);
+    $box = ViewWithContent::addTo($owner);
     $setBoxTextAndStyleFx($box, $name . (int) $box->getApp()->tryGetRequestQueryParam('i'));
 
     $box->js(true, new JsExpression(<<<'JS'
@@ -84,7 +85,7 @@ Button::addTo($app, ['Readd U'])->on('click', new JsExpression(<<<'JS'
 
 Header::addTo($app, ['API']);
 
-$apiContext = View::addTo($app);
+$apiContext = ViewWithContent::addTo($app);
 $setBoxTextAndStyleFx($apiContext, 'stateContext');
 $apiButton = Button::addTo($app, ['Run slow API']);
 $apiButton->on('click', static function () use ($apiButton) {
@@ -99,7 +100,7 @@ Button::addTo($app, ['Run slow API & remove'])->on('click', new JsBlock([
 
 Header::addTo($app, ['SSE']);
 
-$sseContext = View::addTo($app);
+$sseContext = ViewWithContent::addTo($app);
 $sse = JsSse::addTo($app, ['stateContext' => $sseContext]);
 $setBoxTextAndStyleFx($sseContext, 'stateContext');
 $sseButton = Button::addTo($app, ['Run slow SSE']);

--- a/demos/_unit-test/scope-builder.php
+++ b/demos/_unit-test/scope-builder.php
@@ -9,7 +9,7 @@ use Atk4\Data\Model\Scope\Condition;
 use Atk4\Ui\App;
 use Atk4\Ui\Form;
 use Atk4\Ui\Header;
-use Atk4\Ui\View;
+use Atk4\Ui\ViewWithContent;
 
 /** @var App $app */
 require_once __DIR__ . '/../init-app.php';
@@ -37,7 +37,7 @@ $form->addControl('qb', [Form\Control\ScopeBuilder::class, 'model' => $model], [
 
 $form->onSubmit(static function (Form $form) use ($model) {
     $message = $form->entity->get('qb')->toWords($model);
-    $view = View::addTo($form)->addClass('atk-scope-builder-response');
+    $view = ViewWithContent::addTo($form)->addClass('atk-scope-builder-response');
     $view->set($message);
 
     return $view;
@@ -137,7 +137,7 @@ $expectedInput = json_encode(json_decode(<<<"EOF"
     EOF, true), \JSON_UNESCAPED_UNICODE);
 
 Header::addTo($app, ['Input:']);
-View::addTo($app, ['element' => 'p', 'content' => $expectedInput])->addClass('atk-expected-input-result');
+ViewWithContent::addTo($app, ['element' => 'p', 'content' => $expectedInput])->addClass('atk-expected-input-result');
 
 $expectedWord = <<<'EOF'
     Project Budget is greater or equal to '{$budget1000Eur}'
@@ -147,4 +147,4 @@ $expectedWord = <<<'EOF'
     EOF;
 
 Header::addTo($app, ['Word:']);
-View::addTo($app, ['element' => 'p', 'content' => $expectedWord])->addClass('atk-expected-word-result');
+ViewWithContent::addTo($app, ['element' => 'p', 'content' => $expectedWord])->addClass('atk-expected-word-result');

--- a/demos/_unit-test/sse.php
+++ b/demos/_unit-test/sse.php
@@ -8,12 +8,12 @@ use Atk4\Ui\App;
 use Atk4\Ui\Js\JsExpression;
 use Atk4\Ui\Js\JsToast;
 use Atk4\Ui\JsSse;
-use Atk4\Ui\View;
+use Atk4\Ui\ViewWithContent;
 
 /** @var App $app */
 require_once __DIR__ . '/../init-app.php';
 
-$v = View::addTo($app)->set('This will trigger a network request for testing SSE...');
+$v = ViewWithContent::addTo($app)->set('This will trigger a network request for testing SSE...');
 
 $sse = JsSse::addTo($app);
 // URL trigger must match phpunit test in SSE provider

--- a/demos/_unit-test/virtual-page.php
+++ b/demos/_unit-test/virtual-page.php
@@ -8,7 +8,7 @@ use Atk4\Ui\App;
 use Atk4\Ui\Button;
 use Atk4\Ui\Form;
 use Atk4\Ui\Js\JsToast;
-use Atk4\Ui\View;
+use Atk4\Ui\ViewWithContent;
 use Atk4\Ui\VirtualPage;
 
 /** @var App $app */
@@ -19,10 +19,10 @@ $vp = VirtualPage::addTo($app);
 $vp->set(static function (VirtualPage $firstPage) {
     $secondVp = VirtualPage::addTo($firstPage);
     $secondVp->set(static function (VirtualPage $secondPage) {
-        View::addTo($secondPage)->set('Second Level Page')->addClass('__atk-behat-test-second');
+        ViewWithContent::addTo($secondPage)->set('Second Level Page')->addClass('__atk-behat-test-second');
         $thirdVp = VirtualPage::addTo($secondPage);
         $thirdVp->set(static function (VirtualPage $thirdPage) {
-            View::addTo($thirdPage)->set('Third Level Page')->addClass('__atk-behat-test-third');
+            ViewWithContent::addTo($thirdPage)->set('Third Level Page')->addClass('__atk-behat-test-third');
             $form = Form::addTo($thirdPage);
             $form->addControl('category', [Form\Control\Lookup::class, 'model' => new Category($thirdPage->getApp()->db)]);
             $form->onSubmit(static function (Form $form) {
@@ -34,7 +34,7 @@ $vp->set(static function (VirtualPage $firstPage) {
         });
         Button::addTo($secondPage, ['Open Third'])->link($thirdVp->getUrl());
     });
-    View::addTo($firstPage)->set('First Level Page')->addClass('__atk-behat-test-first');
+    ViewWithContent::addTo($firstPage)->set('First Level Page')->addClass('__atk-behat-test-first');
     Button::addTo($firstPage, ['Open Second'])->link($secondVp->getUrl());
 });
 

--- a/demos/basic/header.php
+++ b/demos/basic/header.php
@@ -7,6 +7,7 @@ namespace Atk4\Ui\Demos;
 use Atk4\Ui\App;
 use Atk4\Ui\Header;
 use Atk4\Ui\View;
+use Atk4\Ui\ViewWithContent;
 
 /** @var App $app */
 require_once __DIR__ . '/../init-app.php';
@@ -19,7 +20,7 @@ Header::addTo($seg, ['H2 Header', 'size' => 2]);
 Header::addTo($seg, ['H3 Header', 'size' => 3]);
 Header::addTo($seg, ['H4 Header', 'size' => 4]);
 Header::addTo($seg, ['H5 Header', 'size' => 5, 'class.dividing' => true]);
-View::addTo($seg, ['element' => 'p'])->set('This is a following paragraph of text');
+ViewWithContent::addTo($seg, ['element' => 'p'])->set('This is a following paragraph of text');
 
 Header::addTo($seg, ['H1', 'size' => 1, 'subHeader' => 'H1 subheader']);
 Header::addTo($seg, ['H5', 'size' => 5, 'subHeader' => 'H5 subheader']);

--- a/demos/basic/menu.php
+++ b/demos/basic/menu.php
@@ -10,7 +10,7 @@ use Atk4\Ui\Form;
 use Atk4\Ui\Header;
 use Atk4\Ui\Js\JsToast;
 use Atk4\Ui\Menu;
-use Atk4\Ui\View;
+use Atk4\Ui\ViewWithContent;
 
 /** @var App $app */
 require_once __DIR__ . '/../init-app.php';
@@ -65,7 +65,7 @@ $group->addItem('Dedicated');
 $menu = Menu::addTo($app, ['vertical']);
 $i = $menu->addItem();
 Header::addTo($i, ['size' => 4])->set('Promotions');
-View::addTo($i, ['element' => 'p'])->set('Check out our promotions');
+ViewWithContent::addTo($i, ['element' => 'p'])->set('Check out our promotions');
 
 // menu without any item should not show
 Menu::addTo($app);

--- a/demos/basic/view.php
+++ b/demos/basic/view.php
@@ -16,6 +16,7 @@ use Atk4\Ui\Message;
 use Atk4\Ui\Paginator;
 use Atk4\Ui\Table;
 use Atk4\Ui\View;
+use Atk4\Ui\ViewWithContent;
 use Atk4\Ui\VirtualPage;
 
 /** @var App $app */
@@ -24,10 +25,10 @@ require_once __DIR__ . '/../init-app.php';
 $img = $app->cdn['atk'] . '/logo.png';
 
 Header::addTo($app, ['Default view has no styling']);
-View::addTo($app)->set('just a <div> element');
+ViewWithContent::addTo($app)->set('just a <div> element');
 
 Header::addTo($app, ['View can specify CSS class']);
-View::addTo($app, ['ui' => 'segment', 'class.raised' => true])->set('Segment');
+ViewWithContent::addTo($app, ['ui' => 'segment', 'class.raised' => true])->set('Segment');
 
 Header::addTo($app, ['View can contain stuff']);
 Header::addTo(View::addTo($app, ['ui' => 'segment'])
@@ -59,7 +60,7 @@ $planeTemplate->set('num', (string) random_int(100, 999));
 $plane = View::addTo($app, ['template' => $planeTemplate]);
 
 Header::addTo($app, ['Can be rendered into HTML']);
-View::addTo($app, ['ui' => 'segment', 'class.raised' => true, 'element' => 'pre'])->set($plane->renderToHtml());
+ViewWithContent::addTo($app, ['ui' => 'segment', 'class.raised' => true, 'element' => 'pre'])->set($plane->renderToHtml());
 
 Header::addTo($app, ['Has a unique global identifier']);
 Label::addTo($app, ['Plane ID:', 'detail' => $plane->name]);

--- a/demos/data-action/jsactionsgrid.php
+++ b/demos/data-action/jsactionsgrid.php
@@ -11,7 +11,7 @@ use Atk4\Ui\Grid;
 use Atk4\Ui\Header;
 use Atk4\Ui\Icon;
 use Atk4\Ui\UserAction\ExecutorFactory;
-use Atk4\Ui\View;
+use Atk4\Ui\ViewWithContent;
 
 // Demo for Model action in Grid
 
@@ -25,7 +25,7 @@ DemoActionsUtil::setupDemoActions($country);
 
 // creating special menu item for multi_step action
 $multiAction = $country->getUserAction('multi_step');
-$specialItem = Factory::factory([View::class], ['class' => ['item'], 'content' => 'Multi Step']);
+$specialItem = Factory::factory([ViewWithContent::class], ['class' => ['item'], 'content' => 'Multi Step']);
 Icon::addTo($specialItem, ['content' => 'window maximize outline']);
 // register this menu item in factory
 $app->getExecutorFactory()->registerTrigger(ExecutorFactory::TABLE_MENU_ITEM, $specialItem, $multiAction);
@@ -35,18 +35,18 @@ Header::addTo($app, ['Execute model action from Grid menu items', 'subHeader' =>
 $grid = Grid::addTo($app, ['menu' => false]);
 $grid->setModel($country);
 
-$divider = Factory::factory([View::class], ['class' => ['divider'], 'content' => '']);
+$divider = Factory::factory([ViewWithContent::class], ['class' => ['divider'], 'content' => '']);
 
-$modelHeader = Factory::factory([View::class], ['class' => ['header'], 'content' => 'Model Actions']);
+$modelHeader = Factory::factory([ViewWithContent::class], ['class' => ['header'], 'content' => 'Model Actions']);
 Icon::addTo($modelHeader, ['content' => 'database']);
 
-$jsHeader = Factory::factory([View::class], ['class' => ['header'], 'content' => 'JS Actions']);
+$jsHeader = Factory::factory([ViewWithContent::class], ['class' => ['header'], 'content' => 'JS Actions']);
 Icon::addTo($jsHeader, ['content' => 'file code']);
 
 $grid->addActionMenuItem($jsHeader);
 // beside model user action, grid menu items can also execute javascript
 $grid->addActionMenuItem('JS Callback', static function () {
-    return (new View())->set('JS Callback done!');
+    return (new ViewWithContent())->set('JS Callback done!');
 }, 'Are you sure?');
 
 $grid->addActionMenuItem($divider);

--- a/demos/form-control/form6.php
+++ b/demos/form-control/form6.php
@@ -8,12 +8,12 @@ use Atk4\Ui\App;
 use Atk4\Ui\Columns;
 use Atk4\Ui\Form;
 use Atk4\Ui\Js\JsToast;
-use Atk4\Ui\View;
+use Atk4\Ui\ViewWithContent;
 
 /** @var App $app */
 require_once __DIR__ . '/../init-app.php';
 
-View::addTo($app, [
+ViewWithContent::addTo($app, [
     'Forms below demonstrate how to work with multi-value selectors',
     'ui' => 'ignored warning message',
 ]);

--- a/demos/form/form5.php
+++ b/demos/form/form5.php
@@ -10,12 +10,12 @@ use Atk4\Ui\App;
 use Atk4\Ui\Columns;
 use Atk4\Ui\Form;
 use Atk4\Ui\Js\JsToast;
-use Atk4\Ui\View;
+use Atk4\Ui\ViewWithContent;
 
 /** @var App $app */
 require_once __DIR__ . '/../init-app.php';
 
-View::addTo($app, [
+ViewWithContent::addTo($app, [
     'Forms below focus on Data integration and automated layouts',
     'ui' => 'ignored warning message',
 ]);

--- a/demos/interactive/card.php
+++ b/demos/interactive/card.php
@@ -10,6 +10,7 @@ use Atk4\Ui\Card;
 use Atk4\Ui\Header;
 use Atk4\Ui\Image;
 use Atk4\Ui\View;
+use Atk4\Ui\ViewWithContent;
 
 /** @var App $app */
 require_once __DIR__ . '/../init-app.php';
@@ -34,7 +35,7 @@ $card->addImage('../images/kristy.png');
 $card->addButton(new Button(['Join']));
 $card->addButton(new Button(['Email']));
 
-$card->addExtraContent(new View(['Copyright notice: Image from Fomantic-UI', 'element' => 'span']));
+$card->addExtraContent(new ViewWithContent(['Copyright notice: Image from Fomantic-UI', 'element' => 'span']));
 
 // Simple Card
 

--- a/demos/interactive/modal.php
+++ b/demos/interactive/modal.php
@@ -18,6 +18,7 @@ use Atk4\Ui\Message;
 use Atk4\Ui\Modal;
 use Atk4\Ui\Text;
 use Atk4\Ui\View;
+use Atk4\Ui\ViewWithContent;
 
 /** @var App $app */
 require_once __DIR__ . '/../init-app.php';
@@ -88,7 +89,7 @@ $vp3Modal->set(static function (View $p) {
 // when $vp1Modal->jsShow() is activate, it will dynamically add this content to it
 $vp1Modal->set(static function (View $p) use ($vp2Modal) {
     ViewTester::addTo($p);
-    View::addTo($p, ['Showing lorem ipsum']); // need in behat test
+    ViewWithContent::addTo($p, ['Showing lorem ipsum']); // need in behat test
     LoremIpsum::addTo($p, ['size' => 2]);
     $form = Form::addTo($p);
     $form->addControl('color', [], ['enum' => ['red', 'green', 'blue'], 'default' => 'green']);

--- a/demos/interactive/popup.php
+++ b/demos/interactive/popup.php
@@ -22,6 +22,7 @@ use Atk4\Ui\Message;
 use Atk4\Ui\Popup;
 use Atk4\Ui\SessionTrait;
 use Atk4\Ui\View;
+use Atk4\Ui\ViewWithContent;
 
 /** @var App $app */
 require_once __DIR__ . '/../init-app.php';
@@ -275,12 +276,12 @@ $button = Button::addTo($app, ['Click Me', 'class.primary' => true]);
 $buttonPopup = Popup::addTo($app, [$button]);
 
 Header::addTo($buttonPopup)->set('Using click events');
-View::addTo($buttonPopup)->set('Adding popup into button activates on click by default. Clicked popups will close if you click away.');
+ViewWithContent::addTo($buttonPopup)->set('Adding popup into button activates on click by default. Clicked popups will close if you click away.');
 
 $input = Form\Control\Line::addTo($app, ['placeholder' => 'Search users', 'icon' => 'circular search link']);
 
 $inputPopup = Popup::addTo($app, [$input, 'triggerOn' => 'focus']);
-View::addTo($inputPopup)->set('You can use this field to search data.');
+ViewWithContent::addTo($inputPopup)->set('You can use this field to search data.');
 
 $button = Button::addTo($app, [null, 'icon' => 'volume down']);
 $buttonPopup = Popup::addTo($app, [$button, 'triggerOn' => 'hover'])->setHoverable();

--- a/demos/interactive/virtual.php
+++ b/demos/interactive/virtual.php
@@ -14,6 +14,7 @@ use Atk4\Ui\Modal;
 use Atk4\Ui\Table;
 use Atk4\Ui\Text;
 use Atk4\Ui\View;
+use Atk4\Ui\ViewWithContent;
 use Atk4\Ui\VirtualPage;
 
 /** @var App $app */
@@ -55,7 +56,7 @@ $button->link($virtualPage->cb->getUrl() . '&p_id=Bike');
 Header::addTo($app, ['Virtual Page Logic']);
 
 $virtualPage = VirtualPage::addTo($app); // this page will not be visible unless you trigger it specifically
-View::addTo($virtualPage, ['Contents of your pop-up here'])->addClass('ui header __atk-behat-test-content');
+ViewWithContent::addTo($virtualPage, ['Contents of your pop-up here'])->addClass('ui header __atk-behat-test-content');
 LoremIpsum::addTo($virtualPage, ['size' => 2]);
 
 Counter::addTo($virtualPage);

--- a/demos/javascript/reloading.php
+++ b/demos/javascript/reloading.php
@@ -11,13 +11,14 @@ use Atk4\Ui\Header;
 use Atk4\Ui\Js\JsExpression;
 use Atk4\Ui\Js\JsReload;
 use Atk4\Ui\View;
+use Atk4\Ui\ViewWithContent;
 
 /** @var App $app */
 require_once __DIR__ . '/../init-app.php';
 
 // Test 1 - Basic reloading
 Header::addTo($app, ['Button reloading segment']);
-$v = View::addTo($app, ['ui' => 'segment'])->set((string) random_int(1, 100));
+$v = ViewWithContent::addTo($app, ['ui' => 'segment'])->set((string) random_int(1, 100));
 Button::addTo($app, ['Reload random number'])
     ->on('click', new JsReload($v, [], new JsExpression('console.log(\'Output with afterSuccess\');')));
 
@@ -51,7 +52,7 @@ $b = Button::addTo($bar, ['Reload counter'])
 // reloading with argument
 Header::addTo($app, ['We can pass argument to reloader']);
 
-$v = View::addTo($app, ['ui' => 'segment'])->set($app->tryGetRequestQueryParam('val') ?? 'No value');
+$v = ViewWithContent::addTo($app, ['ui' => 'segment'])->set($app->tryGetRequestQueryParam('val') ?? 'No value');
 
 Button::addTo($app, ['Set value to "hello"'])
     ->on('click', new JsReload($v, ['val' => 'hello']));

--- a/demos/javascript/vue-component.php
+++ b/demos/javascript/vue-component.php
@@ -12,6 +12,7 @@ use Atk4\Ui\Js\JsExpression;
 use Atk4\Ui\Lister;
 use Atk4\Ui\Message;
 use Atk4\Ui\View;
+use Atk4\Ui\ViewWithContent;
 use Atk4\Ui\VueComponent;
 
 /** @var App $app */
@@ -28,12 +29,12 @@ $entity = (new Country($app->db))
 $subHeader = 'Try me. I will restore value on "Escape" or save it on "Enter" or when field get blur after it has been changed.';
 Header::addTo($app, ['Inline editing.', 'size' => 3, 'subHeader' => $subHeader]);
 
-View::addTo($app)->set('with autoSave');
+ViewWithContent::addTo($app)->set('with autoSave');
 $inlineEditWithAutoSave = VueComponent\InlineEdit::addTo($app, ['autoSave' => true]);
 $inlineEditWithAutoSave->fieldName = $entity->fieldName()->name;
 $inlineEditWithAutoSave->setEntity($entity);
 
-View::addTo($app)->set('with onChange callback');
+ViewWithContent::addTo($app)->set('with onChange callback');
 $inlineEditWithCallback = VueComponent\InlineEdit::addTo($app);
 $inlineEditWithCallback->fieldName = $entity->fieldName()->name;
 $inlineEditWithCallback->setEntity($entity);
@@ -178,4 +179,4 @@ $clock->vue('my-clock', ['styles' => $clockStyle], new JsExpression('myClock'));
 
 $button = Button::addTo($app, ['Change Style']);
 $button->on('click', $clock->jsEmitEvent($clock->name . '-clock-change-style'));
-View::addTo($app, ['element' => 'p', 'I am not part of the component but I can still change style using the eventBus.']);
+ViewWithContent::addTo($app, ['element' => 'p', 'I am not part of the component but I can still change style using the eventBus.']);

--- a/demos/others/sticky.php
+++ b/demos/others/sticky.php
@@ -7,12 +7,12 @@ namespace Atk4\Ui\Demos;
 use Atk4\Ui\App;
 use Atk4\Ui\Button;
 use Atk4\Ui\Header;
-use Atk4\Ui\View;
+use Atk4\Ui\ViewWithContent;
 
 /** @var App $app */
 require_once __DIR__ . '/../init-app.php';
 
-View::addTo($app, [
+ViewWithContent::addTo($app, [
     'Sticky GET allows us to preserve some GET arguments',
     'ui' => 'ignored info message',
 ]);

--- a/docs/icon.md
+++ b/docs/icon.md
@@ -136,7 +136,7 @@ Here is the code with comments:
  * For convenience use this with link(), which will automatically open a new window
  * too.
  */
-class SocialAdd extends \Atk4\Ui\View
+class SocialAdd extends \Atk4\Ui\ViewWithContent
 {
     public $social;
     public $icon;

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -396,11 +396,6 @@ parameters:
 
         # TODO fix contravariance for View::set() method
         -
-            path: 'src/Console.php'
-            identifier: method.childParameterType
-            message: '~^Parameter #1 \$fx \(Closure\(\$this\): void\) of method Atk4\\Ui\\Console::set\(\) should be compatible with parameter \$content \(string\) of method Atk4\\Ui\\View::set\(\)$~'
-            count: 1
-        -
             path: 'src/Form/Control/Calendar.php'
             identifier: method.childParameterType
             message: '~^Parameter #1 \$action \(Atk4\\Ui\\Js\\JsExpressionable\) of method Atk4\\Ui\\Form\\Control\\Calendar::onChange\(\) should be contravariant with parameter \$action \(array\{Closure\(Atk4\\Ui\\Js\\Jquery, mixed\): \(Atk4\\Ui\\Js\\JsExpressionable\|Atk4\\Ui\\View\|string\|void\)\}\|Atk4\\Ui\\Js\\JsExpressionable\|\(Closure\(Atk4\\Ui\\Js\\Jquery, mixed\): \(Atk4\\Ui\\Js\\JsExpressionable\|Atk4\\Ui\\View\|string\|void\)\)\) of method Atk4\\Ui\\Form\\Control::onChange\(\)$~'
@@ -419,26 +414,6 @@ parameters:
             path: 'src/JsCallback.php'
             identifier: method.childParameterType
             message: '~^Parameter #2 \$args \(array<int\|string, Atk4\\Ui\\Js\\JsCallbackLoadableValue>\) of method Atk4\\Ui\\JsCallback::set\(\) should be contravariant with parameter \$fxArgs \(list<mixed>\) of method Atk4\\Ui\\Callback::set\(\)$~'
-            count: 1
-        -
-            path: 'src/Loader.php'
-            identifier: method.childParameterType
-            message: '~^Parameter #1 \$fx \(Closure\(\$this\): void\) of method Atk4\\Ui\\Loader::set\(\) should be compatible with parameter \$content \(string\) of method Atk4\\Ui\\View::set\(\)$~'
-            count: 1
-        -
-            path: 'src/Modal.php'
-            identifier: method.childParameterType
-            message: '~^Parameter #1 \$fx \(Closure\(Atk4\\Ui\\View\): void\) of method Atk4\\Ui\\Modal::set\(\) should be compatible with parameter \$content \(string\) of method Atk4\\Ui\\View::set\(\)$~'
-            count: 1
-        -
-            path: 'src/Popup.php'
-            identifier: method.childParameterType
-            message: '~^Parameter #1 \$fx \(Closure\(Atk4\\Ui\\View\): void\) of method Atk4\\Ui\\Popup::set\(\) should be compatible with parameter \$content \(string\) of method Atk4\\Ui\\View::set\(\)$~'
-            count: 1
-        -
-            path: 'src/VirtualPage.php'
-            identifier: method.childParameterType
-            message: '~^Parameter #1 \$fx \(Closure\(\$this, mixed, mixed, mixed, mixed, mixed, mixed, mixed, mixed, mixed, mixed\): void\) of method Atk4\\Ui\\VirtualPage::set\(\) should be compatible with parameter \$content \(string\) of method Atk4\\Ui\\View::set\(\)$~'
             count: 1
         -
             path: 'src/VirtualPage.php'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -571,12 +571,12 @@ parameters:
         -
             path: 'src/Header.php'
             identifier: assign.propertyType
-            message: '~^Property Atk4\\Ui\\Header::\$subHeader \(string\) does not accept Atk4\\Ui\\View\.$~'
+            message: '~^Property Atk4\\Ui\\Header::\$subHeader \(string\) does not accept Atk4\\Ui\\ViewWithContent\.$~'
             count: 1
         -
             path: 'src/Label.php'
             identifier: assign.propertyType
-            message: '~^Property Atk4\\Ui\\Label::\$detail \(string\|false\|null\) does not accept Atk4\\Ui\\View\.$~'
+            message: '~^Property Atk4\\Ui\\Label::\$detail \(string\|false\|null\) does not accept Atk4\\Ui\\ViewWithContent\.$~'
             count: 1
         -
             path: 'src/Menu.php'

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -10,6 +10,9 @@ class Breadcrumb extends Lister
 
     public $defaultTemplate = 'breadcrumb.html';
 
+    /** @var string|null */
+    public $title;
+
     /** @var list<array{section: string, link: string|array<0|string, string|int|false>}> */
     public $path = [];
 
@@ -43,7 +46,7 @@ class Breadcrumb extends Lister
     public function popTitle()
     {
         $title = array_pop($this->path);
-        $this->set($title['section'] ?? '');
+        $this->title = $title['section'];
 
         return $this;
     }
@@ -69,5 +72,9 @@ class Breadcrumb extends Lister
         $this->setSource($this->path);
 
         parent::renderView();
+
+        if ($this->title !== null) {
+            $this->template->append('Content', $this->title);
+        }
     }
 }

--- a/src/Button.php
+++ b/src/Button.php
@@ -7,7 +7,7 @@ namespace Atk4\Ui;
 /**
  * Component implementing UI Button.
  */
-class Button extends View
+class Button extends ViewWithContent
 {
     public $defaultTemplate = 'button.html';
 

--- a/src/Card.php
+++ b/src/Card.php
@@ -183,7 +183,7 @@ class Card extends View
 
         $this->template->trySet('dataId', $this->getApp()->uiPersistence->typecastAttributeSaveField($this->entity->getIdField(), $this->entity->getId()));
 
-        View::addTo($this->getSection(), [$entity->getTitle(), 'class.header' => true]);
+        ViewWithContent::addTo($this->getSection(), [$entity->getTitle(), 'class.header' => true]);
         $this->getSection()->addFields($entity, $fields, $this->useLabel, $this->useTable);
     }
 
@@ -198,7 +198,7 @@ class Card extends View
     {
         $section = CardSection::addToWithCl($this, array_merge($this->cardSectionSeed, ['card' => $this]), ['Section']);
         if ($title) {
-            View::addTo($section, [$title, 'class.header' => true]);
+            ViewWithContent::addTo($section, [$title, 'class.header' => true]);
         }
 
         if ($entity !== null && $fields) {
@@ -280,10 +280,10 @@ class Card extends View
                 $extra .= $entity->get($field) . $glue;
             }
             $extra = rtrim($extra, $glue);
-            $this->addExtraContent(new View([$extra, 'ui' => 'basic fitted segment']));
+            $this->addExtraContent(new ViewWithContent([$extra, 'ui' => 'basic fitted segment']));
         } else {
             foreach ($fields as $field) {
-                $this->addExtraContent(new View([$entity->get($field), 'class.ui basic fitted segment' => true]));
+                $this->addExtraContent(new ViewWithContent([$entity->get($field), 'class.ui basic fitted segment' => true]));
             }
         }
     }

--- a/src/CardSection.php
+++ b/src/CardSection.php
@@ -43,7 +43,7 @@ class CardSection extends View
         $view = null;
 
         if (is_string($description)) {
-            $view = View::addTo($this, [$description, 'class' => ['description']]);
+            $view = ViewWithContent::addTo($this, [$description, 'class' => ['description']]);
         } else {
             $view = $this->add($description)->addClass('description');
         }

--- a/src/Columns.php
+++ b/src/Columns.php
@@ -7,7 +7,7 @@ namespace Atk4\Ui;
 /**
  * Vertically distributed columns based on CSS Grid system.
  */
-class Columns extends View
+class Columns extends ViewWithContent
 {
     public $ui = 'grid';
 

--- a/src/Console.php
+++ b/src/Console.php
@@ -62,8 +62,9 @@ class Console extends View implements LoggerInterface
      * @param \Closure($this): void $fx    callback which will be executed while displaying output inside console
      * @param bool|string           $event "true" would mean to execute on page load, string would indicate
      *                                     JS event. See first argument for View::js()
+     *
+     * @return $this
      */
-    #[\Override]
     public function set($fx = null, $event = null)
     {
         if (!$fx instanceof \Closure) {

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -19,8 +19,26 @@ class Dropdown extends Lister
     /** @var JsCallback|null Callback when a new value is selected in Dropdown. */
     public $cb;
 
+    /** @var string|null Set static contents of this view. */
+    public $content;
+
     /** @var array<string, mixed> As per Fomantic-UI dropdown options. */
     public $dropdownOptions = [];
+
+    /**
+     * @param array<0|string, mixed>|string $label
+     */
+    public function __construct($label = [])
+    {
+        $defaults = is_array($label) ? $label : [$label];
+
+        if (array_key_exists(0, $defaults)) {
+            $defaults['content'] = $defaults[0];
+            unset($defaults[0]);
+        }
+
+        parent::__construct($defaults);
+    }
 
     #[\Override]
     protected function init(): void
@@ -70,6 +88,10 @@ class Dropdown extends Lister
         $this->js(true)->dropdown($this->dropdownOptions);
 
         parent::renderView();
+
+        if ($this->content !== null) {
+            $this->template->append('Content', $this->content);
+        }
     }
 
     #[\Override]

--- a/src/Form/Control.php
+++ b/src/Form/Control.php
@@ -13,13 +13,14 @@ use Atk4\Ui\Js\Jquery;
 use Atk4\Ui\Js\JsExpression;
 use Atk4\Ui\Js\JsExpressionable;
 use Atk4\Ui\View;
+use Atk4\Ui\ViewWithContent;
 
 /**
  * Provides generic functionality for a form control.
  *
  * @phpstan-type JsCallbackSetWithValueClosure \Closure(Jquery, mixed): (JsExpressionable|View|string|void)
  */
-abstract class Control extends View
+abstract class Control extends ViewWithContent
 {
     /** @var Form|null to which this field belongs */
     public ?View $form = null;

--- a/src/Header.php
+++ b/src/Header.php
@@ -14,7 +14,7 @@ namespace Atk4\Ui;
  *
  * $h = new Header(['size' => 'large']); // make large header <div class="ui large header">..</div>
  */
-class Header extends View
+class Header extends ViewWithContent
 {
     /** @var int|string Set to 1, 2, .. 5 for page-headers or small/medium/large for content headers. */
     public $size;

--- a/src/Header.php
+++ b/src/Header.php
@@ -55,7 +55,7 @@ class Header extends ViewWithContent
         }
 
         if ($this->subHeader) {
-            $this->subHeader = View::addTo($this, [$this->subHeader], ['SubHeader'])->addClass('sub header');
+            $this->subHeader = ViewWithContent::addTo($this, [$this->subHeader], ['SubHeader'])->addClass('sub header');
         }
 
         if ($this->aligned) {

--- a/src/HelloWorld.php
+++ b/src/HelloWorld.php
@@ -7,7 +7,7 @@ namespace Atk4\Ui;
 /**
  * Implements Hello World. Add this view anywhere!
  */
-class HelloWorld extends View
+class HelloWorld extends ViewWithContent
 {
     #[\Override]
     protected function init(): void

--- a/src/Icon.php
+++ b/src/Icon.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Atk4\Ui;
 
-class Icon extends View
+class Icon extends ViewWithContent
 {
     public $defaultTemplate = 'icon.html';
 

--- a/src/Image.php
+++ b/src/Image.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Atk4\Ui;
 
-class Image extends View
+class Image extends ViewWithContent
 {
     public $ui = 'image';
 

--- a/src/ItemsPerPageSelector.php
+++ b/src/ItemsPerPageSelector.php
@@ -11,7 +11,7 @@ use Atk4\Ui\Js\JsExpression;
  * Implement an item per page length selector.
  * Set as a dropdown menu which contains the number of items per page need.
  */
-class ItemsPerPageSelector extends View
+class ItemsPerPageSelector extends ViewWithContent
 {
     public $defaultTemplate = 'pagelength.html';
     public $ui = 'selection compact dropdown';

--- a/src/Label.php
+++ b/src/Label.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Atk4\Ui;
 
-class Label extends View
+class Label extends ViewWithContent
 {
     public $ui = 'label';
 

--- a/src/Label.php
+++ b/src/Label.php
@@ -56,7 +56,7 @@ class Label extends ViewWithContent
         }
 
         if ($this->detail) {
-            $this->detail = View::addTo($this, [$this->detail], ['AfterContent'])->addClass('detail');
+            $this->detail = ViewWithContent::addTo($this, [$this->detail], ['AfterContent'])->addClass('detail');
         }
 
         if ($this->iconRight) {

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -75,8 +75,9 @@ class Loader extends View
      *  });
      *
      * @param \Closure($this): void $fx
+     *
+     * @return $this
      */
-    #[\Override]
     public function set($fx = null)
     {
         if (!$fx instanceof \Closure) {

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -9,7 +9,7 @@ use Atk4\Ui\Js\Jquery;
 use Atk4\Ui\Js\JsBlock;
 use Atk4\Ui\Js\JsExpressionable;
 
-class Menu extends View
+class Menu extends ViewWithContent
 {
     public $ui = 'menu';
 

--- a/src/MenuItem.php
+++ b/src/MenuItem.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Atk4\Ui;
 
-class MenuItem extends View
+class MenuItem extends ViewWithContent
 {
     /** @var string Specify a label for this menu item. */
     public $label;

--- a/src/Message.php
+++ b/src/Message.php
@@ -11,7 +11,7 @@ namespace Atk4\Ui;
  * ])
  * ->text->addParagraph('').
  */
-class Message extends View
+class Message extends ViewWithContent
 {
     /** @var 'info'|'warning'|'success'|'error'|null */
     public $type;

--- a/src/Modal.php
+++ b/src/Modal.php
@@ -69,8 +69,9 @@ class Modal extends View
      * Set callback function for this modal.
      *
      * @param \Closure(View): void $fx
+     *
+     * @return $this
      */
-    #[\Override]
     public function set($fx = null)
     {
         if (!$fx instanceof \Closure) {

--- a/src/Panel/Right.php
+++ b/src/Panel/Right.php
@@ -11,6 +11,7 @@ use Atk4\Ui\Js\JsChain;
 use Atk4\Ui\Js\JsExpressionable;
 use Atk4\Ui\Modal;
 use Atk4\Ui\View;
+use Atk4\Ui\ViewWithContent;
 
 /**
  * Right Panel implementation.
@@ -140,7 +141,7 @@ class Right extends View implements Loadable
             $cancelButton = (new Button(['Cancel']))->addClass('cancel');
         }
         $this->closeModal = $this->getApp()->add(array_merge($this->defaultModal, ['title' => $title]));
-        $this->closeModal->add([View::class, $msg, 'element' => 'p']);
+        $this->closeModal->add([ViewWithContent::class, $msg, 'element' => 'p']);
         $this->closeModal->addButtonAction(Factory::factory($okButton));
         $this->closeModal->addButtonAction(Factory::factory($cancelButton));
 

--- a/src/Popup.php
+++ b/src/Popup.php
@@ -127,8 +127,9 @@ class Popup extends View
      * for adding content to it.
      *
      * @param \Closure(View): void $fx
+     *
+     * @return $this
      */
-    #[\Override]
     public function set($fx = null)
     {
         if (!$fx instanceof \Closure) {

--- a/src/ProgressBar.php
+++ b/src/ProgressBar.php
@@ -9,7 +9,7 @@ use Atk4\Ui\Js\JsExpressionable;
 /**
  * $bar = ProgressBar::addTo($app, [10, 'label' => 'Processing files']);.
  */
-class ProgressBar extends View
+class ProgressBar extends ViewWithContent
 {
     /** @var string|false|null Contains a text label to display under the bar. Null/false will disable the label. */
     public $label;

--- a/src/Table/Column/ActionMenu.php
+++ b/src/Table/Column/ActionMenu.php
@@ -14,6 +14,7 @@ use Atk4\Ui\Js\JsExpressionable;
 use Atk4\Ui\Table;
 use Atk4\Ui\UserAction\ExecutorInterface;
 use Atk4\Ui\View;
+use Atk4\Ui\ViewWithContent;
 
 /**
  * Table column action menu.
@@ -65,7 +66,7 @@ class ActionMenu extends Table\Column
         $name = $this->name . '_action_' . (count($this->items) + 1);
 
         if (!is_object($item)) {
-            $item = Factory::factory([View::class], ['ui' => 'item', 'content' => $item]);
+            $item = Factory::factory([ViewWithContent::class], ['ui' => 'item', 'content' => $item]);
         }
 
         $this->assertColumnViewNotInitialized($item);

--- a/src/Tabs.php
+++ b/src/Tabs.php
@@ -7,7 +7,7 @@ namespace Atk4\Ui;
 use Atk4\Core\Factory;
 use Atk4\Ui\Js\JsFunction;
 
-class Tabs extends View
+class Tabs extends ViewWithContent
 {
     public $defaultTemplate = 'tabs.html';
     public $ui = 'tabbed menu';

--- a/src/Text.php
+++ b/src/Text.php
@@ -9,7 +9,7 @@ use Atk4\Ui\HtmlTemplate\Value as HtmlValue;
 /**
  * Simple text block view.
  */
-class Text extends View
+class Text extends ViewWithContent
 {
     public $defaultTemplate;
 

--- a/src/UserAction/PanelExecutor.php
+++ b/src/UserAction/PanelExecutor.php
@@ -13,6 +13,7 @@ use Atk4\Ui\Js\JsToast;
 use Atk4\Ui\Loader;
 use Atk4\Ui\Panel\Right;
 use Atk4\Ui\View;
+use Atk4\Ui\ViewWithContent;
 
 /**
  * A Step Action Executor that use a Right Panel.
@@ -134,7 +135,7 @@ class PanelExecutor extends Right implements JsExecutorInterface
         }
 
         foreach ($this->steps as $step) {
-            View::addTo($this->stepList)->set($this->stepListItems[$step])->addClass('item')->setAttr(['data-list-item' => $step]);
+            ViewWithContent::addTo($this->stepList)->set($this->stepListItems[$step])->addClass('item')->setAttr(['data-list-item' => $step]);
         }
     }
 

--- a/src/UserAction/PreviewExecutor.php
+++ b/src/UserAction/PreviewExecutor.php
@@ -7,6 +7,7 @@ namespace Atk4\Ui\UserAction;
 use Atk4\Ui\Button;
 use Atk4\Ui\Message;
 use Atk4\Ui\View;
+use Atk4\Ui\ViewWithContent;
 
 class PreviewExecutor extends BasicExecutor
 {
@@ -29,12 +30,12 @@ class PreviewExecutor extends BasicExecutor
 
         switch ($this->previewType) {
             case 'console':
-                $this->preview = View::addTo($this, ['ui' => 'inverted black segment', 'element' => 'pre']);
+                $this->preview = ViewWithContent::addTo($this, ['ui' => 'inverted black segment', 'element' => 'pre']);
                 $this->preview->set($text);
 
                 break;
             case 'text':
-                $this->preview = View::addTo($this, ['ui' => 'segment']);
+                $this->preview = ViewWithContent::addTo($this, ['ui' => 'segment']);
                 $this->preview->set($text);
 
                 break;

--- a/src/UserAction/StepExecutorTrait.php
+++ b/src/UserAction/StepExecutorTrait.php
@@ -14,6 +14,7 @@ use Atk4\Ui\Js\JsExpressionable;
 use Atk4\Ui\Js\JsFunction;
 use Atk4\Ui\Loader;
 use Atk4\Ui\View;
+use Atk4\Ui\ViewWithContent;
 
 trait StepExecutorTrait
 {
@@ -218,12 +219,12 @@ trait StepExecutorTrait
 
         switch ($this->previewType) {
             case 'console':
-                $preview = View::addTo($page, ['ui' => 'inverted black segment', 'element' => 'pre']);
+                $preview = ViewWithContent::addTo($page, ['ui' => 'inverted black segment', 'element' => 'pre']);
                 $preview->set($text);
 
                 break;
             case 'text':
-                $preview = View::addTo($page, ['ui' => 'basic segment']);
+                $preview = ViewWithContent::addTo($page, ['ui' => 'basic segment']);
                 $preview->set($text);
 
                 break;
@@ -237,7 +238,7 @@ trait StepExecutorTrait
 
     protected function doFinal(View $page): void
     {
-        View::addTo($page, ['content' => $this->finalMsg]);
+        ViewWithContent::addTo($page, ['content' => $this->finalMsg]);
         foreach ($this->getActionData('fields') as $field => $value) {
             $this->action->getEntity()->set($field, $value);
         }

--- a/src/UserAction/VpExecutor.php
+++ b/src/UserAction/VpExecutor.php
@@ -14,6 +14,7 @@ use Atk4\Ui\Js\JsChain;
 use Atk4\Ui\Js\JsToast;
 use Atk4\Ui\Loader;
 use Atk4\Ui\View;
+use Atk4\Ui\ViewWithContent;
 use Atk4\Ui\VirtualPage;
 
 /**
@@ -138,8 +139,8 @@ class VpExecutor extends VirtualPage implements JsExecutorInterface
         }
 
         foreach ($this->steps as $step) {
-            // TODO replace `(View::class)` with `View` once https://github.com/phpstan/phpstan/issues/10469 is fixed
-            (View::class)::addTo($this->stepList)->set($this->stepListItems[$step])->addClass('item')->setAttr(['data-list-item' => $step]);
+            // TODO replace `(ViewWithContent::class)` with `ViewWithContent` once https://github.com/phpstan/phpstan/issues/10469 is fixed
+            (ViewWithContent::class)::addTo($this->stepList)->set($this->stepListItems[$step])->addClass('item')->setAttr(['data-list-item' => $step]);
         }
     }
 

--- a/src/View.php
+++ b/src/View.php
@@ -76,9 +76,6 @@ class View extends AbstractView
      */
     public $defaultTemplate = 'element.html';
 
-    /** @var string|null Set static contents of this view. */
-    public $content;
-
     /** Change this if you want to substitute default "div" for something else. */
     public string $element = 'div';
 
@@ -88,17 +85,10 @@ class View extends AbstractView
     // {{{ Setting Things up
 
     /**
-     * @param array<0|string, mixed>|string $label
+     * @param array<string, mixed> $defaults
      */
-    public function __construct($label = [])
+    public function __construct(array $defaults = [])
     {
-        $defaults = is_array($label) ? $label : [$label];
-
-        if (array_key_exists(0, $defaults)) {
-            $defaults['content'] = $defaults[0];
-            unset($defaults[0]);
-        }
-
         $this->setDefaults($defaults);
     }
 
@@ -278,26 +268,6 @@ class View extends AbstractView
     // }}}
 
     // {{{ Manipulating classes and view properties
-
-    /**
-     * TODO this method is hard to override, drop it from View.
-     *
-     * @param string $content
-     *
-     * @return $this
-     */
-    public function set($content)
-    {
-        if (!is_string($content) && $content !== null) { // @phpstan-ignore function.alreadyNarrowedType, notIdentical.alwaysTrue, booleanAnd.alwaysFalse
-            throw (new Exception('Not sure what to do with argument'))
-                ->addMoreInfo('this', $this)
-                ->addMoreInfo('arg', $content);
-        }
-
-        $this->content = $content;
-
-        return $this;
-    }
 
     /**
      * Add CSS class to element. Previously added classes are not affected.
@@ -575,10 +545,6 @@ class View extends AbstractView
                     $this->_jsActions[$when][] = $action;
                 }
             }
-        }
-
-        if ($this->content !== null) {
-            $this->template->append('Content', $this->content);
         }
     }
 

--- a/src/ViewWithContent.php
+++ b/src/ViewWithContent.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atk4\Ui;
+
+/**
+ * TODO move to trait and this class should be migrated to Text.
+ */
+class ViewWithContent extends View
+{
+    /** @var string|null Set static contents of this view. */
+    public $content;
+
+    /**
+     * @param array<0|string, mixed>|string $label
+     */
+    public function __construct($label = [])
+    {
+        $defaults = is_array($label) ? $label : [$label];
+
+        if (array_key_exists(0, $defaults)) {
+            $defaults['content'] = $defaults[0];
+            unset($defaults[0]);
+        }
+
+        parent::__construct($defaults);
+    }
+
+    /**
+     * @param string $content
+     *
+     * @return $this
+     */
+    public function set($content)
+    {
+        if (!is_string($content) && $content !== null) { // @phpstan-ignore function.alreadyNarrowedType, notIdentical.alwaysTrue, booleanAnd.alwaysFalse
+            throw (new Exception('Not sure what to do with argument'))
+                ->addMoreInfo('this', $this)
+                ->addMoreInfo('arg', $content);
+        }
+
+        $this->content = $content;
+
+        return $this;
+    }
+
+    protected function recursiveRender(): void
+    {
+        parent::recursiveRender();
+
+        if ($this->content !== null) {
+            $this->template->append('Content', $this->content);
+        }
+    }
+}

--- a/src/ViewWithContent.php
+++ b/src/ViewWithContent.php
@@ -45,6 +45,7 @@ class ViewWithContent extends View
         return $this;
     }
 
+    #[\Override]
     protected function recursiveRender(): void
     {
         parent::recursiveRender();

--- a/src/ViewWithContent.php
+++ b/src/ViewWithContent.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Atk4\Ui;
 
-/**
- * TODO move to trait and this class should be migrated to Text.
- */
 class ViewWithContent extends View
 {
     /** @var string|null Set static contents of this view. */

--- a/src/VirtualPage.php
+++ b/src/VirtualPage.php
@@ -40,8 +40,9 @@ class VirtualPage extends View
      *
      * @param \Closure($this, mixed, mixed, mixed, mixed, mixed, mixed, mixed, mixed, mixed, mixed): void $fx
      * @param list<mixed>                                                                                 $fxArgs
+     *
+     * @return $this
      */
-    #[\Override]
     public function set($fx = null, $fxArgs = [])
     {
         if (!$fx instanceof \Closure) {

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -18,6 +18,7 @@ use Atk4\Ui\Popup;
 use Atk4\Ui\View;
 use Atk4\Ui\View\EntityTrait;
 use Atk4\Ui\View\ModelTrait;
+use Atk4\Ui\ViewWithContent;
 use Atk4\Ui\VirtualPage;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -220,7 +221,7 @@ class ViewTest extends TestCase
 
         $this->expectException(\Error::class);
         $this->expectExceptionMessage('$fx must be of type Closure');
-        $v->set('strlen');
+        $v->set('strlen'); // @phpstan-ignore argument.type, argument.templateType
     }
 
     /**

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -88,7 +88,7 @@ class ViewTest extends TestCase
 
     public function testMultipleTimesRender(): void
     {
-        $v = new View();
+        $v = new ViewWithContent();
         $v->set('foo');
 
         $v->setApp($this->createApp());
@@ -99,7 +99,7 @@ class ViewTest extends TestCase
 
     public function testAddAfterRenderException(): void
     {
-        $v = new View();
+        $v = new ViewWithContent();
         $v->set('foo');
 
         $v->setApp($this->createApp());
@@ -202,7 +202,7 @@ class ViewTest extends TestCase
 
     public function testSetException(): void
     {
-        $v = new View();
+        $v = new ViewWithContent();
 
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Not sure what to do with argument');


### PR DESCRIPTION
continue #2075 and #2239

`View::set` method was too abstract and clean override using LSP was not possible.

If `View::$content` property is needed (and optionally set the data using constructor and/or `View::set` method), migrate to `ViewWithContent` class which behaves like the original `View`.

There were two major usecases for `View::$content` property / `View::set()` method:
- set text data for `Content` tag
- set value for form control