### PR TITLE
View::set() can be used to set content property only

### DIFF
--- a/demos/form-control/upload.php
+++ b/demos/form-control/upload.php
@@ -18,7 +18,7 @@ $img = $form->addControl('img', [Form\Control\UploadImage::class, ['defaultSrc' 
 $control = $form->addControl('file', [Form\Control\Upload::class, ['accept' => ['.png', '.jpg']]]);
 
 // $control->set('a_generated_token', 'a-file-name');
-// $control->set('a_generated_token');
+// $control->set('a_generated_token', null);
 
 $img->onDelete(function (string $fileId) use ($img) {
     $img->clearThumbnail();

--- a/demos/layout/layouts.php
+++ b/demos/layout/layouts.php
@@ -33,7 +33,6 @@ $i = View::addTo($app, ['class.green' => true, 'ui' => 'segment'])->setElement('
 
 // add buttons in toolbar
 foreach ($buttons as $k => $args) {
-    Button::addTo($tb)
-        ->set([$args['title'], 'iconRight' => 'down arrow'])
-        ->on('click', $i->js()->attr('src', $app->url($args['page'])));
+    $button = Button::addTo($tb, [$args['title'], 'iconRight' => 'down arrow']);
+    $button->on('click', $i->js()->attr('src', $app->url($args['page'])));
 }

--- a/docs/template.rst
+++ b/docs/template.rst
@@ -85,7 +85,7 @@ engine directly, but you would be able to use it through views::
 
 
     $v = new View('my_template.html');
-    $v->set('name', 'Mr. Boss');
+    $v->template->set('name', 'Mr. Boss');
 
     $lister = new Lister($v, 'Content');
     $lister->setModel($userlist);
@@ -96,7 +96,7 @@ The code above will work like this:
 
 1. View will load and parse template.
 
-2. Using $v->set('name') will set value of the tag inside template directly.
+2. Using $v->template->set('name', ...) will set value of the tag inside template directly.
 
 3. Lister will clone region 'Content' from my_template.
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -224,13 +224,7 @@ parameters:
         # TODO fix contravariance for View::set() method
         -
             path: 'src/Console.php'
-            message: '~^Parameter #1 \$fx \(Closure\(\$this\): void\) of method Atk4\\Ui\\Console::set\(\) should be contravariant with parameter \$arg1 \(mixed\) of method Atk4\\Ui\\View::set\(\)$~'
-        -
-            path: 'src/Console.php'
-            message: '~^Parameter #2 \$event \(bool\|string\) of method Atk4\\Ui\\Console::set\(\) should be contravariant with parameter \$arg2 \(mixed\) of method Atk4\\Ui\\View::set\(\)$~'
-        -
-            path: 'src/Form/Control.php'
-            message: '~^Parameter #2 \$ignore \(\*NEVER\*\) of method Atk4\\Ui\\Form\\Control::set\(\) should be compatible with parameter \$arg2 \(mixed\) of method Atk4\\Ui\\View::set\(\)$~'
+            message: '~^Parameter #1 \$fx \(Closure\(\$this\): void\) of method Atk4\\Ui\\Console::set\(\) should be compatible with parameter \$content \(string\) of method Atk4\\Ui\\View::set\(\)$~'
         -
             path: 'src/Form/Control/Calendar.php'
             message: '~^Parameter #1 \$expr \(Atk4\\Ui\\Js\\JsExpressionable\) of method Atk4\\Ui\\Form\\Control\\Calendar::onChange\(\) should be contravariant with parameter \$expr \(array\{Closure\(Atk4\\Ui\\Js\\Jquery, mixed, mixed, mixed, mixed, mixed, mixed, mixed, mixed, mixed, mixed\): \(Atk4\\Ui\\Js\\JsExpressionable\|Atk4\\Ui\\View\|string\|void\)\}\|Atk4\\Ui\\Js\\JsExpressionable\|\(Closure\(Atk4\\Ui\\Js\\Jquery, mixed, mixed, mixed, mixed, mixed, mixed, mixed, mixed, mixed, mixed\): \(Atk4\\Ui\\Js\\JsExpressionable\|Atk4\\Ui\\View\|string\|void\)\)\) of method Atk4\\Ui\\Form\\Control::onChange\(\)$~'
@@ -242,31 +236,19 @@ parameters:
             message: '~^Parameter #1 \$fx \(Closure\(Atk4\\Ui\\Js\\Jquery, mixed, mixed, mixed, mixed, mixed, mixed, mixed, mixed, mixed, mixed\): \(Atk4\\Ui\\Js\\JsExpressionable\|Atk4\\Ui\\View\|string\|void\)\) of method Atk4\\Ui\\JsCallback::set\(\) should be contravariant with parameter \$fx \(Closure\(mixed, mixed, mixed, mixed, mixed, mixed, mixed, mixed, mixed, mixed\): mixed\) of method Atk4\\Ui\\Callback::set\(\)$~'
         -
             path: 'src/Loader.php'
-            message: '~^Parameter #1 \$fx \(Closure\(\$this\): void\) of method Atk4\\Ui\\Loader::set\(\) should be contravariant with parameter \$arg1 \(mixed\) of method Atk4\\Ui\\View::set\(\)$~'
-        -
-            path: 'src/Loader.php'
-            message: '~^Parameter #2 \$ignore \(\*NEVER\*\) of method Atk4\\Ui\\Loader::set\(\) should be compatible with parameter \$arg2 \(mixed\) of method Atk4\\Ui\\View::set\(\)$~'
+            message: '~^Parameter #1 \$fx \(Closure\(\$this\): void\) of method Atk4\\Ui\\Loader::set\(\) should be compatible with parameter \$content \(string\) of method Atk4\\Ui\\View::set\(\)$~'
         -
             path: 'src/Modal.php'
-            message: '~^Parameter #1 \$fx \(Closure\(Atk4\\Ui\\View\): void\) of method Atk4\\Ui\\Modal::set\(\) should be contravariant with parameter \$arg1 \(mixed\) of method Atk4\\Ui\\View::set\(\)$~'
-        -
-            path: 'src/Modal.php'
-            message: '~^Parameter #2 \$ignore \(\*NEVER\*\) of method Atk4\\Ui\\Modal::set\(\) should be compatible with parameter \$arg2 \(mixed\) of method Atk4\\Ui\\View::set\(\)$~'
+            message: '~^Parameter #1 \$fx \(Closure\(Atk4\\Ui\\View\): void\) of method Atk4\\Ui\\Modal::set\(\) should be compatible with parameter \$content \(string\) of method Atk4\\Ui\\View::set\(\)$~'
         -
             path: 'src/Popup.php'
-            message: '~^Parameter #1 \$fx \(Closure\(Atk4\\Ui\\View\): void\) of method Atk4\\Ui\\Popup::set\(\) should be contravariant with parameter \$arg1 \(mixed\) of method Atk4\\Ui\\View::set\(\)$~'
-        -
-            path: 'src/Popup.php'
-            message: '~^Parameter #2 \$ignore \(\*NEVER\*\) of method Atk4\\Ui\\Popup::set\(\) should be compatible with parameter \$arg2 \(mixed\) of method Atk4\\Ui\\View::set\(\)$~'
+            message: '~^Parameter #1 \$fx \(Closure\(Atk4\\Ui\\View\): void\) of method Atk4\\Ui\\Popup::set\(\) should be compatible with parameter \$content \(string\) of method Atk4\\Ui\\View::set\(\)$~'
         -
             path: 'src/VirtualPage.php'
-            message: '~^Parameter #1 \$fx \(Closure\(\$this, mixed, mixed, mixed, mixed, mixed, mixed, mixed, mixed, mixed, mixed\): void\) of method Atk4\\Ui\\VirtualPage::set\(\) should be contravariant with parameter \$arg1 \(mixed\) of method Atk4\\Ui\\View::set\(\)$~'
+            message: '~^Parameter #1 \$fx \(Closure\(\$this, mixed, mixed, mixed, mixed, mixed, mixed, mixed, mixed, mixed, mixed\): void\) of method Atk4\\Ui\\VirtualPage::set\(\) should be compatible with parameter \$content \(string\) of method Atk4\\Ui\\View::set\(\)$~'
         -
             path: 'src/VirtualPage.php'
             message: '~^Parameter #1 \$fx of method Atk4\\Ui\\Callback::set\(\) expects \(Closure\(mixed, mixed, mixed, mixed, mixed, mixed, mixed, mixed, mixed, mixed\): void\)\|null, Closure\(\$this, mixed, mixed, mixed, mixed, mixed, mixed, mixed, mixed, mixed, mixed\): void given\.$~'
-        -
-            path: 'src/VirtualPage.php'
-            message: '~^Parameter #2 \$fxArgs \(array\) of method Atk4\\Ui\\VirtualPage::set\(\) should be contravariant with parameter \$arg2 \(mixed\) of method Atk4\\Ui\\View::set\(\)$~'
 
         # TODO these rules are generated, this ignores should be fixed in the code
         # for level = 3

--- a/src/Form.php
+++ b/src/Form.php
@@ -291,16 +291,16 @@ class Form extends View
         if ($success instanceof View) {
             $response = $success;
         } elseif ($useTemplate) {
-            $response = $this->getApp()->loadTemplate($this->successTemplate);
-            $response->set('header', $success);
+            $responseTemplate = $this->getApp()->loadTemplate($this->successTemplate);
+            $responseTemplate->set('header', $success);
 
             if ($subHeader) {
-                $response->set('message', $subHeader);
+                $responseTemplate->set('message', $subHeader);
             } else {
-                $response->del('p');
+                $responseTemplate->del('p');
             }
 
-            $response = $this->js()->html($response->renderToHtml());
+            $response = $this->js()->html($responseTemplate->renderToHtml());
         } else {
             $response = new Message([$success, 'type' => 'success', 'icon' => 'check']);
             $response->setApp($this->getApp());

--- a/src/HelloWorld.php
+++ b/src/HelloWorld.php
@@ -13,6 +13,6 @@ class HelloWorld extends View
     {
         parent::init();
 
-        $this->set('Content', 'Hello World');
+        $this->set('Hello World');
     }
 }

--- a/src/ItemsPerPageSelector.php
+++ b/src/ItemsPerPageSelector.php
@@ -60,7 +60,7 @@ class ItemsPerPageSelector extends View
         $this->cb->set(function () use ($fx) {
             $ipp = isset($_GET['ipp']) ? (int) $_GET['ipp'] : null;
             // $this->pageLength->set(preg_replace("/\[ipp\]/", $ipp, $this->label));
-            $this->set($ipp);
+            $this->set($ipp); // @phpstan-ignore-line TODO https://github.com/atk4/ui/issues/2016
             $reload = $fx($ipp);
             if ($reload) {
                 $this->getApp()->terminateJson($reload);

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -94,7 +94,7 @@ class Menu extends View
         $label = $name['title'] ?? $name['text'] ?? $name['name'] ?? $name[0] ?? null;
 
         if ($label !== null) {
-            $subMenu->set('label', $label);
+            $subMenu->template->set('label', $label);
         }
 
         if (isset($name['icon'])) {
@@ -126,7 +126,7 @@ class Menu extends View
         $title = $name['title'] ?? $name['text'] ?? $name['name'] ?? $name[0] ?? null;
 
         if ($title !== null) {
-            $group->set('title', $title);
+            $group->template->set('title', $title);
         }
 
         if (isset($name['icon'])) {

--- a/src/View.php
+++ b/src/View.php
@@ -334,44 +334,25 @@ class View extends AbstractView
     /**
      * TODO this method is hard to override, drop it from View.
      *
-     * Override this method without compatibility with parent, if you wish
-     * to set your own things your own way for your view.
-     *
-     * @param mixed $arg1
-     * @param mixed $arg2
+     * @param string $content
      *
      * @return $this
      */
-    public function set($arg1 = null, $arg2 = null)
+    public function set($content)
     {
-        if ($arg2 !== null) {
-            if (is_string($arg1)) {
-                $this->template->set($arg1, $arg2);
-
-                return $this;
-            }
-        } else {
-            if (is_string($arg1) || $arg1 === null) {
-                $this->content = $arg1;
-
-                return $this;
-            }
-
-            if (is_array($arg1)) {
-                if (isset($arg1[0])) {
-                    $this->content = $arg1[0];
-                    unset($arg1[0]);
-                }
-                $this->setDefaults($arg1);
-
-                return $this;
-            }
+        if (func_num_args() > 1) { // prevent bad usage
+            throw new Exception('Only one argument is needed by View::set()');
         }
 
-        throw (new Exception('Not sure what to do with argument'))
-            ->addMoreInfo('this', $this)
-            ->addMoreInfo('arg1', $arg1)
-            ->addMoreInfo('arg2', $arg2);
+        if (!is_string($content) && $content !== null) { // @phpstan-ignore-line
+            throw (new Exception('Not sure what to do with argument'))
+                ->addMoreInfo('this', $this)
+                ->addMoreInfo('arg', $content);
+        }
+
+        $this->content = $content;
+
+        return $this;
     }
 
     /**

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -148,7 +148,7 @@ class ViewTest extends TestCase
 
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Not sure what to do with argument');
-        $v->set(1);
+        $v->set(1); // @phpstan-ignore-line
     }
 
     /**
@@ -182,6 +182,8 @@ class ViewTest extends TestCase
     }
 
     /**
+     * TODO remove the explicit exceptions and this test/provider once release 5.0 is made.
+     *
      * @param class-string<View> $class
      *
      * @dataProvider setNotOneArgumentExceptionProvider
@@ -192,7 +194,7 @@ class ViewTest extends TestCase
 
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Only one argument is needed by ' . preg_replace('~.+\\\\~', '', $class) . '::set()');
-        $v->set(function () {}, null);
+        $v->set(function () {}, null); // @phpstan-ignore-line
     }
 
     /**
@@ -201,6 +203,7 @@ class ViewTest extends TestCase
     public function setNotOneArgumentExceptionProvider(): array
     {
         return [
+            [View::class],
             [Loader::class],
             [Modal::class],
             [Popup::class],


### PR DESCRIPTION
`View::set()` method was historically coded to support too many usecases which made it very hard to override and satisfy LSP.

Weak static analysis also allowed #2016 bug.

Thankfully, at least in atk4/ui, the misuse count was low.

The replacement is `$this->template->set()` and `$this->setDefaults()` (or `$this->property = value`) depending on the usecase.