### PR TITLE
Always assert request URL path starts with '/'

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -70,22 +70,16 @@ class App
     /** @var bool Will replace an exception handler with our own, that will output errors nicely. */
     public $catchExceptions = true;
 
-    /** @var bool Will display error if callback wasn't triggered. */
-    public $catchRunawayCallbacks = true;
+    /** Will display error if callback wasn't triggered. */
+    protected bool $catchRunawayCallbacks = true;
 
-    /** @var bool Will always run application even if developer didn't explicitly executed run();. */
-    public $alwaysRun = true;
+    /** Will always run application even if developer didn't explicitly executed run();. */
+    protected bool $alwaysRun = true;
 
-    /**
-     * Will be set to true after app->run() is called, which may be done automatically
-     * on exit.
-     */
+    /** Will be set to true after app->run() is called, which may be done automatically on exit. */
     public bool $runCalled = false;
 
-    /**
-     * Will be set to true, when exit is called. Sometimes exit is intercepted by shutdown
-     * handler and we don't want to execute 'beforeExit' multiple times.
-     */
+    /** Will be set to true after exit is called. */
     private bool $exitCalled = false;
 
     public bool $isRendering = false;

--- a/src/App.php
+++ b/src/App.php
@@ -220,6 +220,11 @@ class App
             $this->uiPersistence = new UiPersistence();
         }
 
+        if (!str_starts_with($this->getRequest()->getUri()->getPath(), '/')) {
+            throw (new Exception('Request URL path must always start with \'/\''))
+                ->addMoreInfo('url', (string) $this->getRequest()->getUri());
+        }
+
         if ($this->session === null) {
             $this->session = new App\SessionManager();
         }
@@ -670,9 +675,6 @@ class App
 
         if ($pagePath === null) {
             $pagePath = $request->getUri()->getPath();
-            if ($pagePath === '') { // TODO path must always start with '/'
-                $pagePath = '/';
-            }
         }
         if (str_ends_with($pagePath, '/')) {
             $pagePath .= $this->urlBuildingIndexPage;

--- a/src/Callback.php
+++ b/src/Callback.php
@@ -104,7 +104,7 @@ class Callback extends AbstractView
 
     public function getTriggeredValue(): string
     {
-        return $_GET[self::URL_QUERY_TRIGGER_PREFIX . $this->urlTrigger] ?? '';
+        return $_GET[self::URL_QUERY_TRIGGER_PREFIX . $this->urlTrigger];
     }
 
     /**
@@ -147,6 +147,9 @@ class Callback extends AbstractView
      */
     private function getUrlArguments(string $value = null): array
     {
-        return [self::URL_QUERY_TARGET => $this->urlTrigger, self::URL_QUERY_TRIGGER_PREFIX . $this->urlTrigger => $value ?? $this->getTriggeredValue()];
+        return [
+            self::URL_QUERY_TARGET => $this->urlTrigger,
+            self::URL_QUERY_TRIGGER_PREFIX . $this->urlTrigger => $value ?? ($this->isTriggered() ? $this->getTriggeredValue() : ''),
+        ];
     }
 }

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -70,11 +70,11 @@ class AppTest extends TestCase
 
     public function testEmptyRequestPathException(): void
     {
+        $request = (new Psr17Factory())->createServerRequest('GET', '');
+
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Request URL path must always start with \'/\'');
-        $this->createApp([
-            'request' => (new Psr17Factory())->createServerRequest('GET', ''),
-        ]);
+        $this->createApp(['request' => $request]);
     }
 
     public function provideUrlCases(): iterable

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atk4\Ui\Tests;
 
 use Atk4\Core\Phpunit\TestCase;
+use Atk4\Ui\Exception;
 use Atk4\Ui\Exception\LateOutputError;
 use Atk4\Ui\HtmlTemplate;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -65,6 +66,15 @@ class AppTest extends TestCase
             self::assertSame($testStr, ob_get_contents());
             ob_end_clean();
         }
+    }
+
+    public function testEmptyRequestPathException(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Request URL path must always start with \'/\'');
+        $this->createApp([
+            'request' => (new Psr17Factory())->createServerRequest('GET', ''),
+        ]);
     }
 
     public function provideUrlCases(): iterable

--- a/tests/CallbackTest.php
+++ b/tests/CallbackTest.php
@@ -26,6 +26,8 @@ class AppMock extends App
 
 class CallbackTest extends TestCase
 {
+    use CreateAppTrait;
+
     /** @var string */
     private $htmlDoctypeRegex = '~^<!DOCTYPE~';
 
@@ -36,7 +38,7 @@ class CallbackTest extends TestCase
     {
         parent::setUp();
 
-        $this->app = new AppMock(['alwaysRun' => false, 'catchExceptions' => false]);
+        $this->app = $this->createApp([AppMock::class]);
         $this->app->initLayout([Layout\Centered::class]);
     }
 

--- a/tests/CallbackTest.php
+++ b/tests/CallbackTest.php
@@ -32,7 +32,7 @@ class CallbackTest extends TestCase
     private $htmlDoctypeRegex = '~^<!DOCTYPE~';
 
     /** @var App */
-    public $app;
+    protected $app;
 
     protected function setUp(): void
     {

--- a/tests/CreateAppTrait.php
+++ b/tests/CreateAppTrait.php
@@ -5,17 +5,25 @@ declare(strict_types=1);
 namespace Atk4\Ui\Tests;
 
 use Atk4\Ui\App;
+use Nyholm\Psr7\Factory\Psr17Factory;
 
 trait CreateAppTrait
 {
     /**
-     * @param array<string, mixed> $defaults
+     * @param array<0|string, mixed> $seed
      */
-    protected function createApp(array $defaults = []): App
+    protected function createApp(array $seed = []): App
     {
-        return new App(array_merge([
+        $class = $seed[0] ?? App::class;
+        unset($seed[0]);
+
+        if (!isset($seed['request'])) {
+            $seed['request'] = (new Psr17Factory())->createServerRequest('GET', '/');
+        }
+
+        return new $class(array_merge([
             'catchExceptions' => false,
             'alwaysRun' => false,
-        ], $defaults));
+        ], $seed));
     }
 }

--- a/tests/CreateAppTrait.php
+++ b/tests/CreateAppTrait.php
@@ -14,14 +14,14 @@ trait CreateAppTrait
      */
     protected function createApp(array $seed = []): App
     {
-        $class = $seed[0] ?? App::class;
+        $appClass = $seed[0] ?? App::class;
         unset($seed[0]);
 
         if (!isset($seed['request'])) {
             $seed['request'] = (new Psr17Factory())->createServerRequest('GET', '/');
         }
 
-        return new $class(array_merge([
+        return new $appClass(array_merge([
             'catchExceptions' => false,
             'alwaysRun' => false,
         ], $seed));

--- a/tests/ExecutorFactoryTest.php
+++ b/tests/ExecutorFactoryTest.php
@@ -40,6 +40,8 @@ class TestModel extends Model
 
 class ExecutorFactoryTest extends TestCase
 {
+    use CreateAppTrait;
+
     /** @var Model */
     public $model;
     /** @var App */
@@ -53,14 +55,6 @@ class ExecutorFactoryTest extends TestCase
         $this->model = new TestModel($p);
         $this->app = $this->createApp();
         $this->app->initLayout([Layout\Admin::class]);
-    }
-
-    protected function createApp(): App
-    {
-        return new App([
-            'catchExceptions' => false,
-            'alwaysRun' => false,
-        ]);
     }
 
     public function testExecutorFactory(): void

--- a/tests/ExecutorFactoryTest.php
+++ b/tests/ExecutorFactoryTest.php
@@ -43,9 +43,9 @@ class ExecutorFactoryTest extends TestCase
     use CreateAppTrait;
 
     /** @var Model */
-    public $model;
+    protected $model;
     /** @var App */
-    public $app;
+    protected $app;
 
     protected function setUp(): void
     {

--- a/tests/FormFieldUiTest.php
+++ b/tests/FormFieldUiTest.php
@@ -30,7 +30,7 @@ class FormFieldUiTest extends TestCase
     use CreateAppTrait;
 
     /** @var Model */
-    public $m;
+    protected $m;
 
     protected function setUp(): void
     {

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -30,10 +30,7 @@ class FormTest extends TestCase
         parent::setUp();
 
         $this->form = new Form();
-        $this->form->setApp(new AppFormTestMock([
-            'catchExceptions' => false,
-            'alwaysRun' => false,
-        ]));
+        $this->form->setApp($this->createApp([AppFormTestMock::class]));
         $this->form->invokeInit();
     }
 

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -20,10 +20,10 @@ class FormTest extends TestCase
     use CreateAppTrait;
 
     /** @var Form|null */
-    public $form;
+    protected $form;
 
     /** @var string */
-    public $formError;
+    protected $formError;
 
     protected function setUp(): void
     {
@@ -59,7 +59,7 @@ class FormTest extends TestCase
      * @param \Closure(Model): void  $submitFx
      * @param \Closure(string): void $checkExpectedErrorsFx
      */
-    public function assertFormSubmit(array $postData, \Closure $submitFx = null, \Closure $checkExpectedErrorsFx = null): void
+    protected function assertFormSubmit(array $postData, \Closure $submitFx = null, \Closure $checkExpectedErrorsFx = null): void
     {
         $wasSubmitCalled = false;
         $_POST = array_merge(array_map(static fn () => '', $this->form->controls), $postData);
@@ -130,7 +130,7 @@ class FormTest extends TestCase
         });
     }
 
-    public function assertFormControlError(string $field, string $error): void
+    protected function assertFormControlError(string $field, string $error): void
     {
         $n = preg_match_all('~\.form\(\'add prompt\', \'([^\']*)\', \'([^\']*)\'\)~', $this->formError, $matchesAll, \PREG_SET_ORDER);
         self::assertGreaterThan(0, $n);
@@ -145,7 +145,7 @@ class FormTest extends TestCase
         self::assertTrue($matched, 'Form control ' . $field . ' did not produce error');
     }
 
-    public function assertFormControlNoErrors(string $field): void
+    protected function assertFormControlNoErrors(string $field): void
     {
         $n = preg_match_all('~\.form\(\'add prompt\', \'([^\']*)\', \'([^\']*)\'\)~', $this->formError, $matchesAll, \PREG_SET_ORDER);
         self::assertGreaterThan(0, $n);

--- a/tests/GridTest.php
+++ b/tests/GridTest.php
@@ -15,7 +15,7 @@ class GridTest extends TestCase
     use TableTestTrait;
 
     /** @var MyModel */
-    public $m;
+    protected $m;
 
     protected function setUp(): void
     {

--- a/tests/TableColumnColorRatingTest.php
+++ b/tests/TableColumnColorRatingTest.php
@@ -16,7 +16,7 @@ class TableColumnColorRatingTest extends TestCase
     use TableTestTrait;
 
     /** @var Table */
-    public $table;
+    protected $table;
 
     protected function setUp(): void
     {

--- a/tests/TableColumnLinkTest.php
+++ b/tests/TableColumnLinkTest.php
@@ -15,7 +15,7 @@ class TableColumnLinkTest extends TestCase
     use TableTestTrait;
 
     /** @var Table */
-    public $table;
+    protected $table;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
normally, request is created from $_SERVER, $_GET, ... globals (or passed explicitly) and thus this PR should have no effect on developer

fixes TODO in `App::url`

`App::$request` should be readonly, thus checking in the App constructor should be enough