### PR TITLE
Typecast ID for UI strictly using UI persistence

### DIFF
--- a/demos/_unit-test/modal-error.php
+++ b/demos/_unit-test/modal-error.php
@@ -34,7 +34,7 @@ $modal->set(static function (View $p) {
     $button = Button::addTo($p)->set('Test ModalExecutor load PHP error');
     $executor = ModalExecutor::assertInstanceOf($p->getExecutorFactory()->createExecutor($country->getUserAction('edit'), $button));
     if (\Closure::bind(static fn () => $executor->loader, null, ModalExecutor::class)()->cb->isTriggered()) {
-        $executor->stickyGet($executor->name, '-1');
+        $executor->stickyGet($executor->name, '99000'); // no such record so load will fail
     }
     $button->on('click', $executor);
 });

--- a/demos/basic/breadcrumb.php
+++ b/demos/basic/breadcrumb.php
@@ -26,8 +26,8 @@ $crumb->addCrumb('Countries', []);
 $model = new Country($app->db);
 $model->setLimit(15);
 
-$id = $crumb->stickyGet('country_id');
-if ($id) {
+$id = $app->uiPersistence->typecastLoadField($model->getField($model->idField), $crumb->stickyGet('country_id'));
+if ($id !== null) {
     // perhaps we edit individual country?
     $model = $model->load($id);
     $crumb->addCrumb($model->name, []);

--- a/demos/collection/multitable.php
+++ b/demos/collection/multitable.php
@@ -50,7 +50,7 @@ $finderClass = AnonymousClassNameCache::get_class(fn () => new class() extends C
         $selections = $this->explodeSelectionValue($this->getApp()->tryGetRequestQueryParam($this->name) ?? '');
 
         if ($selections !== []) {
-            $table->js(true)->find('tr[data-id=' . $selections[0] . ']')->addClass('active');
+            $table->js(true)->find('tr[data-id=' . $this->getApp()->uiPersistence->typecastSaveField($this->model->getField($this->model->idField), $selections[0]) . ']')->addClass('active');
         }
 
         $makeJsReloadFx = function (array $path): JsReload {
@@ -65,7 +65,7 @@ $finderClass = AnonymousClassNameCache::get_class(fn () => new class() extends C
         $table->on('click', 'tr', $jsReload);
 
         while ($id = array_shift($selections)) {
-            $path[] = $id;
+            $path[] = $this->getApp()->uiPersistence->typecastSaveField($this->model->getField($this->model->idField), $id);
             $pushModel = new $model($model->getPersistence());
             $pushModel = $pushModel->tryLoad($id);
             if ($pushModel === null) {
@@ -87,7 +87,7 @@ $finderClass = AnonymousClassNameCache::get_class(fn () => new class() extends C
             $table->setModel($pushModel->setLimit(10), [$pushModel->titleField]);
 
             if ($selections !== []) {
-                $table->js(true)->find('tr[data-id=' . $selections[0] . ']')->addClass('active');
+                $table->js(true)->find('tr[data-id=' . $this->getApp()->uiPersistence->typecastSaveField($this->model->getField($this->model->idField), $selections[0]) . ']')->addClass('active');
             }
 
             $jsReload = $makeJsReloadFx($path);

--- a/demos/form-control/dropdown-plus.php
+++ b/demos/form-control/dropdown-plus.php
@@ -27,7 +27,7 @@ $form->addControl('sub_category_id', [Form\Control\DropdownCascade::class, 'casc
 $form->addControl('product_id', [Form\Control\DropdownCascade::class, 'cascadeFrom' => 'sub_category_id', 'reference' => SubCategory::hinting()->fieldName()->Products]);
 
 $form->onSubmit(static function (Form $form) use ($app) {
-    $message = $app->encodeJson($form->model->get());
+    $message = $app->encodeJson($app->uiPersistence->typecastSaveRow($form->model, $form->model->get()));
 
     $view = new Message('Values: ');
     $view->setApp($form->getApp());

--- a/demos/form-control/dropdown-plus.php
+++ b/demos/form-control/dropdown-plus.php
@@ -53,7 +53,6 @@ $form->addControl('withModel2', [
     'model' => (new Country($app->db))->setLimit(25),
     'renderRowFunction' => static function (Country $row) {
         return [
-            'value' => $row->getId(),
             'title' => $row->getTitle() . ' (' . $row->iso3 . ')',
         ];
     },
@@ -66,7 +65,6 @@ $form->addControl('withModel3', [
     'model' => (new File($app->db))->setLimit(25),
     'renderRowFunction' => static function (File $row) {
         return [
-            'value' => $row->getId(),
             'title' => $row->getTitle(),
             'icon' => $row->is_folder ? 'folder' : 'file',
         ];

--- a/demos/form-control/lookup.php
+++ b/demos/form-control/lookup.php
@@ -31,10 +31,10 @@ Label::addTo($form, ['Lookup countries', 'class.top attached' => true], ['AboveC
 $model = new Model($app->db, ['table' => 'test']);
 
 // lookup without plus button
-$model->hasOne('country1', ['model' => [Country::class]]);
+$model->hasOne('country1', ['model' => [Country::class], 'type' => WrappedIdType::NAME]);
 
 // lookup with plus button
-$model->hasOne('country2', ['model' => [Country::class], 'ui' => ['form' => ['plus' => true]]]);
+$model->hasOne('country2', ['model' => [Country::class], 'type' => WrappedIdType::NAME, 'ui' => ['form' => ['plus' => true]]]);
 
 $form->setModel($model->createEntity());
 

--- a/demos/form-control/multiline.php
+++ b/demos/form-control/multiline.php
@@ -61,14 +61,7 @@ $form->onSubmit(static function (Form $form) use ($multiline) {
         return $multiline->saveRows()->model->export();
     });
 
-    // TODO typecast using https://github.com/atk4/ui/pull/1991 once merged
-    foreach ($rows as $kRow => $row) {
-        foreach ($row as $kV => $v) {
-            if ($v instanceof \DateTime) {
-                $rows[$kRow][$kV] = $form->getApp()->uiPersistence->typecastSaveField($multiline->model->getField($kV), $row[$kV]);
-            }
-        }
-    }
+    $rows = array_map(static fn ($row) => $form->getApp()->uiPersistence->typecastSaveRow($multiline->model, $row), $rows);
 
     return new JsToast($form->getApp()->encodeJson($rows));
 });

--- a/demos/form/form2.php
+++ b/demos/form/form2.php
@@ -96,8 +96,8 @@ $personClass = AnonymousClassNameCache::get_class(fn () => new class() extends M
         $this->addField('name', ['required' => true]);
         $this->addField('surname', ['ui' => ['placeholder' => 'e.g. Smith']]);
         $this->addField('gender', ['enum' => ['M', 'F']]);
-        $this->hasOne('country_lookup_id', ['model' => [Country::class]]); // this works fast
-        $this->hasOne('country_dropdown_id', ['model' => [Country::class], 'ui' => ['form' => new Form\Control\Dropdown()]]); // this works slow
+        $this->hasOne('country_lookup_id', ['model' => [Country::class], 'type' => WrappedIdType::NAME]); // this works fast
+        $this->hasOne('country_dropdown_id', ['model' => [Country::class], 'type' => WrappedIdType::NAME, 'ui' => ['form' => new Form\Control\Dropdown()]]); // this works slow
     }
 
     #[\Override]

--- a/demos/init-db.php
+++ b/demos/init-db.php
@@ -278,6 +278,8 @@ class ModelWithPrefixedFields extends Model
 
         parent::init();
 
+        $this->getField($this->idField)->type = WrappedIdType::NAME;
+
         $this->initPreventModification();
 
         if ($this->getPersistence()->getDatabasePlatform() instanceof PostgreSQLPlatform || class_exists(CodeCoverage::class, false)) {
@@ -294,6 +296,17 @@ class ModelWithPrefixedFields extends Model
         ]);
 
         return parent::addField($name, $seed);
+    }
+
+    #[\Override]
+    public function hasOne(string $link, array $defaults = [])
+    {
+        // TODO remove once HasOne reference can infer type from their model
+        if (!isset($defaults['type'])) {
+            $defaults['type'] = WrappedIdType::NAME;
+        }
+
+        return parent::hasOne($link, $defaults);
     }
 
     #[\Override]

--- a/demos/init-db.php
+++ b/demos/init-db.php
@@ -10,7 +10,9 @@ use Atk4\Data\Model;
 use Atk4\Ui\Exception;
 use Atk4\Ui\Form;
 use Atk4\Ui\Table;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Types\Type as DbalType;
 use Mvorisek\Atk4\Hintable\Data\HintablePropertyDef;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
 
@@ -23,6 +25,77 @@ try {
     throw (new Exception('This demo requires access to the database. See "demos/init-db.php"'))
         ->addMoreInfo('PDO error', $e->getMessage());
 }
+
+/**
+ * Improve testing by using non-scalar ID with custom DBAL type.
+ */
+class WrappedId
+{
+    private const MIN_VALUE = 1;
+    private const MAX_VALUE = 100_000;
+
+    private int $id;
+
+    public function __construct(int $id)
+    {
+        if ($id < self::MIN_VALUE || $id > self::MAX_VALUE) {
+            throw (new Exception('ID value is outside supported range'))
+                ->addMoreInfo('value', $id);
+        }
+
+        $this->id = $id;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+}
+
+class WrappedIdType extends DbalType
+{
+    public const NAME = 'atk4_ui_demos_id';
+
+    #[\Override]
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+
+    #[\Override]
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
+    {
+        return DbalType::getType('integer')->getSQLDeclaration($fieldDeclaration, $platform);
+    }
+
+    #[\Override]
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?int
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return DbalType::getType('integer')->convertToDatabaseValue($value->getId(), $platform);
+    }
+
+    #[\Override]
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?object
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return new WrappedId(DbalType::getType('integer')->convertToPHPValue($value, $platform));
+    }
+
+    #[\Override]
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
+    {
+        return true;
+    }
+}
+
+DbalType::addType(WrappedIdType::NAME, WrappedIdType::class);
 
 trait ModelPreventModificationTrait
 {
@@ -124,6 +197,12 @@ trait ModelPreventModificationTrait
 
 /**
  * Improve testing by using prefixed real field and SQL names.
+ *
+ * @method (static|null)                   tryLoad(WrappedId $id = null)     remove parentheses around return type once https://github.com/phpstan/phpstan/issues/10548 is fixed
+ * @method static                          load(WrappedId $id)
+ * @method \Traversable<WrappedId, static> getIterator()
+ * @method WrappedId                       insert(array<string, mixed> $row)
+ * @method static                          delete(WrappedId $id = null)
  */
 class ModelWithPrefixedFields extends Model
 {
@@ -215,6 +294,30 @@ class ModelWithPrefixedFields extends Model
         ]);
 
         return parent::addField($name, $seed);
+    }
+
+    #[\Override]
+    public function getId(): ?WrappedId
+    {
+        return parent::getId();
+    }
+
+    /**
+     * @param WrappedId|($allowNull is true ? null : never) $value
+     */
+    #[\Override] // @phpstan-ignore-line
+    public function setId($value, bool $allowNull = true)
+    {
+        return parent::setId($value, $allowNull);
+    }
+
+    /**
+     * @return \Traversable<WrappedId, static>
+     */
+    #[\Override]
+    public function createIteratorBy($field, $operator = null, $value = null): \Traversable
+    {
+        return parent::createIteratorBy(...'func_get_args'());
     }
 }
 

--- a/demos/layout/layout-panel.php
+++ b/demos/layout/layout-panel.php
@@ -110,7 +110,7 @@ View::addTo($app, ['ui' => 'divider']);
 Header::addTo($app, ['UserAction Friendly', 'size' => 4, 'subHeader' => 'Panel can run model action.']);
 
 $panel3 = Panel\Right::addTo($app);
-$countryId = $panel3->stickyGet('id');
+$countryId = $app->uiPersistence->typecastLoadField($country->getField($country->idField), $panel3->stickyGet('id'));
 $msg = Message::addTo($panel3, ['Run Country model action below.']);
 
 $deck = View::addTo($app, ['ui' => 'cards']);

--- a/demos/layout/layouts.php
+++ b/demos/layout/layouts.php
@@ -18,8 +18,8 @@ $buttons = [
     ['page' => ['layouts_nolayout'], 'title' => 'HTML without layout'],
     ['page' => ['layouts_manual'], 'title' => 'Manual layout'],
     ['page' => ['../basic/header', 'layout' => Layout\Centered::class], 'title' => 'Centered layout'],
-    ['page' => ['layouts_admin'], 'title' => 'Admin Layout'],
-    ['page' => ['layouts_error'], 'title' => 'Exception Error'],
+    ['page' => ['layouts_admin'], 'title' => 'Admin layout'],
+    ['page' => ['layouts_error'], 'title' => 'Unhandled error'],
 ];
 
 // layout

--- a/docs/form-control.md
+++ b/docs/form-control.md
@@ -379,7 +379,6 @@ This function is called with each model record and needs to return an array:
 ```
 $dropdown->renderRowFunction = function (Model $record) {
     return [
-        'value' => $record->idField,
         'title' => $record->getTitle() . ' (' . $record->get('subtitle') . ')',
     ];
 }
@@ -390,7 +389,6 @@ You can also use this function to add an Icon to a record:
 ```
 $dropdown->renderRowFunction = function (Model $record) {
     return [
-        'value' => $record->idField,
         'title' => $record->getTitle() . ' (' . $record->get('subtitle') . ')',
         'icon' => $record->get('value') > 100 ? 'money' : 'coins',
     ];
@@ -426,7 +424,6 @@ With the according renderRowFunction:
 ```
 function (Model $record) {
     return [
-        'value' => $record->getId(),
         'title' => $record->getTitle,
         'icon' => $record->value > 100 ? 'money' : 'coins',
         'someOtherField' => $record->get('SomeOtherField'),
@@ -435,7 +432,7 @@ function (Model $record) {
 }
 ```
 
-Of course, the tags `value`, `title`, `icon`, `someOtherField` and `someOtherField2` need to be set in my_dropdown.html.
+Of course, the tags `title`, `icon`, `someOtherField` and `someOtherField2` need to be set in my_dropdown.html.
 
 ### Usage with $values property
 

--- a/src/Card.php
+++ b/src/Card.php
@@ -177,7 +177,7 @@ class Card extends View
             $fields = array_keys($this->model->getFields(['editable', 'visible']));
         }
 
-        $this->template->trySet('dataId', (string) $this->model->getId());
+        $this->template->trySet('dataId', $this->getApp()->uiPersistence->typecastSaveField($this->model->getField($this->model->idField), $this->model->getId()));
 
         View::addTo($this->getSection(), [$entity->getTitle(), 'class.header' => true]);
         $this->getSection()->addFields($entity, $fields, $this->useLabel, $this->useTable);

--- a/src/Crud.php
+++ b/src/Crud.php
@@ -206,7 +206,7 @@ class Crud extends Grid
             case Model\UserAction::MODIFIER_DELETE:
                 // use deleted record ID to remove row, fallback to closest tr if ID is not available
                 $js = $this->deletedId
-                    ? $this->js(false, null, 'tr[data-id="' . $this->deletedId . '"]')
+                    ? $this->js(false, null, 'tr[data-id="' . $this->getApp()->uiPersistence->typecastSaveField($this->model->getField($this->model->idField), $this->deletedId) . '"]')
                     : (new Jquery())->closest('tr');
                 $js = $js->transition('fade left', new JsFunction([], [new JsExpression('this.remove()')]));
 

--- a/src/Form.php
+++ b/src/Form.php
@@ -105,7 +105,7 @@ class Form extends View
     public $controlDisplaySelector = '.field';
 
     /** @var array<string, mixed> Use this apiConfig variable to pass API settings to Fomantic-UI in .api(). */
-    public $apiConfig = [];
+    public array $apiConfig = [];
 
     /** @var array<string, mixed> Use this formConfig variable to pass settings to Fomantic-UI in .from(). */
     public $formConfig = [];

--- a/src/Form/Control/Dropdown.php
+++ b/src/Form/Control/Dropdown.php
@@ -232,7 +232,7 @@ class Dropdown extends Input
     {
         foreach ($this->model as $id => $row) {
             $title = $row->getTitle();
-            $this->_tItem->set('value', (string) $id);
+            $this->_tItem->set('value', $this->getApp()->uiPersistence->typecastSaveField($this->model->getField($this->model->idField), $id));
             $this->_tItem->set('title', $title || is_numeric($title) ? (string) $title : '');
             // add item to template
             $this->template->dangerouslyAppendHtml('Item', $this->_tItem->renderToHtml());

--- a/src/Form/Control/Dropdown.php
+++ b/src/Form/Control/Dropdown.php
@@ -26,7 +26,7 @@ class Dropdown extends Input
      *     'file' => ['File', 'icon' => 'file'],
      * ].
      *
-     * @var array<int|string, mixed>
+     * @var array<array-key, mixed>
      */
     public array $values;
 
@@ -50,7 +50,6 @@ class Dropdown extends Input
      * can be defined. The function gets each row of the model/values property as first parameter.
      * if used with $values property, gets the key of this element as second parameter.
      * When using with a model, the second parameter is null and can be ignored.
-     * Must return an array with at least 'value' and 'caption' elements set.
      * Use additional 'icon' element to add an icon to this row.
      *
      * Example 1 with Model: Title in Uppercase
@@ -91,11 +90,11 @@ class Dropdown extends Input
      */
     public $renderRowFunction;
 
-    /** @var HtmlTemplate Subtemplate for a single dropdown item. */
-    protected $_tItem;
+    /** Subtemplate for a single dropdown item. */
+    protected HtmlTemplate $_tItem;
 
-    /** @var HtmlTemplate Subtemplate for an icon for a single dropdown item. */
-    protected $_tIcon;
+    /** Subtemplate for an icon for a single dropdown item. */
+    protected HtmlTemplate $_tIcon;
 
     #[\Override]
     protected function init(): void
@@ -270,8 +269,8 @@ class Dropdown extends Input
      * Used when a custom callback is defined for row rendering. Sets
      * values to row template and appends it to main template.
      *
-     * @param mixed      $row
-     * @param int|string $key
+     * @param mixed                               $row
+     * @param ($row is Model ? never : array-key) $key
      */
     protected function _addCallBackRow($row, $key = null): void
     {

--- a/src/Form/Control/DropdownCascade.php
+++ b/src/Form/Control/DropdownCascade.php
@@ -68,21 +68,35 @@ class DropdownCascade extends Dropdown
      * Return an empty value set if ID is null.
      *
      * @param mixed $id
+     *
+     * @return list<array{value: string, text: mixed, name: mixed}>
      */
     public function getNewValues($id): array
     {
         if ($id === null) {
-            return [['value' => '', 'text' => $this->empty, 'name' => $this->empty]];
+            return [[
+                'value' => '',
+                'text' => $this->empty,
+                'name' => $this->empty,
+            ]];
         }
 
         $model = $this->cascadeFrom->model->load($id)->ref($this->reference);
         $values = [];
         foreach ($model as $row) {
             if ($this->renderRowFunction) {
-                $res = ($this->renderRowFunction)($row); // @phpstan-ignore-line
-                $values[] = ['value' => $res['value'], 'text' => $res['title'], 'name' => $res['title']];
+                $res = ($this->renderRowFunction)($row);
+                $values[] = [
+                    'value' => $this->getApp()->uiPersistence->typecastSaveField($model->getField($model->idField), $row->getId()),
+                    'text' => $res['title'],
+                    'name' => $res['title'],
+                ];
             } else {
-                $values[] = ['value' => $this->getApp()->uiPersistence->typecastSaveField($model->getField($model->idField), $row->getId()), 'text' => $row->get($model->titleField), 'name' => $row->get($model->titleField)];
+                $values[] = [
+                    'value' => $this->getApp()->uiPersistence->typecastSaveField($model->getField($model->idField), $row->getId()),
+                    'text' => $row->get($model->titleField),
+                    'name' => $row->get($model->titleField),
+                ];
             }
         }
 
@@ -93,7 +107,8 @@ class DropdownCascade extends Dropdown
      * Will mark current value as selected from a list
      * of possible values.
      *
-     * @param mixed $value the current field value
+     * @param list<array{value: string, text: mixed, name: mixed}> $values
+     * @param mixed                                                $value  the current field value
      */
     private function getJsValues(array $values, $value): array
     {

--- a/src/Form/Control/DropdownCascade.php
+++ b/src/Form/Control/DropdownCascade.php
@@ -82,7 +82,7 @@ class DropdownCascade extends Dropdown
                 $res = ($this->renderRowFunction)($row); // @phpstan-ignore-line
                 $values[] = ['value' => $res['value'], 'text' => $res['title'], 'name' => $res['title']];
             } else {
-                $values[] = ['value' => $row->getId(), 'text' => $row->get($model->titleField), 'name' => $row->get($model->titleField)];
+                $values[] = ['value' => $this->getApp()->uiPersistence->typecastSaveField($model->getField($model->idField), $row->getId()), 'text' => $row->get($model->titleField), 'name' => $row->get($model->titleField)];
             }
         }
 
@@ -93,12 +93,15 @@ class DropdownCascade extends Dropdown
      * Will mark current value as selected from a list
      * of possible values.
      *
-     * @param string|int $value the current field value
+     * @param mixed $value the current field value
      */
     private function getJsValues(array $values, $value): array
     {
+        $model = $this->cascadeFrom->model->ref($this->reference);
+        $valueStr = $this->getApp()->uiPersistence->typecastSaveField($model->getField($model->idField), $value);
+
         foreach ($values as $k => $v) {
-            if ($v['value'] === $value) {
+            if ($v['value'] === $valueStr) {
                 $values[$k]['selected'] = true;
 
                 break;

--- a/src/Form/Control/Lookup.php
+++ b/src/Form/Control/Lookup.php
@@ -113,9 +113,9 @@ class Lookup extends Input
      * Define callback for generating the row data
      * If left empty default callback Lookup::defaultRenderRow is used.
      *
-     * @var \Closure($this, Model): array{value: mixed, title: mixed}|null
+     * @var \Closure($this, Model): array{title: mixed}
      */
-    public $renderRowFunction;
+    public ?\Closure $renderRowFunction = null;
 
     /**
      * Whether or not to accept multiple value.
@@ -180,7 +180,7 @@ class Lookup extends Input
      *
      * @param int|bool $limit
      *
-     * @return array<int, array{value: mixed, title: mixed}>
+     * @return array<int, array{value: string, title: mixed}>
      */
     public function getData($limit = true): array
     {
@@ -205,12 +205,15 @@ class Lookup extends Input
     /**
      * Renders the Lookup row depending on properties set.
      *
-     * @return array{value: mixed, title: mixed}
+     * @return array{value: string, title: mixed}
      */
     public function renderRow(Model $row): array
     {
         if ($this->renderRowFunction !== null) {
-            return ($this->renderRowFunction)($this, $row);
+            return array_merge(
+                ['value' => $this->defaultRenderRow($row)['value']],
+                ($this->renderRowFunction)($this, $row)
+            );
         }
 
         return $this->defaultRenderRow($row);
@@ -219,16 +222,17 @@ class Lookup extends Input
     /**
      * Default callback for generating data row.
      *
-     * @param string $key
-     *
-     * @return array{value: mixed, title: mixed}
+     * @return array{value: string, title: mixed}
      */
     protected function defaultRenderRow(Model $row)
     {
         $idField = $this->idField ?? $row->idField;
         $titleField = $this->titleField ?? $row->titleField;
 
-        return ['value' => $row->get($idField), 'title' => $row->get($titleField)];
+        return [
+            'value' => $this->getApp()->uiPersistence->typecastSaveField($row->getField($idField), $row->get($idField)),
+            'title' => $row->get($titleField),
+        ];
     }
 
     /**

--- a/src/Form/Control/Lookup.php
+++ b/src/Form/Control/Lookup.php
@@ -27,7 +27,7 @@ class Lookup extends Input
 
     public string $inputType = 'hidden';
 
-    /** @var array<int|string, mixed> Declare this property so Lookup is consistent as decorator to replace Form\Control\Dropdown. */
+    /** @var array<array-key, mixed> Declare this property so Lookup is consistent as decorator to replace Form\Control\Dropdown. */
     public array $values;
 
     /** @var CallbackLater Object used to capture requests from the browser. */
@@ -85,7 +85,7 @@ class Lookup extends Input
      *
      * @var array<string, mixed>
      */
-    public $apiConfig = ['cache' => false];
+    public array $apiConfig = ['cache' => false];
 
     /**
      * Fomantic-UI dropdown module settings.
@@ -223,7 +223,7 @@ class Lookup extends Input
      *
      * @return array{value: mixed, title: mixed}
      */
-    public function defaultRenderRow(Model $row, $key = null)
+    protected function defaultRenderRow(Model $row)
     {
         $idField = $this->idField ?? $row->idField;
         $titleField = $this->titleField ?? $row->titleField;

--- a/src/Form/Control/Multiline.php
+++ b/src/Form/Control/Multiline.php
@@ -173,7 +173,7 @@ class Multiline extends Form\Control
      *
      * @var array<string, \Closure(Field, string): void>
      */
-    private $valuePropsBinding = [];
+    private array $valuePropsBinding = [];
 
     /**
      * A JsFunction to execute when Multiline add(+) button is clicked.
@@ -337,8 +337,12 @@ class Multiline extends Form\Control
     {
         $model = $this->model;
 
-        // collects existing IDs
-        $currentIds = array_column($model->export(), $model->idField);
+        // delete removed rows
+        // TODO this is dangerous, deleted row IDs should be passed from UI
+        $idsToDelete = array_filter(array_column($this->rowData, $model->idField), static fn ($v) => $v !== null);
+        foreach ($model->createIteratorBy($model->idField, 'not in', $idsToDelete) as $entity) {
+            $entity->delete();
+        }
 
         foreach ($this->rowData as $row) {
             $entity = $row[$model->idField] !== null
@@ -357,16 +361,6 @@ class Multiline extends Form\Control
             if (!$entity->isLoaded() || $entity->getDirtyRef() !== []) {
                 $entity->save();
             }
-
-            $k = array_search($entity->getId(), $currentIds, true);
-            if ($k !== false) {
-                unset($currentIds[$k]);
-            }
-        }
-
-        // delete removed IDs
-        foreach ($currentIds as $id) {
-            $model->delete($id);
         }
 
         return $this;
@@ -562,7 +556,7 @@ class Multiline extends Form\Control
     public function setLookupOptionValue(Field $field, string $value): void
     {
         $model = $field->getReference()->refModel($this->model);
-        $entity = $model->tryLoadBy($field->getReference()->getTheirFieldName($model), $value);
+        $entity = $model->tryLoadBy($field->getReference()->getTheirFieldName($model), $this->getApp()->uiPersistence->typecastLoadField($field, $value));
         if ($entity !== null) {
             $option = ['key' => $value, 'text' => $entity->get($model->titleField), 'value' => $value];
             foreach ($this->fieldDefs as $key => $component) {
@@ -621,8 +615,10 @@ class Multiline extends Form\Control
             $model = $field->getReference()->refModel($this->model);
             $model->setLimit($limit);
 
+            $theirFieldName = $field->getReference()->getTheirFieldName($model);
             foreach ($model as $item) {
-                $items[$item->get($field->getReference()->getTheirFieldName($model))] = $item->get($model->titleField);
+                $theirValue = $this->getApp()->uiPersistence->typecastSaveField($model->getField($theirFieldName), $item->get($theirFieldName));
+                $items[$theirValue] = $item->get($model->titleField);
             }
         }
 
@@ -632,9 +628,9 @@ class Multiline extends Form\Control
     /**
      * Apply Props to component that require props based on field value.
      */
-    protected function valuePropsBinding(string $values): void
+    protected function valuePropsBinding(string $valueJson): void
     {
-        $fieldValues = $this->getApp()->decodeJson($values);
+        $fieldValues = $this->getApp()->decodeJson($valueJson);
 
         foreach ($fieldValues as $rows) {
             foreach ($rows as $fieldName => $value) {
@@ -656,13 +652,13 @@ class Multiline extends Form\Control
 
         parent::renderView();
 
-        $inputValue = $this->getValue();
-        $this->valuePropsBinding($inputValue);
+        $inputValueJson = $this->getValue();
+        $this->valuePropsBinding($inputValueJson);
 
         $this->multiLine->vue('atk-multiline', [
             'data' => [
                 'formName' => $this->form->formElement->name,
-                'inputValue' => $inputValue,
+                'inputValue' => $inputValueJson,
                 'inputName' => $this->shortName,
                 'fields' => $this->fieldDefs,
                 'url' => $this->renderCallback->getJsUrl(),

--- a/src/Form/Control/Multiline.php
+++ b/src/Form/Control/Multiline.php
@@ -802,7 +802,7 @@ class Multiline extends Form\Control
                 'expr' => isset($dummyFields[$field->shortName])
                     ? $dummyFields[$field->shortName]->expr
                     : ($field->shortName === $dummyModel->idField
-                        ? '-1'
+                        ? '99000'
                         : $createExprFromValueFx($entity->getModel()->getPersistence()->typecastSaveField($field, $field->get($entity)))),
                 'type' => $field->type,
                 'actual' => $field->actual,

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -336,7 +336,7 @@ class Grid extends View
     }
 
     #[\Override]
-    public function jsReload($args = [], $afterSuccess = null, $apiConfig = []): JsExpressionable
+    public function jsReload($args = [], $afterSuccess = null, array $apiConfig = []): JsExpressionable
     {
         return new JsReload($this->container, $args, $afterSuccess, $apiConfig);
     }

--- a/src/JsCallback.php
+++ b/src/JsCallback.php
@@ -18,7 +18,7 @@ class JsCallback extends Callback
     public $confirm;
 
     /** @var array<string, mixed> Use this apiConfig variable to pass API settings to Fomantic-UI in .api(). */
-    public $apiConfig = [];
+    public array $apiConfig = [];
 
     /** @var string|null Include web storage data item (key) value to be included in the request. */
     public $storeName;

--- a/src/Lister.php
+++ b/src/Lister.php
@@ -181,10 +181,11 @@ class Lister extends View
         if ($this->tRow->hasTag('_title')) {
             $this->tRow->set('_title', $this->currentRow->getTitle());
         }
+        $idStr = $this->getApp()->uiPersistence->typecastSaveField($this->currentRow->getField($this->currentRow->idField), $this->currentRow->getId());
         if ($this->tRow->hasTag('_href')) {
-            $this->tRow->set('_href', $this->url(['id' => $this->currentRow->getId()]));
+            $this->tRow->set('_href', $this->url(['id' => $idStr]));
         }
-        $this->tRow->trySet('_id', $this->name . '-' . $this->currentRow->getId());
+        $this->tRow->trySet('_id', $this->name . '-' . $idStr);
 
         $html = $this->tRow->renderToHtml();
         if ($this->template->hasTag('rows')) {

--- a/src/Persistence/Ui.php
+++ b/src/Persistence/Ui.php
@@ -248,6 +248,10 @@ class Ui extends Persistence
                 throw new Exception('Object serialization is not supported');
         }
 
+        if ($value === '' && $field->type === 'atk4_ui_demos_id') { // TODO extend the UI persistence for demos only
+            return null;
+        }
+
         // typecast using DBAL type and normalize
         $value = parent::_typecastLoadField($field, $value);
         $value = (new Field(['type' => $field->type]))->normalize($value);

--- a/src/Table.php
+++ b/src/Table.php
@@ -468,7 +468,7 @@ class Table extends Lister
 
             // render row and add to body
             $this->tRow->dangerouslySetHtml($htmlTags);
-            $this->tRow->set('dataId', (string) $this->currentRow->getId());
+            $this->tRow->set('dataId', $this->getApp()->uiPersistence->typecastSaveField($this->model->getField($this->model->idField), $this->currentRow->getId()));
             $this->template->dangerouslyAppendHtml('Body', $this->tRow->renderToHtml());
             $this->tRow->del(array_keys($htmlTags));
         } else {

--- a/src/Table/Column/Link.php
+++ b/src/Table/Column/Link.php
@@ -155,7 +155,7 @@ class Link extends Table\Column
                 $key = $val;
             }
 
-            $page[$key] = $row->get($val);
+            $page[$key] = $this->getApp()->uiPersistence->typecastSaveField($row->getField($val), $row->get($val));
         }
 
         return ['c_' . $this->shortName => $this->table->url($page)];

--- a/src/UserAction/ConfirmationExecutor.php
+++ b/src/UserAction/ConfirmationExecutor.php
@@ -138,7 +138,7 @@ class ConfirmationExecutor extends Modal implements JsExecutorInterface
                 $this->loader->jsLoad(
                     [
                         'step' => 'execute',
-                        $this->name => $this->action->getEntity()->getId(),
+                        $this->name => $this->getApp()->uiPersistence->typecastSaveField($this->action->getModel()->getField($this->action->getModel()->idField), $this->action->getEntity()->getId()),
                     ],
                     ['method' => 'POST']
                 ),

--- a/src/UserAction/StepExecutorTrait.php
+++ b/src/UserAction/StepExecutorTrait.php
@@ -187,7 +187,7 @@ trait StepExecutorTrait
             $chain = $this->loader->jsLoad(
                 [
                     'step' => $this->getPreviousStep($this->step),
-                    $this->name => $this->action->getEntity()->getId(),
+                    $this->name => $this->getApp()->uiPersistence->typecastSaveField($this->action->getModel()->getField($this->action->getModel()->idField), $this->action->getEntity()->getId()),
                 ],
                 ['method' => 'POST'],
                 $this->loader->name
@@ -203,7 +203,7 @@ trait StepExecutorTrait
                 $this->loader->jsLoad(
                     [
                         'step' => 'final',
-                        $this->name => $this->action->getEntity()->getId(),
+                        $this->name => $this->getApp()->uiPersistence->typecastSaveField($this->action->getModel()->getField($this->action->getModel()->idField), $this->action->getEntity()->getId()),
                     ],
                     ['method' => 'POST'],
                     $this->loader->name
@@ -363,7 +363,7 @@ trait StepExecutorTrait
             $chain = $this->loader->jsLoad(
                 [
                     'step' => $this->getPreviousStep($step),
-                    $this->name => $this->action->getEntity()->getId(),
+                    $this->name => $this->getApp()->uiPersistence->typecastSaveField($this->action->getModel()->getField($this->action->getModel()->idField), $this->action->getEntity()->getId()),
                 ],
                 ['method' => 'POST'],
                 $this->loader->name
@@ -401,7 +401,7 @@ trait StepExecutorTrait
                 $this->loader->jsLoad(
                     [
                         'step' => $this->isLastStep($step) ? 'final' : $this->getNextStep($step),
-                        $this->name => $this->action->getEntity()->getId(),
+                        $this->name => $this->getApp()->uiPersistence->typecastSaveField($this->action->getModel()->getField($this->action->getModel()->idField), $this->action->getEntity()->getId()),
                     ],
                     ['method' => 'POST'],
                     $this->loader->name

--- a/src/View.php
+++ b/src/View.php
@@ -891,7 +891,7 @@ class View extends AbstractView
      *
      * @return JsReload
      */
-    public function jsReload($args = [], $afterSuccess = null, $apiConfig = []): JsExpressionable
+    public function jsReload($args = [], $afterSuccess = null, array $apiConfig = []): JsExpressionable
     {
         return new JsReload($this, $args, $afterSuccess, $apiConfig);
     }

--- a/src/View.php
+++ b/src/View.php
@@ -1007,7 +1007,7 @@ class View extends AbstractView
         } elseif ($action instanceof UserAction\ExecutorInterface || $action instanceof UserAction\SharedExecutor || $action instanceof Model\UserAction) {
             $ex = $action instanceof Model\UserAction ? $this->getExecutorFactory()->createExecutor($action, $this) : $action;
 
-            $setupNonSharedExecutorFx = static function (UserAction\ExecutorInterface $ex) use (&$defaults, &$arguments): void {
+            $setupNonSharedExecutorFx = function (UserAction\ExecutorInterface $ex) use (&$defaults, &$arguments): void {
                 /** @var AbstractView&UserAction\ExecutorInterface $ex https://github.com/phpstan/phpstan/issues/3770 */
                 $ex = $ex;
 
@@ -1018,6 +1018,11 @@ class View extends AbstractView
                     // if "id" is not specified we assume arguments[0] is the model ID
                     $arguments[$ex->name] = $arguments[0];
                     unset($arguments[0]);
+                }
+
+                if (isset($arguments[$ex->name]) && !$arguments[$ex->name] instanceof JsExpressionable) {
+                    $exModel = $ex->getAction()->getModel();
+                    $arguments[$ex->name] = $this->getApp()->uiPersistence->typecastSaveField($exModel->getField($exModel->idField), $arguments[$ex->name]);
                 }
 
                 if ($ex instanceof UserAction\JsCallbackExecutor) {

--- a/tests-behat/dropdown.feature
+++ b/tests-behat/dropdown.feature
@@ -6,7 +6,7 @@ Feature: Dropdown
     Then I select value "Sugar/Sweetened" in lookup "sub_category_id"
     Then I select value "Soda" in lookup "product_id"
     When I click using selector "(//div[text()='Save'])[2]"
-    Then Modal is open with text '{ "category_id": 2, "sub_category_id": 9, "product_id": 4 }' in selector "p"
+    Then Modal is open with text '{ "category_id": "2", "sub_category_id": "9", "product_id": "4" }' in selector "p"
     Then I click close modal
     Then I should see "Soda"
     Then I select value "Coffee and Tea" in lookup "sub_category_id"

--- a/tests-behat/multiline.feature
+++ b/tests-behat/multiline.feature
@@ -10,7 +10,7 @@ Feature: Multiline
     Then the "div[name=-atk_fp_multiline_item__total_sql]" element should contain "134"
     Then the "div[name=-atk_fp_multiline_item__total_php]" element should contain "134"
     Then I press button "Save"
-    Then Toast display should contain text '"atk_fp_multiline_item__box": 67, "atk_fp_multiline_item__total_sql": 134 }'
+    Then Toast display should contain text '"atk_fp_multiline_item__box": "67", "atk_fp_multiline_item__total_sql": "134" }'
 
   Scenario: add row
     When I click using selector "//tfoot//button[i.plus.icon]"
@@ -23,14 +23,14 @@ Feature: Multiline
     Then I check if text in "//tr[3]//div[@name='-atk_fp_multiline_item__total_sql']" match text "15"
     Then I check if text in "//tr[3]//div[@name='-atk_fp_multiline_item__total_php']" match text "15"
     Then I press button "Save"
-    Then Toast display should contain text '"atk_fp_multiline_item__box": 5, "atk_fp_multiline_item__total_sql": 15 } ]'
+    Then Toast display should contain text '"atk_fp_multiline_item__box": "5", "atk_fp_multiline_item__total_sql": "15" } ]'
     Then I should not see "Must not be empty"
 
   Scenario: delete row
     When I click using selector "//tr[3]//input[@type='checkbox']"
     When I click using selector "//tfoot//button[i.trash.icon]"
     Then I press button "Save"
-    Then Toast display should contain text '"atk_fp_multiline_item__box": 100, "atk_fp_multiline_item__total_sql": 200 } ]'
+    Then Toast display should contain text '"atk_fp_multiline_item__box": "100", "atk_fp_multiline_item__total_sql": "200" } ]'
 
   Scenario: delete all rows
     When I click using selector "//thead//input[@type='checkbox']"


### PR DESCRIPTION
in #1991 the UI typecasting will be relaxed for non-displayed HTML attributes like `data` so numbers are formatted "more using machine readable format"