### PR TITLE
Make "__atk_tab" GET param non-sticky

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -135,7 +135,6 @@ class App
     /** @var array<string, bool> global sticky arguments */
     protected array $stickyGetArguments = [
         '__atk_json' => false,
-        '__atk_tab' => false,
     ];
 
     /** @var class-string */

--- a/tests/DemosTest.php
+++ b/tests/DemosTest.php
@@ -153,7 +153,7 @@ class DemosTest extends TestCase
     {
         $appSticky = array_diff_assoc(
             \Closure::bind(static fn () => $app->stickyGetArguments, null, App::class)(),
-            ['__atk_json' => false, '__atk_tab' => false, 'APP_CALL_EXIT' => true, 'APP_CATCH_EXCEPTIONS' => true]
+            ['__atk_json' => false, 'APP_CALL_EXIT' => true, 'APP_CATCH_EXCEPTIONS' => true]
         );
         if ($appSticky !== []) {
             throw (new Exception('Global GET sticky must never be set by any component'))


### PR DESCRIPTION
`__atk_tab` GET param is needed only for the initial tab load, I do not think it has to be sticky.