### PR TITLE
Drop Behat CI for PHP 7.4 and 8.0

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -234,7 +234,7 @@ jobs:
     name: Behat
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/mvorisek/image-php:${{ matrix.php }}-selenium
+      image: ghcr.io/mvorisek/image-php${{ matrix.php < 8.1 && '@sha256' || '' }}:${{ matrix.php == '7.4' && '2362d2eddf97bc43f6bf3f99b81afa9aa192402dacfada933bac1835cd38136b' || (matrix.php == '8.0' && 'be424f776187ff71541e3ff4c6ec173d792c9b915057110427e3502c01480cdd' || matrix.php) }}${{ matrix.php >= 8.1 && '-selenium' || '' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -234,7 +234,7 @@ jobs:
     name: Behat
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/mvorisek/image-php${{ matrix.php < 8.1 && '@sha256' || '' }}:${{ matrix.php == '7.4' && '2362d2eddf97bc43f6bf3f99b81afa9aa192402dacfada933bac1835cd38136b' || (matrix.php == '8.0' && 'be424f776187ff71541e3ff4c6ec173d792c9b915057110427e3502c01480cdd' || matrix.php) }}${{ matrix.php >= 8.1 && '-selenium' || '' }}
+      image: ghcr.io/mvorisek/image-php:${{ matrix.php }}-selenium
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -238,7 +238,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0', '8.1', '8.2', '8.3']
+        # Selenium with PHP 7.4 and 8.0 was failing too often on initial/create session request, probably because of older (Alpine 3.16) base image
+        php: ['8.1', '8.2', '8.3']
         type: ['Chrome', 'Chrome Lowest']
         include:
           - php: 'latest'


### PR DESCRIPTION
I tried to use older Docker images that used to work.

I dumped then the curl requests. The first "POST http://127.0.0.1:4444/wd/hub/session" request is sometimes returned with empty string and 200 status code after exactly 10 minutes.

The issue seems to be in Github Actions configuration, as it used to work perfectly before about 1 Nov 2023 without any change.

The relevance with PHP version is that 7.4 and 8.0 PHP versions use older Alpine 3.16 vs. (3.18 for PHP 8.1+).