### PR TITLE
Fix number input type for values over 1000

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -91,7 +91,7 @@ jobs:
         image: mysql:8
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5 -e MYSQL_ROOT_PASSWORD=atk4_pass_root -e MYSQL_USER=atk4_test_user -e MYSQL_PASSWORD=atk4_pass -e MYSQL_DATABASE=atk4_test
       mariadb:
-        image: mariadb
+        image: mariadb:11.2
         options: --health-cmd="mariadb-admin ping" --health-interval=10s --health-timeout=5s --health-retries=5 -e MYSQL_ROOT_PASSWORD=atk4_pass_root -e MYSQL_USER=atk4_test_user -e MYSQL_PASSWORD=atk4_pass -e MYSQL_DATABASE=atk4_test
       postgres:
         image: postgres:12-alpine
@@ -255,7 +255,7 @@ jobs:
         image: mysql:8
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5 -e MYSQL_ROOT_PASSWORD=atk4_pass_root -e MYSQL_USER=atk4_test_user -e MYSQL_PASSWORD=atk4_pass -e MYSQL_DATABASE=atk4_test
       mariadb:
-        image: mariadb
+        image: mariadb:11.2
         options: --health-cmd="mariadb-admin ping" --health-interval=10s --health-timeout=5s --health-retries=5 -e MYSQL_ROOT_PASSWORD=atk4_pass_root -e MYSQL_USER=atk4_test_user -e MYSQL_PASSWORD=atk4_pass -e MYSQL_DATABASE=atk4_test
       postgres:
         image: postgres:12-alpine

--- a/src/Form/Control/Input.php
+++ b/src/Form/Control/Input.php
@@ -106,8 +106,8 @@ class Input extends Form\Control
     {
         return $this->getApp()->getTag('input/', array_merge([
             'name' => $this->shortName,
-            'type' => $this->inputType,
-            'placeholder' => $this->inputType !== 'hidden' ? $this->placeholder : false,
+            'type' => $this->inputType !== 'text' ? $this->inputType : false,
+            'placeholder' => $this->inputType !== 'hidden' && $this->placeholder ? $this->placeholder : false,
             'id' => $this->name . '_input',
             'value' => $this->getValue(),
             'disabled' => $this->disabled && $this->inputType !== 'hidden',

--- a/src/Form/Control/Multiline.php
+++ b/src/Form/Control/Multiline.php
@@ -484,8 +484,6 @@ class Multiline extends Form\Control
     {
         $props = $this->componentProps[self::INPUT] ?? [];
 
-        $props['type'] = ($field->type === 'integer' || $field->type === 'float' || $field->type === 'atk4_money') ? 'numberX' : 'text';
-
         return array_merge($props, $field->ui['multiline'][self::INPUT] ?? []);
     }
 

--- a/src/Form/Control/Multiline.php
+++ b/src/Form/Control/Multiline.php
@@ -484,7 +484,7 @@ class Multiline extends Form\Control
     {
         $props = $this->componentProps[self::INPUT] ?? [];
 
-        $props['type'] = ($field->type === 'integer' || $field->type === 'float' || $field->type === 'atk4_money') ? 'number' : 'text';
+        $props['type'] = ($field->type === 'integer' || $field->type === 'float' || $field->type === 'atk4_money') ? 'numberX' : 'text';
 
         return array_merge($props, $field->ui['multiline'][self::INPUT] ?? []);
     }

--- a/src/Form/Control/ScopeBuilder.php
+++ b/src/Form/Control/ScopeBuilder.php
@@ -660,12 +660,12 @@ class ScopeBuilder extends Form\Control
                     Condition::OPERATOR_DOESNOT_EQUAL => Condition::OPERATOR_NOT_IN,
                 ];
                 $value = implode(', ', $value);
-                $operator = $map[$operator] ?? Condition::OPERATOR_NOT_IN;
+                $operator = $map[$operator];
             }
 
             $operatorsMap = array_merge(static::$operatorsMap[$inputType] ?? [], static::$operatorsMap['text']);
             $operatorKey = array_search(strtoupper($operator), $operatorsMap, true);
-            $operator = $operatorKey !== false ? $operatorKey : self::OPERATOR_EQUALS;
+            $operator = $operatorKey;
         }
 
         return [

--- a/src/Form/Control/ScopeBuilder.php
+++ b/src/Form/Control/ScopeBuilder.php
@@ -213,7 +213,7 @@ class ScopeBuilder extends Form\Control
             'choices' => [__CLASS__, 'getChoices'],
         ],
         'numeric' => [
-            'type' => 'text',
+            'type' => 'numeric',
             'inputType' => 'number',
             'operators' => [
                 self::OPERATOR_SIGN_EQUALS,

--- a/src/Form/Control/ScopeBuilder.php
+++ b/src/Form/Control/ScopeBuilder.php
@@ -310,7 +310,10 @@ class ScopeBuilder extends Form\Control
 
         // build a ruleId => inputType map
         // this is used when selecting proper operator for the inputType (see self::$operatorsMap)
-        $inputsMap = array_column($this->rules, 'inputType', 'id');
+        $inputsMap = [];
+        foreach ($this->rules as $rule) {
+            $inputsMap[$rule['id']] = $rule['inputType'] ?? null;
+        }
 
         if ($this->entityField !== null && $this->entityField->get() !== null) {
             $scope = $this->entityField->get();

--- a/src/Table/Column/FilterModel/TypeDate.php
+++ b/src/Table/Column/FilterModel/TypeDate.php
@@ -61,7 +61,7 @@ class TypeDate extends Column\FilterModel
         $this->addField('exact_date', ['type' => 'date', 'ui' => ['caption' => '']]);
 
         // the integer field to generate a date when x day selector is used
-        $this->addField('number_days', ['ui' => ['caption' => '', 'form' => [Form\Control\Line::class, 'inputType' => 'numberX']]]);
+        $this->addField('number_days', ['ui' => ['caption' => '', 'form' => [Form\Control\Line::class]]]);
     }
 
     #[\Override]

--- a/src/Table/Column/FilterModel/TypeDate.php
+++ b/src/Table/Column/FilterModel/TypeDate.php
@@ -61,7 +61,7 @@ class TypeDate extends Column\FilterModel
         $this->addField('exact_date', ['type' => 'date', 'ui' => ['caption' => '']]);
 
         // the integer field to generate a date when x day selector is used
-        $this->addField('number_days', ['ui' => ['caption' => '', 'form' => [Form\Control\Line::class, 'inputType' => 'number']]]);
+        $this->addField('number_days', ['ui' => ['caption' => '', 'form' => [Form\Control\Line::class, 'inputType' => 'numberX']]]);
     }
 
     #[\Override]

--- a/src/Table/Column/FilterModel/TypeDatetime.php
+++ b/src/Table/Column/FilterModel/TypeDatetime.php
@@ -61,7 +61,7 @@ class TypeDatetime extends Column\FilterModel
         $this->addField('exact_date', ['type' => 'date', 'ui' => ['caption' => '']]);
 
         // the integer field to generate a date when x day selector is used
-        $this->addField('number_days', ['ui' => ['caption' => '', 'form' => [Form\Control\Line::class, 'inputType' => 'number']]]);
+        $this->addField('number_days', ['ui' => ['caption' => '', 'form' => [Form\Control\Line::class, 'inputType' => 'numberX']]]);
     }
 
     #[\Override]

--- a/src/Table/Column/FilterModel/TypeDatetime.php
+++ b/src/Table/Column/FilterModel/TypeDatetime.php
@@ -61,7 +61,7 @@ class TypeDatetime extends Column\FilterModel
         $this->addField('exact_date', ['type' => 'date', 'ui' => ['caption' => '']]);
 
         // the integer field to generate a date when x day selector is used
-        $this->addField('number_days', ['ui' => ['caption' => '', 'form' => [Form\Control\Line::class, 'inputType' => 'numberX']]]);
+        $this->addField('number_days', ['ui' => ['caption' => '', 'form' => [Form\Control\Line::class]]]);
     }
 
     #[\Override]

--- a/src/Table/Column/FilterModel/TypeNumber.php
+++ b/src/Table/Column/FilterModel/TypeNumber.php
@@ -26,8 +26,8 @@ class TypeNumber extends Column\FilterModel
         ];
         $this->op->default = '=';
 
-        $this->value->ui['form'] = [Form\Control\Line::class, 'inputType' => 'numberX'];
-        $this->addField('range', ['ui' => ['caption' => '', 'form' => [Form\Control\Line::class, 'inputType' => 'numberX']]]);
+        $this->value->ui['form'] = [Form\Control\Line::class];
+        $this->addField('range', ['ui' => ['caption' => '', 'form' => [Form\Control\Line::class]]]);
     }
 
     #[\Override]

--- a/src/Table/Column/FilterModel/TypeNumber.php
+++ b/src/Table/Column/FilterModel/TypeNumber.php
@@ -26,8 +26,8 @@ class TypeNumber extends Column\FilterModel
         ];
         $this->op->default = '=';
 
-        $this->value->ui['form'] = [Form\Control\Line::class, 'inputType' => 'number'];
-        $this->addField('range', ['ui' => ['caption' => '', 'form' => [Form\Control\Line::class, 'inputType' => 'number']]]);
+        $this->value->ui['form'] = [Form\Control\Line::class, 'inputType' => 'numberX'];
+        $this->addField('range', ['ui' => ['caption' => '', 'form' => [Form\Control\Line::class, 'inputType' => 'numberX']]]);
     }
 
     #[\Override]


### PR DESCRIPTION
UI numeric values/types are rendered using UI persistence and can contain non-numeric characters like space, comma.

## repro

Currently, such correctly formatted UI values, are considered as bad, example:

![image](https://github.com/atk4/ui/assets/2228672/6fce05a5-bb96-4dd5-a980-062222cf5b5b)

can be reproduced on `demos/form-control/multiline.php` demo by writing `1 000` in "Qty" number input.

## solution

The visual style is controlled by https://developer.mozilla.org/en-US/docs/Web/CSS/:invalid CSS presudo class which is set by https://developer.mozilla.org/en-US/docs/Web/HTML/Constraint_validation . In short, input `type=number` cannot be used for anything else than `\d+` value, thus we need to set `type` to be different than `number` or do not set it at all.