### PR TITLE
Require tag name in App::getTag() explicitly

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -888,12 +888,12 @@ class App
      * ])
      * --> <a href="hello"><b class="red"><i class="blue">welcome</i></b></a>'
      *
-     * @param array<0|string, string|bool>                                                                              $attr
-     * @param string|array<int, array{0?: string, 1?: array<0|string, string|bool>, 2?: string|array|null}|string>|null $value
+     * @param array<0|string, string|bool>                                                                             $attr
+     * @param string|array<int, array{0: string, 1?: array<0|string, string|bool>, 2?: string|array|null}|string>|null $value
      */
-    public function getTag(string $tag = null, array $attr = [], $value = null): string
+    public function getTag(string $tag, array $attr = [], $value = null): string
     {
-        $tag = strtolower($tag === null ? 'div' : $tag);
+        $tag = strtolower($tag);
         $tagOrig = $tag;
 
         $isOpening = true;

--- a/src/Form/Control/Dropdown.php
+++ b/src/Form/Control/Dropdown.php
@@ -111,8 +111,6 @@ class Dropdown extends Input
      * Returns presentable value to be inserted into input tag.
      *
      * Dropdown input tag accepts only CSV formatted list of IDs.
-     *
-     * @return mixed
      */
     public function getValue()
     {

--- a/src/Form/Control/Input.php
+++ b/src/Form/Control/Input.php
@@ -88,7 +88,7 @@ class Input extends Form\Control
     /**
      * Returns presentable value to be inserted into input tag.
      *
-     * @return mixed
+     * @return string|null
      */
     public function getValue()
     {

--- a/src/Form/Control/ScopeBuilder.php
+++ b/src/Form/Control/ScopeBuilder.php
@@ -502,24 +502,23 @@ class ScopeBuilder extends Form\Control
      */
     public function queryToScope(array $query): Scope\AbstractScope
     {
-        $type = $query['type'] ?? 'query-builder-group';
-        $query = $query['query'] ?? $query;
-
-        switch ($type) {
-            case 'query-builder-group':
-                $components = array_map(fn ($v) => $this->queryToScope($v), $query['children']);
-                $scope = new Scope($components, $query['logicalOperator']);
-
-                break;
-            case 'query-builder-rule':
-                $scope = $this->queryToCondition($query);
-
-                break;
-            default:
-                $scope = Scope::createAnd();
+        if (!isset($query['type'])) {
+            $query = ['type' => 'query-builder-group', 'query' => $query];
         }
 
-        return $scope;
+        switch ($query['type']) {
+            case 'query-builder-rule':
+                $scope = $this->queryToCondition($query['query']);
+
+                break;
+            case 'query-builder-group':
+                $components = array_map(fn ($v) => $this->queryToScope($v), $query['query']['children']);
+                $scope = new Scope($components, $query['query']['logicalOperator']);
+
+                break;
+        }
+
+        return $scope; // @phpstan-ignore-line
     }
 
     /**

--- a/src/Table/Column.php
+++ b/src/Table/Column.php
@@ -246,9 +246,9 @@ class Column
      * Returns a suitable cell tag with the supplied value. Applies modifiers
      * added through addClass and setAttr.
      *
-     * @param string       $position 'head', 'body' or 'tail'
-     * @param string|array $value    either HTML or array defining HTML structure, see App::getTag help
-     * @param array        $attr     extra attributes to apply on the tag
+     * @param string                                                                                                   $position 'head', 'body' or 'tail'
+     * @param string|array<int, array{0: string, 1?: array<0|string, string|bool>, 2?: string|array|null}|string>|null $value    either HTML or array defining HTML structure, see App::getTag help
+     * @param array<string, string|bool>                                                                               $attr     extra attributes to apply on the tag
      */
     public function getTag(string $position, $value, array $attr = []): string
     {

--- a/src/Table/Column.php
+++ b/src/Table/Column.php
@@ -248,7 +248,7 @@ class Column
      *
      * @param string                                                                                                   $position 'head', 'body' or 'tail'
      * @param string|array<int, array{0: string, 1?: array<0|string, string|bool>, 2?: string|array|null}|string>|null $value    either HTML or array defining HTML structure, see App::getTag help
-     * @param array<string, string|bool>                                                                               $attr     extra attributes to apply on the tag
+     * @param array<string, string|bool|array>                                                                         $attr     extra attributes to apply on the tag
      */
     public function getTag(string $position, $value, array $attr = []): string
     {

--- a/src/Table/Column.php
+++ b/src/Table/Column.php
@@ -291,7 +291,7 @@ class Column
             $attr['id'] = $this->name . '_th';
 
             // add the action tag to the caption
-            $caption = [$this->headerActionTag, $caption];
+            $caption = [$this->headerActionTag, $this->getApp()->encodeHtml($caption)];
         }
 
         if ($this->table->sortable) {

--- a/src/Table/Column/ActionButtons.php
+++ b/src/Table/Column/ActionButtons.php
@@ -118,12 +118,12 @@ class ActionButtons extends Table\Column
         }
 
         // render our buttons
-        $output = '';
+        $outputHtml = '';
         foreach ($this->buttons as $button) {
-            $output .= $button->getHtml();
+            $outputHtml .= $button->getHtml();
         }
 
-        return $this->getApp()->getTag('div', ['class' => 'ui buttons'], [$output]);
+        return $this->getApp()->getTag('div', ['class' => 'ui buttons'], [$outputHtml]);
     }
 
     public function getHtmlTags(Model $row, ?Field $field): array

--- a/src/Table/Column/ActionMenu.php
+++ b/src/Table/Column/ActionMenu.php
@@ -120,15 +120,15 @@ class ActionMenu extends Table\Column
         }
 
         // render our menus
-        $output = '';
+        $outputHtml = '';
         foreach ($this->items as $item) {
-            $output .= $item->getHtml();
+            $outputHtml .= $item->getHtml();
         }
 
         $res = $this->getApp()->getTag('div', ['class' => 'ui ' . $this->ui . ' atk-action-menu'], [
             ['div', ['class' => 'text'], $this->label],
             $this->icon ? $this->getApp()->getTag('i', ['class' => $this->icon . ' icon'], '') : '',
-            ['div', ['class' => 'menu'], [$output]],
+            ['div', ['class' => 'menu'], [$outputHtml]],
         ]);
 
         return $res;

--- a/src/Table/Column/Labels.php
+++ b/src/Table/Column/Labels.php
@@ -29,10 +29,10 @@ class Labels extends Table\Column
         $labelsHtml = [];
         foreach ($v as $id) {
             // if field values is set, then use titles instead of IDs
-            $id = $values[$id] ?? $id;
+            $label = $values[$id] ?? $id;
 
-            if ($id !== '') {
-                $labelsHtml[] = $this->getApp()->getTag('div', ['class' => 'ui label'], $id);
+            if ($label !== '') {
+                $labelsHtml[] = $this->getApp()->getTag('div', ['class' => 'ui label'], $label);
             }
         }
 

--- a/src/Table/Column/Labels.php
+++ b/src/Table/Column/Labels.php
@@ -16,7 +16,7 @@ use Atk4\Ui\Table;
  */
 class Labels extends Table\Column
 {
-    /** @var array|null Allowed values, prioritized over Field::$values */
+    /** @var array<string|int, string>|null Allowed values, prioritized over Field::$values */
     public ?array $values = null;
 
     public function getHtmlTags(Model $row, ?Field $field): array

--- a/src/Table/Column/Link.php
+++ b/src/Table/Column/Link.php
@@ -121,21 +121,21 @@ class Link extends Table\Column
             $attr['target'] = $this->target;
         }
 
-        $icon = '';
+        $iconHtml = '';
         if ($this->icon) {
-            $icon = $this->getApp()->getTag('i', ['class' => $this->icon . ' icon'], '');
+            $iconHtml = $this->getApp()->getTag('i', ['class' => $this->icon . ' icon'], '');
         }
 
-        $label = '';
+        $labelHtml = '';
         if ($this->useLabel) {
-            $label = $field ? ('{$' . $field->shortName . '}') : '[Link]';
+            $labelHtml = $field ? ('{$' . $field->shortName . '}') : '[Link]';
         }
 
         if ($this->class) {
             $attr['class'] = $this->class;
         }
 
-        return $this->getApp()->getTag('a', $attr, [$icon, $label]); // TODO $label is not HTML encoded
+        return $this->getApp()->getTag('a', $attr, [$iconHtml, $labelHtml]);
     }
 
     public function getHtmlTags(Model $row, ?Field $field): array

--- a/src/Table/Column/Status.php
+++ b/src/Table/Column/Status.php
@@ -46,7 +46,8 @@ class Status extends Table\Column
         }
 
         return $this->getApp()->getTag('td', $attr, [
-            $this->getApp()->getTag('i', ['class' => 'icon {$_' . $field->shortName . '_icon}'], '') . ' {$' . $field->shortName . '}',
+            ['i', ['class' => 'icon {$_' . $field->shortName . '_icon}'], ''],
+            ' {$' . $field->shortName . '}',
         ]);
     }
 

--- a/src/Table/Column/Tooltip.php
+++ b/src/Table/Column/Tooltip.php
@@ -47,12 +47,13 @@ class Tooltip extends Table\Column
         }
 
         return $this->getApp()->getTag('td', $attr, [
-            ' {$' . $field->shortName . '}' . $this->getApp()->getTag('span', [
+            ' {$' . $field->shortName . '}',
+            ['span', [
                 'class' => 'ui icon link {$_' . $field->shortName . '_data_visible_class}',
                 'data-tooltip' => '{$_' . $field->shortName . '_data_tooltip}',
             ], [
                 ['i', ['class' => 'ui icon {$_' . $field->shortName . '_icon}']],
-            ]),
+            ]],
         ]);
     }
 

--- a/src/Table/Column/Tooltip.php
+++ b/src/Table/Column/Tooltip.php
@@ -47,13 +47,12 @@ class Tooltip extends Table\Column
         }
 
         return $this->getApp()->getTag('td', $attr, [
-            ' {$' . $field->shortName . '}'
-                . $this->getApp()->getTag('span', [
-                    'class' => 'ui icon link {$_' . $field->shortName . '_data_visible_class}',
-                    'data-tooltip' => '{$_' . $field->shortName . '_data_tooltip}',
-                ], [
-                    ['i', ['class' => 'ui icon {$_' . $field->shortName . '_icon}']],
-                ]),
+            ' {$' . $field->shortName . '}' . $this->getApp()->getTag('span', [
+                'class' => 'ui icon link {$_' . $field->shortName . '_data_visible_class}',
+                'data-tooltip' => '{$_' . $field->shortName . '_data_tooltip}',
+            ], [
+                ['i', ['class' => 'ui icon {$_' . $field->shortName . '_icon}']],
+            ]),
         ]);
     }
 

--- a/tests/TagTest.php
+++ b/tests/TagTest.php
@@ -10,6 +10,9 @@ use Atk4\Ui\Exception;
 
 class TagTest extends TestCase
 {
+    /**
+     * @param array{0: string, 1?: array<0|string, string|bool>, 2?: string|array|null} $args
+     */
     public static function assertTagRender(string $expectedHtml, array $args): void
     {
         $app = (new \ReflectionClass(App::class))->newInstanceWithoutConstructor();
@@ -21,12 +24,11 @@ class TagTest extends TestCase
     {
         self::assertTagRender('<b>', ['b']);
         self::assertTagRender('<b>hello world</b>', ['b', [], 'hello world']);
-        self::assertTagRender('<div>', []);
     }
 
     public function testEscaping(): void
     {
-        self::assertTagRender('<div foo="he&quot;llo">', [null, ['foo' => 'he"llo']]);
+        self::assertTagRender('<div foo="he&quot;llo">', ['div', ['foo' => 'he"llo']]);
         self::assertTagRender('<b>bold text &gt;&gt;</b>', ['b', [], 'bold text >>']);
     }
 


### PR DESCRIPTION
tag name to `App::getTag()` must be passed explicitly (use` ?? 'div'` for the 1st arg if needed)