### PR TITLE
Unify App::url() code, convert string page to array early

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -615,7 +615,7 @@ class App
                     return (new ExceptionRenderer\Html(new \Exception()))->getVendorDirectory();
                 }, null, ExceptionRenderer\Html::class)();
             } else {
-                $request = new \Symfony\Component\HttpFoundation\Request($_GET, [], [], [], [], $_SERVER);
+                $request = new \Symfony\Component\HttpFoundation\Request([], [], [], [], [], $_SERVER);
                 $requestUrlPath = $request->getBasePath();
                 $requestLocalPath = realpath($request->server->get('SCRIPT_FILENAME'));
             }

--- a/src/App.php
+++ b/src/App.php
@@ -657,31 +657,30 @@ class App
      */
     public function url($page = [], array $extraRequestUrlArgs = []): string
     {
-        $request = $this->getRequest();
-
-        $pagePath = '';
         if (is_string($page)) {
             $pageExploded = explode('?', $page, 2);
-            $pagePath = $pageExploded[0];
             parse_str($pageExploded[1] ?? '', $page);
-        } else {
-            if (isset($page[0])) {
-                $pagePath = $page[0];
-            } else {
-                // use current page by default
-                $requestUrl = $request->getUri()->getPath();
-                if ($requestUrl === '') { // TODO path must always start with '/'
-                    $requestUrl = '/';
-                }
-                if (substr($requestUrl, -1) === '/') {
-                    $pagePath = $this->urlBuildingIndexPage;
-                } else {
-                    $pagePath = basename($requestUrl, $this->urlBuildingExt);
-                }
-            }
-            unset($page[0]);
-            $pagePath .= $this->urlBuildingExt;
+            $page[0] = $pageExploded[0];
         }
+
+        $request = $this->getRequest();
+
+        if (isset($page[0])) {
+            $pagePath = $page[0];
+        } else {
+            // use current page by default
+            $requestUrl = $request->getUri()->getPath();
+            if ($requestUrl === '') { // TODO path must always start with '/'
+                $requestUrl = '/';
+            }
+            if (substr($requestUrl, -1) === '/') {
+                $pagePath = $this->urlBuildingIndexPage;
+            } else {
+                $pagePath = basename($requestUrl, $this->urlBuildingExt);
+            }
+        }
+        unset($page[0]);
+        $pagePath .= $this->urlBuildingExt;
 
         $args = $extraRequestUrlArgs;
 

--- a/src/App.php
+++ b/src/App.php
@@ -670,16 +670,17 @@ class App
             } else {
                 // use current page by default
                 $requestUrl = $request->getUri()->getPath();
-                if (substr($requestUrl, -1, 1) === '/') {
+                if ($requestUrl === '') { // TODO path must always start with '/'
+                    $requestUrl = '/';
+                }
+                if (substr($requestUrl, -1) === '/') {
                     $pagePath = $this->urlBuildingIndexPage;
                 } else {
                     $pagePath = basename($requestUrl, $this->urlBuildingExt);
                 }
             }
             unset($page[0]);
-            if ($pagePath) {
-                $pagePath .= $this->urlBuildingExt;
-            }
+            $pagePath .= $this->urlBuildingExt;
         }
 
         $args = $extraRequestUrlArgs;

--- a/src/App.php
+++ b/src/App.php
@@ -615,7 +615,7 @@ class App
                     return (new ExceptionRenderer\Html(new \Exception()))->getVendorDirectory();
                 }, null, ExceptionRenderer\Html::class)();
             } else {
-                $request = \Symfony\Component\HttpFoundation\Request::createFromGlobals();
+                $request = new \Symfony\Component\HttpFoundation\Request($_GET, [], [], [], [], $_SERVER);
                 $requestUrlPath = $request->getBasePath();
                 $requestLocalPath = realpath($request->server->get('SCRIPT_FILENAME'));
             }

--- a/src/App.php
+++ b/src/App.php
@@ -612,7 +612,7 @@ class App
             if (\PHP_SAPI === 'cli') { // for phpunit
                 $requestUrlPath = '/';
                 $requestLocalPath = \Closure::bind(static function () {
-                    return dirname((new ExceptionRenderer\Html(new \Exception()))->getVendorDirectory());
+                    return (new ExceptionRenderer\Html(new \Exception()))->getVendorDirectory();
                 }, null, ExceptionRenderer\Html::class)();
             } else {
                 $request = \Symfony\Component\HttpFoundation\Request::createFromGlobals();

--- a/src/App.php
+++ b/src/App.php
@@ -686,9 +686,10 @@ class App
         $args = $extraRequestUrlArgs;
 
         // add sticky arguments
+        $queryParams = $this->getRequest()->getQueryParams();
         foreach ($this->stickyGetArguments as $k => $v) {
-            if ($v && isset($_GET[$k])) {
-                $args[$k] = $_GET[$k];
+            if ($v && isset($queryParams[$k])) {
+                $args[$k] = $queryParams[$k];
             } else {
                 unset($args[$k]);
             }

--- a/src/App.php
+++ b/src/App.php
@@ -660,14 +660,15 @@ class App
         if (is_string($page)) {
             $pageExploded = explode('?', $page, 2);
             parse_str($pageExploded[1] ?? '', $page);
-            $page[0] = $pageExploded[0];
+            $pagePath = $pageExploded[0] !== '' ? $pageExploded[0] : null;
+        } else {
+            $pagePath = $page[0] ?? null;
+            unset($page[0]);
         }
 
         $request = $this->getRequest();
 
-        if (isset($page[0])) {
-            $pagePath = $page[0];
-        } else {
+        if ($pagePath === null) {
             // use current page by default
             $requestUrl = $request->getUri()->getPath();
             if ($requestUrl === '') { // TODO path must always start with '/'
@@ -679,7 +680,6 @@ class App
                 $pagePath = basename($requestUrl, $this->urlBuildingExt);
             }
         }
-        unset($page[0]);
         $pagePath .= $this->urlBuildingExt;
 
         $args = $extraRequestUrlArgs;

--- a/src/App.php
+++ b/src/App.php
@@ -679,7 +679,9 @@ class App
                 $pagePath = basename($pagePath, $this->urlBuildingExt);
             }
         }
-        $pagePath .= $this->urlBuildingExt;
+        if (!str_contains(basename($pagePath), '.')) {
+            $pagePath .= $this->urlBuildingExt;
+        }
 
         $args = $extraRequestUrlArgs;
 

--- a/src/App.php
+++ b/src/App.php
@@ -669,15 +669,14 @@ class App
         $request = $this->getRequest();
 
         if ($pagePath === null) {
-            // use current page by default
-            $requestUrl = $request->getUri()->getPath();
-            if ($requestUrl === '') { // TODO path must always start with '/'
-                $requestUrl = '/';
+            $pagePath = $request->getUri()->getPath();
+            if ($pagePath === '') { // TODO path must always start with '/'
+                $pagePath = '/';
             }
-            if (substr($requestUrl, -1) === '/') {
+            if (substr($pagePath, -1) === '/') {
                 $pagePath = $this->urlBuildingIndexPage;
             } else {
-                $pagePath = basename($requestUrl, $this->urlBuildingExt);
+                $pagePath = basename($pagePath, $this->urlBuildingExt);
             }
         }
         $pagePath .= $this->urlBuildingExt;
@@ -685,10 +684,10 @@ class App
         $args = $extraRequestUrlArgs;
 
         // add sticky arguments
-        $queryParams = $this->getRequest()->getQueryParams();
+        $requestQueryParams = $request->getQueryParams();
         foreach ($this->stickyGetArguments as $k => $v) {
-            if ($v && isset($queryParams[$k])) {
-                $args[$k] = $queryParams[$k];
+            if ($v && isset($requestQueryParams[$k])) {
+                $args[$k] = $requestQueryParams[$k];
             } else {
                 unset($args[$k]);
             }

--- a/src/App.php
+++ b/src/App.php
@@ -704,11 +704,9 @@ class App
             }
         }
 
-        // put URL together
         $pageQuery = http_build_query($args, '', '&', \PHP_QUERY_RFC3986);
-        $url = $pagePath . ($pageQuery ? '?' . $pageQuery : '');
 
-        return $url;
+        return $pagePath . ($pageQuery !== '' ? '?' . $pageQuery : '');
     }
 
     /**

--- a/tests/CallbackTest.php
+++ b/tests/CallbackTest.php
@@ -89,8 +89,8 @@ class CallbackTest extends TestCase
         $this->simulateCallbackTriggering($cbApp);
         $this->simulateCallbackTriggering($cb);
 
-        $expectedUrlCbApp = '?' . Callback::URL_QUERY_TRIGGER_PREFIX . 'aa=callback&' . Callback::URL_QUERY_TARGET . '=aa';
-        $expectedUrlCb = '?' . /* Callback::URL_QUERY_TRIGGER_PREFIX . 'aa=1&' . */ Callback::URL_QUERY_TRIGGER_PREFIX . 'bb=callback&' . Callback::URL_QUERY_TARGET . '=bb';
+        $expectedUrlCbApp = 'index.php?' . Callback::URL_QUERY_TRIGGER_PREFIX . 'aa=callback&' . Callback::URL_QUERY_TARGET . '=aa';
+        $expectedUrlCb = 'index.php?' . /* Callback::URL_QUERY_TRIGGER_PREFIX . 'aa=1&' . */ Callback::URL_QUERY_TRIGGER_PREFIX . 'bb=callback&' . Callback::URL_QUERY_TARGET . '=bb';
         self::assertSame($expectedUrlCbApp, $cbApp->getUrl());
         self::assertSame($expectedUrlCb, $cb->getUrl());
 


### PR DESCRIPTION
The only effective change is when empty or string page starting with `?` is passed, then as the string path is empty, current URL page is returned as the URL path part.

extracted from #2095