### PR TITLE
Drop Form::jsInput() shortcut method

### DIFF
--- a/demos/_unit-test/form-empty.php
+++ b/demos/_unit-test/form-empty.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atk4\Ui\Demos;
+
+use Atk4\Ui\Form;
+use Atk4\Ui\Js\JsToast;
+
+/** @var \Atk4\Ui\App $app */
+require_once __DIR__ . '/../init-app.php';
+
+$form = Form::addTo($app);
+
+$form->onSubmit(static function (Form $form) {
+    return new JsToast('Post ' . ($form->getApp()->getRequest()->getParsedBody() === [] ? 'ok' : 'unexpected'));
+});

--- a/demos/form-control/multiline.php
+++ b/demos/form-control/multiline.php
@@ -9,6 +9,8 @@ use Atk4\Ui\Header;
 use Atk4\Ui\Js\JsExpression;
 use Atk4\Ui\Js\JsFunction;
 use Atk4\Ui\Js\JsToast;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use SebastianBergmann\CodeCoverage\CodeCoverage;
 
 /** @var \Atk4\Ui\App $app */
 require_once __DIR__ . '/../init-app.php';
@@ -24,6 +26,9 @@ $inventory->getField($inventory->fieldName()->qty)->ui['multiline'] = [Form\Cont
 $inventory->getField($inventory->fieldName()->box)->ui['multiline'] = [Form\Control\Multiline::TABLE_CELL => ['width' => 2]];
 $inventory->getField($inventory->fieldName()->total_sql)->ui['multiline'] = [Form\Control\Multiline::TABLE_CELL => ['width' => 1, 'class' => 'blue']];
 $inventory->getField($inventory->fieldName()->total_php)->ui['multiline'] = [Form\Control\Multiline::TABLE_CELL => ['width' => 1, 'class' => 'blue']];
+if ($app->db->getDatabasePlatform() instanceof PostgreSQLPlatform || class_exists(CodeCoverage::class, false)) {
+    $inventory->setOrder($inventory->idField);
+}
 
 $form = Form::addTo($app);
 

--- a/demos/form/form.php
+++ b/demos/form/form.php
@@ -198,7 +198,7 @@ $form->onSubmit(static function (Form $form) {
     }
 
     return new JsBlock([
-        $form->jsInput('email')->val('john@gmail.com'),
+        $form->getControl('email')->jsInput()->val('john@gmail.com'),
         $form->getControl('is_accept_terms')->js()->checkbox('set checked'),
     ]);
 });

--- a/demos/init-db.php
+++ b/demos/init-db.php
@@ -210,8 +210,8 @@ class ModelWithPrefixedFields extends Model
  * @property string $sys_name  @Atk4\Field()
  * @property string $iso       @Atk4\Field()
  * @property string $iso3      @Atk4\Field()
- * @property string $numcode   @Atk4\Field()
- * @property string $phonecode @Atk4\Field()
+ * @property int    $numcode   @Atk4\Field()
+ * @property int    $phonecode @Atk4\Field()
  */
 class Country extends ModelWithPrefixedFields
 {

--- a/src/Form.php
+++ b/src/Form.php
@@ -348,17 +348,6 @@ class Form extends View
         return $this->layout->addGroup($title);
     }
 
-    /**
-     * Returns JS Chain that targets INPUT element of a specified field. This method is handy
-     * if you wish to set a value to a certain field.
-     *
-     * @return Jquery
-     */
-    public function jsInput(string $name): JsExpressionable
-    {
-        return $this->layout->getControl($name)->jsInput();
-    }
-
     // }}}
 
     // {{{ Internals

--- a/src/Form.php
+++ b/src/Form.php
@@ -521,6 +521,7 @@ class Form extends View
             'on' => 'submit',
             'url' => $this->cb->getJsUrl(),
             'method' => 'POST',
+            'contentType' => 'application/x-www-form-urlencoded; charset=UTF-8', // remove once https://github.com/jquery/jquery/issues/5346 is fixed
             'serializeForm' => true,
         ], $this->apiConfig));
 

--- a/src/Form.php
+++ b/src/Form.php
@@ -432,7 +432,12 @@ class Form extends View
         foreach ($this->controls as $k => $control) {
             // save field value only if field was editable in form at all
             if (!$control->readOnly && !$control->disabled) {
-                $postRawValue = $postRawData[$k];
+                $postRawValue = $postRawData[$k] ?? null;
+                if ($postRawValue === null) {
+                    throw (new Exception('Form POST param does not exist'))
+                        ->addMoreInfo('key', $k);
+                }
+
                 try {
                     $control->set($this->getApp()->uiPersistence->typecastLoadField($control->entityField->getField(), $postRawValue));
                 } catch (\Exception $e) {

--- a/src/Form/Control.php
+++ b/src/Form/Control.php
@@ -148,8 +148,8 @@ class Control extends View
      *
      * $field->jsInput(true)->val(123);
      *
-     * @param bool|string      $when
-     * @param JsExpressionable $action
+     * @param bool|string                                     $when
+     * @param ($when is false ? null : JsExpressionable|null) $action
      *
      * @return Jquery
      */

--- a/src/Form/Control.php
+++ b/src/Form/Control.php
@@ -151,9 +151,9 @@ class Control extends View
      * @param bool|string                                     $when
      * @param ($when is false ? null : JsExpressionable|null) $action
      *
-     * @return Jquery
+     * @return ($action is null ? Jquery : null)
      */
-    public function jsInput($when = false, $action = null): JsExpressionable
+    public function jsInput($when = false, $action = null): ?JsExpressionable
     {
         return $this->js($when, $action, '#' . $this->name . '_input');
     }

--- a/src/View.php
+++ b/src/View.php
@@ -749,7 +749,7 @@ class View extends AbstractView
      *
      * @return ($action is null ? Jquery : null)
      */
-    public function js($when = false, $action = null, $selector = null)
+    public function js($when = false, $action = null, $selector = null): ?JsExpressionable
     {
         // binding on a specific event
         // TODO allow only boolean $when, otherwise user should use self::on() method

--- a/tests-behat/form.feature
+++ b/tests-behat/form.feature
@@ -84,3 +84,8 @@ Feature: Form
     When I click using selector "//label[text()='I am a developer']"
     Then I should not see "Check all language that apply"
     Then I should not see "Css"
+
+  Scenario: empty POST
+    Given I am on "_unit-test/form-empty.php"
+    When I press button "Save"
+    Then Toast display should contain text "Post ok"

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -239,4 +239,13 @@ class AppTest extends TestCase
         $expectedUrlAutoindex2 = $makeExpectedUrlFx('', '.html');
         self::assertSame($expectedUrlAutoindex2, $app->url($page, $extraRequestUrlArgs));
     }
+
+    public function testTerminateNoContentTypeException(): void
+    {
+        $app = $this->createApp();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Content type must be always set');
+        $app->terminate();
+    }
 }

--- a/tests/DemosTest.php
+++ b/tests/DemosTest.php
@@ -502,13 +502,13 @@ class DemosTest extends TestCase
     /**
      * @dataProvider provideDemoCallbackErrorCases
      */
-    public function testDemoCallbackError(string $path, string $expectedExceptionMessage): void
+    public function testDemoCallbackError(string $path, string $expectedExceptionMessage, array $options = []): void
     {
         if (static::class === self::class) {
             $this->expectExceptionMessage($expectedExceptionMessage);
         }
 
-        $response = $this->getResponseFromRequest5xx($path);
+        $response = $this->getResponseFromRequest5xx($path, $options);
 
         self::assertSame(500, $response->getStatusCode());
         self::assertSame('text/html', preg_replace('~;\s*charset=.+$~', '', $response->getHeaderLine('Content-Type')));
@@ -539,6 +539,12 @@ class DemosTest extends TestCase
         yield [
             '_unit-test/callback-nested.php?err_sub_loader2&' . Callback::URL_QUERY_TRIGGER_PREFIX . 'trigger_main_loader=callback&' . Callback::URL_QUERY_TRIGGER_PREFIX . 'trigger_sub_loader=callback&' . Callback::URL_QUERY_TARGET . '=trigger_sub_loader',
             'Exception II from Sub Loader',
+        ];
+
+        yield [
+            '_unit-test/post.php?' . Callback::URL_QUERY_TRIGGER_PREFIX . 'test_submit=ajax&' . Callback::URL_QUERY_TARGET . '=test_submit',
+            'Form POST param does not exist',
+            ['form_params' => []],
         ];
     }
 }


### PR DESCRIPTION
the replacement is more flexible

also test several edge cases Form usecases