### PR TITLE
Handle non-string tooltip description properly

### DIFF
--- a/src/Table/Column/Tooltip.php
+++ b/src/Table/Column/Tooltip.php
@@ -72,7 +72,7 @@ class Tooltip extends Table\Column
 
         return [
             '_' . $field->shortName . '_data_visible_class' => '',
-            '_' . $field->shortName . '_data_tooltip' => (string) $tooltip,
+            '_' . $field->shortName . '_data_tooltip' => $this->getApp()->uiPersistence->typecastSaveField($row->getModel()->getField($this->tooltipField), $tooltip),
             '_' . $field->shortName . '_icon' => $this->icon,
         ];
     }

--- a/src/Table/Column/Tooltip.php
+++ b/src/Table/Column/Tooltip.php
@@ -72,7 +72,7 @@ class Tooltip extends Table\Column
 
         return [
             '_' . $field->shortName . '_data_visible_class' => '',
-            '_' . $field->shortName . '_data_tooltip' => (String) $tooltip,
+            '_' . $field->shortName . '_data_tooltip' => (string) $tooltip,
             '_' . $field->shortName . '_icon' => $this->icon,
         ];
     }

--- a/src/Table/Column/Tooltip.php
+++ b/src/Table/Column/Tooltip.php
@@ -72,7 +72,7 @@ class Tooltip extends Table\Column
 
         return [
             '_' . $field->shortName . '_data_visible_class' => '',
-            '_' . $field->shortName . '_data_tooltip' => $tooltip,
+            '_' . $field->shortName . '_data_tooltip' => (String) $tooltip,
             '_' . $field->shortName . '_icon' => $this->icon,
         ];
     }


### PR DESCRIPTION
Tooltips should allow for non-string fields, string-conversion missing, fixed by this PR