### PR TITLE
Use View::$entity property for entity access

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ It's easy to create your own application styling. Here are some example UI:
 As of version 2.0 - Agile Toolkit offers support for User Actions. Those are easy to define in your Data Model declaration:
 
 ```php
-$this->addUserAction('archive', function (Model $m) {
-    $m->set('is_archived', true);
+$this->addUserAction('archive', function (Model $entity) {
+    $this->set('is_archived', true);
     $this->saveAndUnload();
 });
 ```

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $form->addField('email');
 $form->onSubmit(function (Form $form) {
     // implement subscribe here
 
-    return $form->jsSuccess('Subscribed ' . $form->model->get('email') . ' to newsletter.');
+    return $form->jsSuccess('Subscribed ' . $form->entity->get('email') . ' to newsletter.');
 });
 
 // decorate anything

--- a/demos/_includes/DemoActionsUtil.php
+++ b/demos/_includes/DemoActionsUtil.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Atk4\Ui\Demos;
 
-use Atk4\Data\Model;
 use Atk4\Data\Model\UserAction;
 use Atk4\Ui\Exception;
 use Atk4\Ui\Form;
@@ -15,18 +14,18 @@ class DemoActionsUtil
     {
         $country->addUserAction('callback', [
             'description' => 'Callback',
-            'callback' => static function (Country $model) {
-                return 'callback execute using country ' . $model->getTitle();
+            'callback' => static function (Country $entity) {
+                return 'callback execute using country ' . $entity->getTitle();
             },
         ]);
 
         $country->addUserAction('preview', [
             'description' => 'Display Preview prior to run the action',
-            'preview' => static function (Country $model) {
-                return 'Previewing country ' . $model->getTitle();
+            'preview' => static function (Country $entity) {
+                return 'Previewing country ' . $entity->getTitle();
             },
-            'callback' => static function (Country $model) {
-                return 'Done previewing ' . $model->getTitle();
+            'callback' => static function (Country $entity) {
+                return 'Done previewing ' . $entity->getTitle();
             },
         ]);
 
@@ -45,11 +44,11 @@ class DemoActionsUtil
             'args' => [
                 'age' => ['type' => 'integer', 'required' => true],
             ],
-            'callback' => static function (Country $model, int $age) {
+            'callback' => static function (Country $entity, int $age) {
                 if ($age < 18) {
-                    $text = 'Sorry not old enough to visit ' . $model->getTitle();
+                    $text = 'Sorry not old enough to visit ' . $entity->getTitle();
                 } else {
-                    $text = $age . ' is old enough to visit ' . $model->getTitle();
+                    $text = $age . ' is old enough to visit ' . $entity->getTitle();
                 }
 
                 return $text;
@@ -62,10 +61,10 @@ class DemoActionsUtil
             'args' => [
                 'age' => ['type' => 'integer', 'required' => true],
             ],
-            'preview' => static function (Country $model, int $age) {
+            'preview' => static function (Country $entity, int $age) {
                 return 'You age is: ' . $age;
             },
-            'callback' => static function (Model $model, $age) {
+            'callback' => static function (Country $entity, $age) {
                 return 'age = ' . $age;
             },
         ]);
@@ -98,13 +97,13 @@ class DemoActionsUtil
         $country->addUserAction('confirm', [
             'caption' => 'User Confirmation',
             'description' => 'Confirm the action using a ConfirmationExecutor',
-            'confirmation' => static function (UserAction $a) {
-                $iso3 = Country::assertInstanceOf($a->getEntity())->iso3;
+            'confirmation' => static function (UserAction $action) {
+                $iso3 = Country::assertInstanceOf($action->getEntity())->iso3;
 
-                return 'Are you sure you want to perform this action on: <b>' . $a->getEntity()->getTitle() . ' (' . $iso3 . ')</b>';
+                return 'Are you sure you want to perform this action on: <b>' . $action->getEntity()->getTitle() . ' (' . $iso3 . ')</b>';
             },
-            'callback' => static function (Country $model) {
-                return 'Confirm country ' . $model->getTitle();
+            'callback' => static function (Country $entity) {
+                return 'Confirm country ' . $entity->getTitle();
             },
         ]);
 
@@ -126,13 +125,13 @@ class DemoActionsUtil
                 ],
             ],
             'fields' => [$country->fieldName()->iso3],
-            'callback' => static function (Country $model, int $age, string $city, string $gender) {
+            'preview' => static function (Country $entity, int $age, string $city, string $gender) {
+                return 'Gender = ' . $gender . ' / Age = ' . $age;
+            },
+            'callback' => static function (Country $entity, int $age, string $city, string $gender) {
                 $n = $gender === 'm' ? 'Mr.' : 'Mrs.';
 
                 return 'Thank you ' . $n . ' at age ' . $age;
-            },
-            'preview' => static function (Country $model, int $age, string $city, string $gender) {
-                return 'Gender = ' . $gender . ' / Age = ' . $age;
             },
         ]);
     }

--- a/demos/_includes/FlyersForm.php
+++ b/demos/_includes/FlyersForm.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Atk4\Ui\Demos;
 
-use Atk4\Data\Model;
 use Atk4\Data\Persistence;
 use Atk4\Ui\Form;
 use Atk4\Ui\Js\JsToast;
@@ -40,9 +39,9 @@ class FlyersForm extends Form
         $this->addControl('country', [
             Form\Control\Lookup::class,
             'model' => new Country($this->getApp()->db),
-            'dependency' => static function (Model $model, $data) {
+            'dependency' => static function (Country $model, $data) {
                 if (isset($data['contains'])) {
-                    $model->addCondition(Country::hinting()->fieldName()->name, 'like', '%' . $data['contains'] . '%');
+                    $model->addCondition($model->fieldName()->name, 'like', '%' . $data['contains'] . '%');
                 }
             },
             'search' => [

--- a/demos/_unit-test/callback.php
+++ b/demos/_unit-test/callback.php
@@ -33,7 +33,7 @@ $button = Button::addTo($app, ['First', 'class.atk-test' => true]);
 $button->on('click', new JsModal('Edit First Record', $vp));
 
 $form->onSubmit(static function (Form $form) use ($table) {
-    $form->model->save();
+    $form->entity->save();
 
     return new JsBlock([
         $table->jsReload(),

--- a/demos/_unit-test/lookup-virtual-page.php
+++ b/demos/_unit-test/lookup-virtual-page.php
@@ -22,7 +22,7 @@ $vp->set(static function (VirtualPage $vp) {
     $form = Form::addTo($vp);
     $form->addControl('category', [Form\Control\Lookup::class, 'model' => new Category($vp->getApp()->db)]);
     $form->onSubmit(static function (Form $form) {
-        $category = $form->getControl('category')->model->load($form->model->get('category'));
+        $category = $form->getControl('category')->model->load($form->entity->get('category'));
 
         return new JsToast($category->getTitle());
     });

--- a/demos/_unit-test/lookup.php
+++ b/demos/_unit-test/lookup.php
@@ -19,8 +19,8 @@ $model->addCondition($model->fieldName()->name, '=', 'Mustard');
 $app->getExecutorFactory()->useTriggerDefault(ExecutorFactory::TABLE_BUTTON);
 
 $edit = $model->getUserAction('edit');
-$edit->callback = static function (Product $model) {
-    return $model->product_category_id->getTitle() . ' - ' . $model->product_sub_category_id->getTitle();
+$edit->callback = static function (Product $entity) {
+    return $entity->product_category_id->getTitle() . ' - ' . $entity->product_sub_category_id->getTitle();
 };
 
 $crud = Crud::addTo($app);

--- a/demos/_unit-test/scope-builder.php
+++ b/demos/_unit-test/scope-builder.php
@@ -36,7 +36,7 @@ $form = Form::addTo($app);
 $form->addControl('qb', [Form\Control\ScopeBuilder::class, 'model' => $model], ['type' => 'object']);
 
 $form->onSubmit(static function (Form $form) use ($model) {
-    $message = $form->model->get('qb')->toWords($model);
+    $message = $form->entity->get('qb')->toWords($model);
     $view = View::addTo($form)->addClass('atk-scope-builder-response');
     $view->set($message);
 

--- a/demos/_unit-test/virtual-page.php
+++ b/demos/_unit-test/virtual-page.php
@@ -26,7 +26,7 @@ $vp->set(static function (VirtualPage $firstPage) {
             $form = Form::addTo($thirdPage);
             $form->addControl('category', [Form\Control\Lookup::class, 'model' => new Category($thirdPage->getApp()->db)]);
             $form->onSubmit(static function (Form $form) {
-                $category = $form->getControl('category')->model->load($form->model->get('category'));
+                $category = $form->getControl('category')->model->load($form->entity->get('category'));
 
                 return new JsToast($category->getTitle());
             });

--- a/demos/collection/crud.php
+++ b/demos/collection/crud.php
@@ -55,10 +55,10 @@ $crud = Crud::addTo($column, [
 // condition on the model can be applied on a model
 $model = new Country($app->db);
 $model->addCondition($model->fieldName()->numcode, '<', 200);
-$model->onHook(Model::HOOK_VALIDATE, static function (Country $model, ?string $intent) {
+$model->onHook(Model::HOOK_VALIDATE, static function (Country $entity, ?string $intent) {
     $err = [];
-    if ($model->numcode >= 200) {
-        $err[$model->fieldName()->numcode] = 'Should be less than 200';
+    if ($entity->numcode >= 200) {
+        $err[$entity->fieldName()->numcode] = 'Should be less than 200';
     }
 
     return $err;

--- a/demos/collection/grid.php
+++ b/demos/collection/grid.php
@@ -24,8 +24,8 @@ require_once __DIR__ . '/../init-app.php';
 
 $grid = Grid::addTo($app);
 $model = new Country($app->db);
-$model->addUserAction('test', static function (Model $model) {
-    return 'test from ' . $model->getTitle() . ' was successful!';
+$model->addUserAction('test', static function (Model $entity) {
+    return 'test from ' . $entity->getTitle() . ' was successful!';
 });
 
 $grid->setModel($model);

--- a/demos/collection/table2.php
+++ b/demos/collection/table2.php
@@ -61,8 +61,8 @@ $table = Table::addTo($app);
 $table->setModel($model, ['action']);
 
 // copy of amount through a PHP callback
-$model->addExpression('amount_copy', ['expr' => static function (Model $model) {
-    return $model->get('amount');
+$model->addExpression('amount_copy', ['expr' => static function (Model $entity) {
+    return $entity->get('amount');
 }, 'type' => 'atk4_money']);
 
 // column with 2 decorators that stack. Money will use red ink and alignment, format will change text.

--- a/demos/data-action/actions.php
+++ b/demos/data-action/actions.php
@@ -31,7 +31,7 @@ $action = $files->addUserAction('import_from_filesystem', [
     'description' => 'Import file in a specify path.',
     // Display information prior to execute the action.
     // ModalExecutor or PreviewExecutor will display preview.
-    'preview' => static function (Model $model, string $path) {
+    'preview' => static function (Model $entity, string $path) {
         return 'Execute Import using path: "' . $path . '"';
     },
     // Argument needed to run the callback action method.

--- a/demos/data-action/jsactions.php
+++ b/demos/data-action/jsactions.php
@@ -49,7 +49,7 @@ $country->addUserAction('greet', [
             'required' => true,
         ],
     ],
-    'callback' => static function (Country $model, string $name) {
+    'callback' => static function (Country $entity, string $name) {
         return 'Hello ' . $name;
     },
 ]);

--- a/demos/data-action/jsactionscrud.php
+++ b/demos/data-action/jsactionscrud.php
@@ -23,7 +23,7 @@ $files->addUserAction('import_from_filesystem', [
     'caption' => 'Import',
     'callback' => 'importFromFilesystem',
     'description' => 'Import file using path:',
-    'preview' => static function (Model $model, $path) {
+    'preview' => static function (Model $entity, $path) {
         return 'Execute Import using path: "' . $path . '"';
     },
     'args' => [
@@ -32,7 +32,7 @@ $files->addUserAction('import_from_filesystem', [
     'appliesTo' => Model\UserAction::APPLIES_TO_NO_RECORDS,
 ]);
 
-$files->addUserAction('download', static function (Model $model) {
+$files->addUserAction('download', static function (Model $entity) {
     return 'File has been download!';
 });
 

--- a/demos/form-control/calendar.php
+++ b/demos/form-control/calendar.php
@@ -52,8 +52,8 @@ $control->addAction(['Clear', 'icon' => 'times red'])
 
 $form->onSubmit(static function (Form $form) use ($app) {
     $data = [];
-    foreach ($form->model->get() as $k => $v) {
-        $data[$k] = $app->uiPersistence->typecastSaveField($form->model->getField($k), $v) ?? 'empty';
+    foreach ($form->entity->get() as $k => $v) {
+        $data[$k] = $app->uiPersistence->typecastSaveField($form->entity->getField($k), $v) ?? 'empty';
     }
 
     return new JsToast(implode(', ', $data));

--- a/demos/form-control/checkbox.php
+++ b/demos/form-control/checkbox.php
@@ -36,5 +36,5 @@ $form->addControl('test_checked', [Form\Control\Checkbox::class])->set(1);
 $form->addControl('also_checked', ['caption' => 'Also checked by default'], ['type' => 'boolean'])->set(true);
 
 $form->onSubmit(static function (Form $form) use ($app) {
-    return new JsToast($app->encodeJson($form->model->get()));
+    return new JsToast($app->encodeJson($form->entity->get()));
 });

--- a/demos/form-control/dropdown-plus.php
+++ b/demos/form-control/dropdown-plus.php
@@ -27,7 +27,7 @@ $form->addControl('sub_category_id', [Form\Control\DropdownCascade::class, 'casc
 $form->addControl('product_id', [Form\Control\DropdownCascade::class, 'cascadeFrom' => 'sub_category_id', 'reference' => SubCategory::hinting()->fieldName()->Products]);
 
 $form->onSubmit(static function (Form $form) use ($app) {
-    $message = $app->encodeJson($app->uiPersistence->typecastSaveRow($form->model, $form->model->get()));
+    $message = $app->encodeJson($app->uiPersistence->typecastSaveRow($form->entity, $form->entity->get()));
 
     $view = new Message('Values: ');
     $view->setApp($form->getApp());
@@ -105,7 +105,7 @@ $form->addControl('multi', [
 ]);
 
 $form->onSubmit(static function (Form $form) use ($app) {
-    $message = $app->encodeJson($form->model->get());
+    $message = $app->encodeJson($form->entity->get());
 
     $view = new Message('Values:');
     $view->setApp($form->getApp());

--- a/demos/form-control/form6.php
+++ b/demos/form-control/form6.php
@@ -34,5 +34,5 @@ $form->addControl('string_d', [], ['values' => ['F' => 'female', 'M' => 'male']]
 $form->addControl('string_r', [Form\Control\Radio::class], ['values' => ['F' => 'female', 'M' => 'male']])->set('M');
 
 $form->onSubmit(static function (Form $form) use ($app) {
-    return new JsToast($app->encodeJson($form->getApp()->uiPersistence->typecastSaveRow($form->model, $form->model->get())));
+    return new JsToast($app->encodeJson($form->getApp()->uiPersistence->typecastSaveRow($form->entity, $form->entity->get())));
 });

--- a/demos/form-control/input2.php
+++ b/demos/form-control/input2.php
@@ -126,7 +126,7 @@ $control = $form->addControl('surname', new Form\Control\Line([
 ]));
 
 $form->onSubmit(static function (Form $form) {
-    return $form->model->get('name');
+    return $form->entity->get('name');
 });
 
 Header::addTo($app, ['Multiple Form Layouts']);
@@ -142,7 +142,7 @@ $formPage = Form\Layout::addTo($tabs->addTab('Other Info'), ['form' => $form]);
 $formPage->addControl('age', new Form\Control\Line());
 
 $form->onSubmit(static function (Form $form) {
-    return $form->model->get('name') . ' has age ' . $form->model->get('age');
+    return $form->entity->get('name') . ' has age ' . $form->entity->get('age');
 });
 
 Header::addTo($app, ['onChange event', 'subHeader' => 'see in browser console']);

--- a/demos/form-control/lookup-dep.php
+++ b/demos/form-control/lookup-dep.php
@@ -56,7 +56,7 @@ $lookup = $form->addControl('country', [
 ]);
 
 $form->onSubmit(static function (Form $form) {
-    return 'Submitted: ' . print_r($form->model->get(), true);
+    return 'Submitted: ' . print_r($form->entity->get(), true);
 });
 
 Header::addTo($app, ['Lookup multiple values']);
@@ -92,5 +92,5 @@ $lookup = $form->addControl('country', [
 ]);
 
 $form->onSubmit(static function (Form $form) {
-    return 'Submitted: ' . print_r($form->model->get(), true);
+    return 'Submitted: ' . print_r($form->entity->get(), true);
 });

--- a/demos/form-control/lookup.php
+++ b/demos/form-control/lookup.php
@@ -53,10 +53,10 @@ $form->onSubmit(static function (Form $form) {
     $view = new Message('Select:');
     $view->setApp($form->getApp());
     $view->invokeInit();
-    $view->text->addParagraph(Country::assertInstanceOf($form->model->ref('country1'))->name ?? 'null');
-    $view->text->addParagraph(Country::assertInstanceOf($form->model->ref('country2'))->name ?? 'null');
-    $view->text->addParagraph($form->model->get('country3') !== '' // related with https://github.com/atk4/ui/pull/1805
-        ? (new Country($form->getApp()->db))->load($form->model->get('country3'))->name
+    $view->text->addParagraph(Country::assertInstanceOf($form->entity->ref('country1'))->name ?? 'null');
+    $view->text->addParagraph(Country::assertInstanceOf($form->entity->ref('country2'))->name ?? 'null');
+    $view->text->addParagraph($form->entity->get('country3') !== '' // related with https://github.com/atk4/ui/pull/1805
+        ? (new Country($form->getApp()->db))->load($form->entity->get('country3'))->name
         : 'null');
 
     return $view;

--- a/demos/form-control/scope-builder.php
+++ b/demos/form-control/scope-builder.php
@@ -19,5 +19,5 @@ $form = Form::addTo($app);
 $form->addControl('qb', [Form\Control\ScopeBuilder::class, 'model' => $model, 'options' => ['debug' => true]]);
 
 $form->onSubmit(static function (Form $form) use ($model) {
-    return "Scope selected:\n\n" . $form->model->get('qb')->toWords($model);
+    return "Scope selected:\n\n" . $form->entity->get('qb')->toWords($model);
 });

--- a/demos/form-control/tree-item-selector.php
+++ b/demos/form-control/tree-item-selector.php
@@ -72,8 +72,8 @@ $control->onItem(static function (int $value) use ($pathFromIdFx, $items) {
 
 $form->onSubmit(static function (Form $form) use ($app) {
     $response = [
-        'multiple' => $form->model->get('tree'),
-        'single' => $form->model->get('tree1'),
+        'multiple' => $form->entity->get('tree'),
+        'single' => $form->entity->get('tree1'),
     ];
 
     $view = new Message('Items:');

--- a/demos/form-control/upload.php
+++ b/demos/form-control/upload.php
@@ -87,5 +87,5 @@ $control->onUpload(static function (array $postFile) use ($form, $control) {
 
 $form->onSubmit(static function (Form $form) {
     // implement submission here
-    return $form->jsSuccess('Thanks for submitting file: ' . $form->model->get('img') . ' / ' . $form->model->get('file'));
+    return $form->jsSuccess('Thanks for submitting file: ' . $form->entity->get('img') . ' / ' . $form->entity->get('file'));
 });

--- a/demos/form/form-section.php
+++ b/demos/form/form-section.php
@@ -22,11 +22,11 @@ $model = new Country($app->db);
 $model = $model->loadAny();
 
 $saveAndDumpValues = static function (Form $form) {
-    $form->model->save();
+    $form->entity->save();
 
     return new JsToast([
         'title' => 'POSTed field values',
-        'message' => '<pre>' . $form->getApp()->encodeJson($form->model->get()) . '</pre>',
+        'message' => '<pre>' . $form->getApp()->encodeJson($form->entity->get()) . '</pre>',
         'class' => 'success',
         'displayTime' => 5000,
     ]);

--- a/demos/form/form.php
+++ b/demos/form/form.php
@@ -34,7 +34,7 @@ $form->addControl('email');
 $form->onSubmit(static function (Form $form) {
     // implement subscribe here
 
-    return $form->jsSuccess('Subscribed ' . $form->model->get('email') . ' to newsletter.');
+    return $form->jsSuccess('Subscribed ' . $form->entity->get('email') . ' to newsletter.');
 });
 
 $form->buttonSave->set('Subscribe');
@@ -59,7 +59,7 @@ $form->addControl('status_string_required', [Form\Control\Dropdown::class], ['ty
 $form->addControl('status_integer_required', [Form\Control\Dropdown::class], ['type' => 'integer', 'values' => $values, 'required' => true]);
 
 $form->onSubmit(static function (Form $form) use ($app) {
-    return new JsToast($app->encodeJson($form->model->get()));
+    return new JsToast($app->encodeJson($form->entity->get()));
 });
 
 Header::addTo($tab, ['Comparing Field type vs Form control class']);
@@ -69,7 +69,7 @@ $form->addControl('control', [Form\Control\Calendar::class, 'type' => 'date', 'c
 $form->buttonSave->set('Compare Date');
 
 $form->onSubmit(static function (Form $form) {
-    $message = 'field = ' . print_r($form->model->get('field'), true) . '; <br> control = ' . print_r($form->model->get('control'), true);
+    $message = 'field = ' . print_r($form->entity->get('field'), true) . '; <br> control = ' . print_r($form->entity->get('control'), true);
     $view = new Message('Date field vs control:');
     $view->setApp($form->getApp());
     $view->invokeInit();
@@ -194,8 +194,8 @@ $form = Form::addTo($tab, ['class.segment' => true]);
 $form->setModel($modelRegister);
 
 $form->onSubmit(static function (Form $form) {
-    if ($form->model->get('name') !== 'John') {
-        return $form->jsError('name', 'Your name is not John! It is "' . $form->model->get('name') . '". It should be John. Pleeease!');
+    if ($form->entity->get('name') !== 'John') {
+        return $form->jsError('name', 'Your name is not John! It is "' . $form->entity->get('name') . '". It should be John. Pleeease!');
     }
 
     return new JsBlock([
@@ -233,13 +233,13 @@ $group->addControl('last_name', ['width' => 'five']);
 
 $form->onSubmit(static function (Form $form) {
     $errors = [];
-    foreach ($form->model->getFields() as $name => $ff) {
+    foreach ($form->entity->getFields() as $name => $ff) {
         if ($name === 'id') {
             continue;
         }
 
-        if ($form->model->get($name) !== 'a') {
-            $errors[] = $form->jsError($name, 'Field ' . $name . ' should contain exactly "a", but contains ' . $form->model->get($name));
+        if ($form->entity->get($name) !== 'a') {
+            $errors[] = $form->jsError($name, 'Field ' . $name . ' should contain exactly "a", but contains ' . $form->entity->get($name));
         }
     }
 

--- a/demos/form/form2.php
+++ b/demos/form/form2.php
@@ -58,18 +58,18 @@ $formNames->addControl('last_name', ['width' => 'six', 'caption' => 'Last Name']
 $form->onSubmit(static function (Form $form) {
     $countryEntity = (new Country($form->getApp()->db))->createEntity();
     // Model will have some validation too
-    foreach ($form->model->getFields('editable') as $k => $field) {
+    foreach ($form->entity->getFields('editable') as $k => $field) {
         if ($countryEntity->hasField($k)) {
-            $countryEntity->set($k, $form->model->get($k));
+            $countryEntity->set($k, $form->entity->get($k));
         }
     }
 
     // in-form validation
     $errors = [];
-    if (mb_strlen($form->model->get('first_name')) < 3) {
-        $errors[] = $form->jsError('first_name', 'too short, ' . $form->model->get('first_name'));
+    if (mb_strlen($form->entity->get('first_name')) < 3) {
+        $errors[] = $form->jsError('first_name', 'too short, ' . $form->entity->get('first_name'));
     }
-    if (mb_strlen($form->model->get('last_name')) < 5) {
+    if (mb_strlen($form->entity->get('last_name')) < 5) {
         $errors[] = $form->jsError('last_name', 'too short');
     }
 

--- a/demos/form/form3.php
+++ b/demos/form/form3.php
@@ -36,12 +36,12 @@ $form->setModel((new $modelClass($app->db))->loadAny());
 $form->onSubmit(static function (Form $form) {
     $errors = [];
     $modelDirty = \Closure::bind(static function () use ($form): array { // TODO Model::dirty property is private
-        return $form->model->dirty;
+        return $form->entity->dirty;
     }, null, Model::class)();
     foreach ($modelDirty as $field => $value) {
         // we should care only about editable fields
-        if ($form->model->getField($field)->isEditable()) {
-            $errors[] = $form->jsError($field, 'Value was changed, ' . $form->getApp()->encodeJson($value) . ' to ' . $form->getApp()->encodeJson($form->model->get($field)));
+        if ($form->entity->getField($field)->isEditable()) {
+            $errors[] = $form->jsError($field, 'Value was changed, ' . $form->getApp()->encodeJson($value) . ' to ' . $form->getApp()->encodeJson($form->entity->get($field)));
         }
     }
 

--- a/demos/form/form5.php
+++ b/demos/form/form5.php
@@ -21,7 +21,7 @@ View::addTo($app, [
 ]);
 
 $formSubmit = static function (Form $form) use ($app) {
-    return new JsToast($app->encodeJson($form->model->get()));
+    return new JsToast($app->encodeJson($form->entity->get()));
 };
 
 $cc = Columns::addTo($app);

--- a/demos/init-db.php
+++ b/demos/init-db.php
@@ -349,9 +349,9 @@ class Country extends ModelWithPrefixedFields
         $this->addField($this->fieldName()->numcode, ['caption' => 'ISO Numeric Code', 'type' => 'integer', 'required' => true]);
         $this->addField($this->fieldName()->phonecode, ['caption' => 'Phone Prefix', 'type' => 'integer', 'required' => true]);
 
-        $this->onHook(Model::HOOK_BEFORE_SAVE, static function (self $model) {
-            if (!$model->sys_name) {
-                $model->sys_name = mb_strtoupper($model->name);
+        $this->onHook(Model::HOOK_BEFORE_SAVE, static function (self $entity) {
+            if (!$entity->sys_name) {
+                $entity->sys_name = mb_strtoupper($entity->name);
             }
         });
     }
@@ -435,9 +435,9 @@ class Stat extends ModelWithPrefixedFields
         $this->addField($this->fieldName()->is_commercial, ['type' => 'boolean']);
         $this->addField($this->fieldName()->currency, ['values' => ['EUR' => 'Euro', 'USD' => 'US Dollar', 'GBP' => 'Pound Sterling']]);
         $this->addField($this->fieldName()->currency_symbol, ['neverPersist' => true]);
-        $this->onHook(Model::HOOK_AFTER_LOAD, static function (self $model) {
+        $this->onHook(Model::HOOK_AFTER_LOAD, static function (self $entity) {
             $map = ['EUR' => '€', 'USD' => '$', 'GBP' => '£'];
-            $model->currency_symbol = $map[$model->currency] ?? '?';
+            $entity->currency_symbol = $map[$entity->currency] ?? '?';
         });
 
         $this->addField($this->fieldName()->project_budget, ['type' => 'atk4_money']);

--- a/demos/interactive/accordion-nested.php
+++ b/demos/interactive/accordion-nested.php
@@ -42,7 +42,7 @@ $addAccordionFx = static function ($view, int $maxDepth, int $level = 0) use (&$
         $form = Form::addTo($vp);
         $form->addControl('email');
         $form->onSubmit(static function (Form $form) {
-            return $form->jsSuccess('Subscribed ' . $form->model->get('email') . ' to newsletter.');
+            return $form->jsSuccess('Subscribed ' . $form->entity->get('email') . ' to newsletter.');
         });
 
         $addAccordionFx($vp, $maxDepth, $level + 1);

--- a/demos/interactive/accordion.php
+++ b/demos/interactive/accordion.php
@@ -50,7 +50,7 @@ $i3 = $accordion->addSection('Dynamic Form', static function (VirtualPage $vp) {
     $form = Form::addTo($vp);
     $form->addControl('Email');
     $form->onSubmit(static function (Form $form) {
-        return $form->jsSuccess('Subscribed ' . $form->model->get('Email') . ' to newsletter.');
+        return $form->jsSuccess('Subscribed ' . $form->entity->get('Email') . ' to newsletter.');
     });
 });
 

--- a/demos/interactive/card-action.php
+++ b/demos/interactive/card-action.php
@@ -33,7 +33,7 @@ $notify = $country->getModel()->addUserAction('Notify', [
     'args' => [
         'note' => ['type' => 'string', 'required' => true],
     ],
-    'callback' => static function (Model $model, $note) {
+    'callback' => static function (Model $entity, $note) {
         return 'Note to client is sent: ' . $note;
     },
 ]);

--- a/demos/interactive/console.php
+++ b/demos/interactive/console.php
@@ -128,11 +128,10 @@ $tab = $tabs->addTab('Use after form submit', static function (VirtualPage $vp) 
 
     $console = Console::addTo($vp, ['event' => false]);
     $console->set(static function (Console $console) use ($form) {
-        $entity = $form->model;
-        $entity->setMulti($_SESSION['atk4_ui_console_demo']);
+        $form->entity->setMulti($_SESSION['atk4_ui_console_demo']);
 
         $console->output('Executing process...');
-        $console->info(var_export($entity->get(), true));
+        $console->info(var_export($form->entity->get(), true));
         sleep(1);
         $console->output('Wait...');
         sleep(3);
@@ -141,7 +140,7 @@ $tab = $tabs->addTab('Use after form submit', static function (VirtualPage $vp) 
     $console->js(true)->hide();
 
     $form->onSubmit(static function (Form $form) use ($console) {
-        $_SESSION['atk4_ui_console_demo'] = $form->model->get();
+        $_SESSION['atk4_ui_console_demo'] = $form->entity->get();
 
         return new JsBlock([
             $console->js()->show(),

--- a/demos/interactive/modal.php
+++ b/demos/interactive/modal.php
@@ -92,7 +92,7 @@ $vp1Modal->set(static function (View $p) use ($vp2Modal) {
     $form = Form::addTo($p);
     $form->addControl('color', [], ['enum' => ['red', 'green', 'blue'], 'default' => 'green']);
     $form->onSubmit(static function (Form $form) use ($vp2Modal) {
-        return $vp2Modal->jsShow(['color' => $form->model->get('color')]);
+        return $vp2Modal->jsShow(['color' => $form->entity->get('color')]);
     });
 });
 
@@ -208,15 +208,15 @@ $stepModal->set(static function (View $p) use ($session, $previousAction, $nextA
         $form->setModel($modelRegister->createEntity());
 
         $form->onSubmit(static function (Form $form) use ($nextAction, $session) {
-            if ($form->model->get('name') !== 'John') {
-                return $form->jsError('name', 'Your name is not John! It is "' . $form->model->get('name') . '". It should be John. Pleeease!');
+            if ($form->entity->get('name') !== 'John') {
+                return $form->jsError('name', 'Your name is not John! It is "' . $form->entity->get('name') . '". It should be John. Pleeease!');
             }
 
             $session->memorize('success', true);
-            $session->memorize('name', $form->model->get('name'));
+            $session->memorize('name', $form->entity->get('name'));
 
             $js = [];
-            $js[] = $form->jsSuccess('Thank you, ' . $form->model->get('name') . ' you can go on!');
+            $js[] = $form->jsSuccess('Thank you, ' . $form->entity->get('name') . ' you can go on!');
             $js[] = $nextAction->js()->removeClass('disabled');
 
             return $js;

--- a/demos/interactive/popup.php
+++ b/demos/interactive/popup.php
@@ -256,13 +256,13 @@ $signup->set(static function (View $pop) {
         // popup handles callbacks properly, so dynamic element such as form works
         // perfectly inside a popup.
         $form->onSubmit(static function (Form $form) {
-            if ($form->model->get('password') !== '123') {
+            if ($form->entity->get('password') !== '123') {
                 return $form->jsError('password', 'Please use password "123"');
             }
 
             // refreshes entire page
-            return $form->getApp()->jsRedirect(['logged' => $form->model->get('email')]);
-            // return new JsExpression('alert([])', ['Thank you ' . $form->model->get('email')]);
+            return $form->getApp()->jsRedirect(['logged' => $form->entity->get('email')]);
+            // return new JsExpression('alert([])', ['Thank you ' . $form->entity->get('email')]);
         });
     }
 });

--- a/demos/interactive/tabs.php
+++ b/demos/interactive/tabs.php
@@ -57,8 +57,8 @@ $tabs->addTab('Dynamic Form', static function (VirtualPage $vp) {
     $form = Form::addTo($vp, ['class.segment' => true]);
     $form->setModel($modelRegister->createEntity());
     $form->onSubmit(static function (Form $form) {
-        if ($form->model->get('name') !== 'John') {
-            return $form->jsError('name', 'Your name is not John! It is "' . $form->model->get('name') . '". It should be John. Pleeease!');
+        if ($form->entity->get('name') !== 'John') {
+            return $form->jsError('name', 'Your name is not John! It is "' . $form->entity->get('name') . '". It should be John. Pleeease!');
         }
     });
 });

--- a/demos/interactive/wizard.php
+++ b/demos/interactive/wizard.php
@@ -43,7 +43,7 @@ $wizard->addStep(['Set DSN', 'icon' => 'configure', 'description' => 'Database C
 
     $form->addControl('dsn', ['caption' => 'Connect DSN'], ['required' => true])->placeholder = 'mysql://user:pass@db-host.example.com/mydb';
     $form->onSubmit(static function (Form $form) use ($wizard) {
-        $wizard->memorize('dsn', $form->model->get('dsn'));
+        $wizard->memorize('dsn', $form->entity->get('dsn'));
 
         return $wizard->jsNext();
     });

--- a/demos/layout/layouts_admin.php
+++ b/demos/layout/layouts_admin.php
@@ -58,7 +58,7 @@ $formGroup->addControl('zip', ['width' => 'four']);
 $form->onSubmit(static function (Form $form) {
     $errors = [];
     foreach (['first_name', 'last_name', 'address'] as $field) {
-        if (!$form->model->get($field)) {
+        if (!$form->entity->get($field)) {
             $errors[] = $form->jsError($field, 'Field ' . $field . ' is mandatory');
         }
     }

--- a/demos/tutorial/actions.php
+++ b/demos/tutorial/actions.php
@@ -124,7 +124,7 @@ $wizard->addStep('Arguments', static function (Wizard $page) {
                     'type' => 'string',
                 ],
             ],
-            'callback' => static function (Model $model, string $name) {
+            'callback' => static function (Model $entity, string $name) {
                 return 'Hi ' . $name;
             },
         ]);
@@ -137,7 +137,7 @@ $wizard->addStep('Arguments', static function (Wizard $page) {
                     'required' => true,
                 ],
             ],
-            'callback' => static function (Model $model, int $age) {
+            'callback' => static function (Model $entity, int $age) {
                 return 'Age is ' . $age;
             },
         ]);
@@ -164,16 +164,16 @@ $wizard->addStep('Crud integration', static function (Wizard $page) {
     Demo::addTo($page)->setCodeAndCall(static function (View $owner) {
         $country = new Country($owner->getApp()->db);
         $country->getUserAction('add')->enabled = false;
-        $country->getUserAction('delete')->enabled = static function (Country $m) {
-            return $m->id % 2 === 0;
+        $country->getUserAction('delete')->enabled = static function (Country $entity) {
+            return $entity->id % 2 === 0;
         };
         $country->addUserAction('mail', [
             'appliesTo' => Model\UserAction::APPLIES_TO_SINGLE_RECORD,
-            'preview' => static function (Country $model) {
-                return 'Here is email preview for ' . $model->name;
+            'preview' => static function (Country $entity) {
+                return 'Here is email preview for ' . $entity->name;
             },
-            'callback' => static function (Country $model) {
-                return 'Email sent to ' . $model->name;
+            'callback' => static function (Country $entity) {
+                return 'Email sent to ' . $entity->name;
             },
             'description' => 'Email testing',
         ]);
@@ -194,8 +194,8 @@ $wizard->addStep('Crud integration', static function (Wizard $page) {
         $model->addUserAction('mail', [
             'fields' => [$model->fieldName()->currency],
             'appliesTo' => Model\UserAction::APPLIES_TO_SINGLE_RECORD,
-            'callback' => static function (Stat $model) {
-                return 'Email sent in ' . $model->currency . ' currency';
+            'callback' => static function (Stat $entity) {
+                return 'Email sent in ' . $entity->currency . ' currency';
             },
             'description' => 'Email testing',
         ]);

--- a/demos/tutorial/intro.php
+++ b/demos/tutorial/intro.php
@@ -133,8 +133,8 @@ $wizard->addStep('Business Model', static function (Wizard $page) {
         session_start();
 
         $model = new DemoInvoice(new Persistence\Array_($_SESSION['atk4_ui_intro_demo'] ?? []));
-        $model->onHook(Model::HOOK_AFTER_SAVE, static function (Model $model) {
-            $_SESSION['atk4_ui_intro_demo'][$model->getId()] = (clone $model->getModel())->addCondition($model->idField, $model->getId())->export(null, null, false)[$model->getId()];
+        $model->onHook(Model::HOOK_AFTER_SAVE, static function (Model $entity) {
+            $_SESSION['atk4_ui_intro_demo'][$entity->getId()] = (clone $entity->getModel())->addCondition($entity->idField, $entity->getId())->export(null, null, false)[$entity->getId()];
         });
 
         Header::addTo($owner, ['Set invoice data:']);
@@ -188,8 +188,8 @@ $wizard->addStep('Persistence', static function (Wizard $page) {
         session_start();
 
         $model = new DemoInvoice(new Persistence\Array_($_SESSION['atk4_ui_intro_demo'] ?? []));
-        $model->onHook(Model::HOOK_AFTER_SAVE, static function (Model $model) {
-            $_SESSION['atk4_ui_intro_demo'][$model->getId()] = (clone $model->getModel())->addCondition($model->idField, $model->getId())->export(null, null, false)[$model->getId()];
+        $model->onHook(Model::HOOK_AFTER_SAVE, static function (Model $entity) {
+            $_SESSION['atk4_ui_intro_demo'][$entity->getId()] = (clone $entity->getModel())->addCondition($entity->idField, $entity->getId())->export(null, null, false)[$entity->getId()];
         });
 
         Header::addTo($owner, ['Record display in Card View using model data.']);

--- a/demos/tutorial/intro.php
+++ b/demos/tutorial/intro.php
@@ -154,7 +154,7 @@ $wizard->addStep('Business Model', static function (Wizard $page) {
         $form->setModel($entity);
 
         $form->onSubmit(static function (Form $form) {
-            $form->model->save();
+            $form->entity->save();
 
             return new JsToast('Saved!');
         });

--- a/docs/breadcrumb.md
+++ b/docs/breadcrumb.md
@@ -65,12 +65,12 @@ $model = new User($app->db);
 $id = $app->stickyGet('user_id');
 if ($id) {
     // perhaps we edit individual user?
-    $model = $model->load($id);
-    $crumb->addCrumb($model->get('name'), []);
+    $entity = $model->load($id);
+    $crumb->addCrumb($entity->get('name'), []);
 
     // here we can check for additional criteria and display a deeper level on the crumb
 
-    Form::addTo($app)->setModel($model);
+    Form::addTo($app)->setModel($entity);
 } else {
     // display list of users
     $table = Table::addTo($app);

--- a/docs/fileupload.md
+++ b/docs/fileupload.md
@@ -99,7 +99,7 @@ The fileId is set to file name by default if omitted:
 ```
 $form->onSubmit(function (Form $form) {
     // implement submission here
-    return $form->jsSuccess('Thanks for submitting file: ' . $form->model->get('img'));
+    return $form->jsSuccess('Thanks for submitting file: ' . $form->entity->get('img'));
 });
 ```
 

--- a/docs/form-control.md
+++ b/docs/form-control.md
@@ -377,22 +377,22 @@ If you want to customize how a record is displayed and/or add an icon, Dropdown 
 This function is called with each model record and needs to return an array:
 
 ```
-$dropdown->renderRowFunction = function (Model $record) {
+$dropdown->renderRowFunction = function (Model $entity) {
     return [
-        'title' => $record->getTitle() . ' (' . $record->get('subtitle') . ')',
+        'title' => $entity->getTitle() . ' (' . $entity->get('subtitle') . ')',
     ];
-}
+};
 ```
 
 You can also use this function to add an Icon to a record:
 
 ```
-$dropdown->renderRowFunction = function (Model $record) {
+$dropdown->renderRowFunction = function (Model $entity) {
     return [
-        'title' => $record->getTitle() . ' (' . $record->get('subtitle') . ')',
-        'icon' => $record->get('value') > 100 ? 'money' : 'coins',
+        'title' => $entity->getTitle() . ' (' . $entity->get('subtitle') . ')',
+        'icon' => $entity->get('value') > 100 ? 'money' : 'coins',
     ];
-}
+};
 ```
 
 If you'd like to even further adjust How each item is displayed (e.g. complex HTML and more model fields), you can extend the Dropdown class and create your own template with the complex HTML:
@@ -422,12 +422,12 @@ class MyDropdown extends \Atk4\Ui\Dropdown
 With the according renderRowFunction:
 
 ```
-function (Model $record) {
+function (Model $entity) {
     return [
-        'title' => $record->getTitle,
-        'icon' => $record->value > 100 ? 'money' : 'coins',
-        'someOtherField' => $record->get('SomeOtherField'),
-        'someOtherField2' => $record->get('SomeOtherField2'),
+        'title' => $entity->getTitle,
+        'icon' => $entity->value > 100 ? 'money' : 'coins',
+        'someOtherField' => $entity->get('SomeOtherField'),
+        'someOtherField2' => $entity->get('SomeOtherField2'),
     ];
 }
 ```

--- a/docs/form-control.md
+++ b/docs/form-control.md
@@ -424,7 +424,7 @@ With the according renderRowFunction:
 ```
 function (Model $entity) {
     return [
-        'title' => $entity->getTitle,
+        'title' => $entity->getTitle(),
         'icon' => $entity->value > 100 ? 'money' : 'coins',
         'someOtherField' => $entity->get('SomeOtherField'),
         'someOtherField2' => $entity->get('SomeOtherField2'),

--- a/docs/form-control.md
+++ b/docs/form-control.md
@@ -94,7 +94,7 @@ $formPage = Form\Layout::addTo($tabs->addTab('Other Info'), ['form' => $form]);
 $formPage->addControl('age', new \Atk4\Ui\Form\Control\Line());
 
 $form->onSubmit(function (Form $form) {
-    return $form->model->get('name') . ' has age ' . $form->model->get('age');
+    return $form->entity->get('name') . ' has age ' . $form->entity->get('age');
 });
 ```
 

--- a/docs/form.md
+++ b/docs/form.md
@@ -45,7 +45,7 @@ directly in PHP:
 $form->onSubmit(function (Form $form) {
     // implement subscribe here
 
-    return "Subscribed " . $form->model->get('email') . " to newsletter.";
+    return "Subscribed " . $form->entity->get('email') . " to newsletter.";
 });
 ```
 
@@ -68,10 +68,10 @@ Even if model not explicitly set (see section below) each form has an underlying
 
 ```
 // single field
-$form->model->set('email', 'some@email.com');
+$form->entity->set('email', 'some@email.com');
 
 // or multiple fields
-$form->model->set([
+$form->entity->set([
     'name' => 'John',
     'email' => 'some@email.com',
 ]);
@@ -316,15 +316,15 @@ $form->addControl('accept_terms', [], ['type' => 'boolean']);
 
 // submit event
 $form->onSubmit(function (Form $form) {
-    if ($form->model->get('password') != $form->model->get('password_verify')) {
+    if ($form->entity->get('password') != $form->entity->get('password_verify')) {
         return $form->jsError('password_verify', 'Passwords do not match');
     }
 
-    if (!$form->model->get('accept_terms')) {
+    if (!$form->entity->get('accept_terms')) {
         return $form->jsError('accept_terms', 'Read and accept terms');
     }
 
-    $form->model->save(); // will only store email / password
+    $form->entity->save(); // will only store email / password
 
     return $form->jsSuccess('Thank you. Check your email now');
 });
@@ -344,7 +344,7 @@ $form->addControl('date1', [], ['type' => 'date']);
 $form->addControl('date2', [\Atk4\Ui\Form\Control\Calendar::class, 'type' => 'date']);
 
 $form->onSubmit(function (Form $form) {
-    echo 'date1 = ' . print_r($form->model->get('date1'), true) . ' and date2 = ' . print_r($form->model->get('date2'), true);
+    echo 'date1 = ' . print_r($form->entity->get('date1'), true) . ' and date2 = ' . print_r($form->entity->get('date2'), true);
 });
 ```
 
@@ -445,7 +445,7 @@ able to add them again in sub-layouts.
 
 ### Loading Values
 
-Although you can set form control values individually using `$form->model->set('field', $value)`
+Although you can set form control values individually using `$form->entity->set('field', $value)`
 it's always nicer to load values for the database. Given a `User` model this is how
 you can create a form to change profile of a currently logged user:
 
@@ -585,11 +585,11 @@ that would perform the check can be defined displaying error or success messages
 
 ```
 $form->onSubmit(function (Form $form) {
-    if (!$form->model->get('terms')) {
+    if (!$form->entity->get('terms')) {
         return $form->jsError('terms', 'You must accept terms and conditions');
     }
 
-    $form->model->save();
+    $form->entity->save();
 
     return $form->jsSuccess('Registration Successful', 'We will call you soon.');
 });
@@ -604,11 +604,11 @@ with a message about failure to accept of terms and conditions:
 $form->onSubmit(function (Form $form) {
     $errors = [];
 
-    if (!$form->model->get('name')) {
+    if (!$form->entity->get('name')) {
         $errors[] = $form->jsError('name', 'Name must be specified');
     }
 
-    if (!$form->model->get('surname')) {
+    if (!$form->entity->get('surname')) {
         $errors[] = $form->jsError('surname', 'Surname must be specified');
     }
 
@@ -616,11 +616,11 @@ $form->onSubmit(function (Form $form) {
         return new \Atk4\Ui\Js\JsBlock($errors);
     }
 
-    if (!$form->model->get('terms')) {
+    if (!$form->entity->get('terms')) {
         return $form->jsError('terms', 'You must accept terms and conditions');
     }
 
-    $form->model->save();
+    $form->entity->save();
 
     return $form->jsSuccess('Registration Successful', 'We will call you soon.');
 });

--- a/docs/grid.md
+++ b/docs/grid.md
@@ -152,7 +152,7 @@ to populate a content:
 ```
 $grid->addModalAction('Details', 'Additional Details', function (View $p, $id) use ($grid) {
     // $id of the record which was clicked
-    // $grid->model = $grid->model->load($id);
+    // $model = $grid->model->load($id);
 
     LoremIpsum::addTo($p);
 });

--- a/docs/js.md
+++ b/docs/js.md
@@ -538,7 +538,7 @@ $table = \Atk4\Ui\Table::addTo($app);
 $form->setModel($bookModel);
 
 $form->onSubmit(function (Form $form) use ($table) {
-    $form->model->save();
+    $form->entity->save();
 
     return new \Atk4\Ui\Js\JsReload($table);
 });
@@ -581,7 +581,7 @@ $button = \Atk4\Ui\Button::addTo($app, ['Add Item', 'icon' => 'plus']);
 $button->on('click', new \Atk4\Ui\Js\JsModal('JSModal Title', $vp));
 
 $form->onSubmit(function (Form $form) use ($table) {
-    $form->model->save();
+    $form->entity->save();
 
     return new \Atk4\Ui\Js\JsBlock([
         $table->jsReload(),
@@ -608,7 +608,7 @@ $button = \Atk4\Ui\Button::addTo($app, ['Add Item', 'icon' => 'plus']);
 $button->on('click', new \Atk4\Ui\Js\JsModal('JSModal Title', $vp));
 
 $form->onSubmit(function (Form $form) use ($table) {
-    $form->model->save();
+    $form->entity->save();
 
     return new \Atk4\Ui\Js\JsBlock([
         $table->jsReload(),
@@ -631,7 +631,7 @@ $vp->set(function (\Atk4\Ui\VirtualPage $p) use ($table, $model) {
     $form = \Atk4\Ui\Form::addTo($p);
     $form->setModel($model);
     $form->onSubmit(function (Form $form) use ($table) {
-        $form->model->save();
+        $form->entity->save();
 
         return new \Atk4\Ui\Js\JsBlock([
             $table->jsReload(),

--- a/docs/lister.md
+++ b/docs/lister.md
@@ -129,7 +129,7 @@ $lister->setSource([
 Your {row} template may contain few special tags:
 
 - {$_id} - will be set to ID of the record (regardless of how your id_field is called)
-- {$_title} - will be set to the title of your record (see $model->$titleField)
+- {$_title} - will be set to the title of your record (see Model::$titleField)
 - {$_href} - will point to current page but with ?id=123 extra GET argument.
 
 ## Load page content dynamically when scrolling

--- a/docs/multiline.md
+++ b/docs/multiline.md
@@ -121,7 +121,7 @@ $ml->setReferenceModel('Emails');
 
 // set up saving of Email on Form submit
 $userForm->onSubmit(function (Form $form) use ($ml) {
-    $form->model->save();
+    $form->entity->save();
     // save emails record related to current user
     $ml->saveRows();
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -206,7 +206,7 @@ $colReload = new \Atk4\Ui\Js\JsReload($col);
 $form = \Atk4\Ui\Form::addTo($col->addColumn());
 $form->setModel(new ToDoItem($s));
 $form->onSubmit(function (Form $form) use ($colReload) {
-    $form->model->save();
+    $form->entity->save();
 
     return $colReload;
 });

--- a/docs/render.md
+++ b/docs/render.md
@@ -31,7 +31,7 @@ or will become child of another view. Method init() is not executed on either ob
 7. init() will identify that there are some "pending children" and will add them in properly.
 
 Most of the UI classes will allow you to operate even if they are not initialized. For instance calling 'setModel()' will
-simply set a $model property and does not really need to rely on $api etc.
+simply set a $model/$entity property and does not really need to rely on $api etc.
 
 Next, lets look at what Initialization really is and why is it important.
 

--- a/docs/tablecolumn.md
+++ b/docs/tablecolumn.md
@@ -328,10 +328,10 @@ Sometimes your formatting may change depending on value. For example you may wan
 only on certain rows. For this you can use an `\Atk4\Ui\Table\Column\Multiformat` decorator:
 
 ```
-$table->addColumn('amount', [\Atk4\Ui\Table\Column\Multiformat::class, function (Model $model) {
-    if ($model->get('is_invoiced') > 0) {
+$table->addColumn('amount', [\Atk4\Ui\Table\Column\Multiformat::class, function (Model $entity) {
+    if ($entity->get('is_invoiced') > 0) {
         return [\Atk4\Ui\Table\Column\Money::class, [\Atk4\Ui\Table\Column\Link::class, 'invoice', ['invoice_id' => 'id']]];
-    } elseif (abs($model->get('is_refunded')) < 50) {
+    } elseif (abs($entity->get('is_refunded')) < 50) {
         return [[\Atk4\Ui\Table\Column\Template::class, 'Amount was <b>refunded</b>']];
     }
 

--- a/docs/tabs.md
+++ b/docs/tabs.md
@@ -71,8 +71,8 @@ $tabs->addTab('Dynamic Form', function (VirtualPage $vp) {
     $form = Form::addTo($vp, ['class.segment' => true]);
     $form->setModel($mRegister);
     $form->onSubmit(function (Form $form) {
-        if ($form->model->get('name') !== 'John') {
-            return $form->jsError('name', 'Your name is not John! It is "' . $form->model->get('name') . '". It should be John. Pleeease!');
+        if ($form->entity->get('name') !== 'John') {
+            return $form->jsError('name', 'Your name is not John! It is "' . $form->entity->get('name') . '". It should be John. Pleeease!');
         }
     });
 });

--- a/docs/virtualpage.md
+++ b/docs/virtualpage.md
@@ -249,7 +249,7 @@ $loader->set(function (\Atk4\Ui\Loader $p) {
     $form->addControl('year');
 
     $form->onSubmit(function (Form $form) use ($p) {
-        return new \Atk4\Ui\Js\JsReload($p, ['year' => $form->model->get('year')]);
+        return new \Atk4\Ui\Js\JsReload($p, ['year' => $form->entity->get('year')]);
     });
 });
 ```

--- a/src/Card.php
+++ b/src/Card.php
@@ -190,16 +190,16 @@ class Card extends View
      *
      * @return View
      */
-    public function addSection(?string $title = null, ?Model $model = null, ?array $fields = null, bool $useTable = false, bool $useLabel = false)
+    public function addSection(?string $title = null, ?Model $entity = null, ?array $fields = null, bool $useTable = false, bool $useLabel = false)
     {
         $section = CardSection::addToWithCl($this, array_merge($this->cardSectionSeed, ['card' => $this]), ['Section']);
         if ($title) {
             View::addTo($section, [$title, 'class.header' => true]);
         }
 
-        if ($model && $fields) {
-            $section->setModel($model);
-            $section->addFields($model, $fields, $useTable, $useLabel);
+        if ($entity !== null && $fields) {
+            $section->setModel($entity);
+            $section->addFields($entity, $fields, $useTable, $useLabel);
         }
 
         return $section;

--- a/src/Card.php
+++ b/src/Card.php
@@ -28,7 +28,7 @@ use Atk4\Ui\UserAction\SharedExecutor;
  * will have it's idField set as data-id HTML attribute for the card. Thus making
  * the ID available via javascript (new Jquery())->data('id')
  *
- * @property false|null $model use $entity property instead TODO remove null once https://github.com/phpstan/phpstan/issues/10787 is fixed
+ * @property false $model use $entity property instead
  */
 class Card extends View
 {

--- a/src/Card.php
+++ b/src/Card.php
@@ -27,6 +27,8 @@ use Atk4\Ui\UserAction\SharedExecutor;
  * When using model or models, the first model that get set via setModel method
  * will have it's idField set as data-id HTML attribute for the card. Thus making
  * the ID available via javascript (new Jquery())->data('id')
+ *
+ * @property false|null $model use $entity property instead TODO remove null once https://github.com/phpstan/phpstan/issues/10787 is fixed
  */
 class Card extends View
 {
@@ -174,10 +176,10 @@ class Card extends View
         parent::setModel($entity);
 
         if ($fields === null) {
-            $fields = array_keys($this->model->getFields(['editable', 'visible']));
+            $fields = array_keys($this->entity->getFields(['editable', 'visible']));
         }
 
-        $this->template->trySet('dataId', $this->getApp()->uiPersistence->typecastAttributeSaveField($this->model->getIdField(), $this->model->getId()));
+        $this->template->trySet('dataId', $this->getApp()->uiPersistence->typecastAttributeSaveField($this->entity->getIdField(), $this->entity->getId()));
 
         View::addTo($this->getSection(), [$entity->getTitle(), 'class.header' => true]);
         $this->getSection()->addFields($entity, $fields, $this->useLabel, $this->useTable);
@@ -218,10 +220,10 @@ class Card extends View
 
         // setting arg for model ID
         // $args[0] is consider to hold a model ID, i.e. as a JS expression
-        if ($this->model !== null && $this->model->isLoaded() && !isset($args[0])) {
-            $defaults[] = $this->model->getId();
+        if ($this->entity !== null && $this->entity->isLoaded() && !isset($args[0])) {
+            $defaults[] = $this->entity->getId();
             if ($cardDeck === null && !$action->isOwnerEntity()) {
-                $action = $action->getActionForEntity($this->model);
+                $action = $action->getActionForEntity($this->entity);
             }
         }
 
@@ -257,19 +259,19 @@ class Card extends View
     /**
      * Set extra content using model field.
      */
-    public function addExtraFields(Model $model, array $fields, ?string $glue = null): void
+    public function addExtraFields(Model $entity, array $fields, ?string $glue = null): void
     {
         // display extra field in line
         if ($glue) {
             $extra = '';
             foreach ($fields as $field) {
-                $extra .= $model->get($field) . $glue;
+                $extra .= $entity->get($field) . $glue;
             }
             $extra = rtrim($extra, $glue);
             $this->addExtraContent(new View([$extra, 'ui' => 'basic fitted segment']));
         } else {
             foreach ($fields as $field) {
-                $this->addExtraContent(new View([$model->get($field), 'class.ui basic fitted segment' => true]));
+                $this->addExtraContent(new View([$entity->get($field), 'class.ui basic fitted segment' => true]));
             }
         }
     }

--- a/src/CardDeck.php
+++ b/src/CardDeck.php
@@ -144,12 +144,12 @@ class CardDeck extends View
 
         $count = $this->initPaginator();
         if ($count) {
-            foreach ($this->model as $m) {
+            foreach ($this->model as $entity) {
                 /** @var Card */
                 $c = $this->cardHolder->add(Factory::factory($this->cardSeed, ['useLabel' => $this->useLabel, 'useTable' => $this->useTable]));
-                $c->setModel($m, $fields);
+                $c->setModel($entity, $fields);
                 if ($extra) {
-                    $c->addExtraFields($m, $extra, $this->extraGlue);
+                    $c->addExtraFields($entity, $extra, $this->extraGlue);
                 }
                 if ($this->useAction) {
                     foreach ($this->getModelActions(Model\UserAction::APPLIES_TO_SINGLE_RECORD) as $action) {

--- a/src/CardSection.php
+++ b/src/CardSection.php
@@ -8,6 +8,8 @@ use Atk4\Data\Model;
 
 /**
  * Display a card section within a Card View.
+ *
+ * @property false $model use $entity property instead
  */
 class CardSection extends View
 {
@@ -26,6 +28,14 @@ class CardSection extends View
         parent::init();
 
         $this->addClass('content');
+    }
+
+    #[\Override]
+    public function setModel(Model $entity, ?array $fields = null): void
+    {
+        $entity->assertIsEntity();
+
+        parent::setModel($entity);
     }
 
     /**
@@ -51,30 +61,30 @@ class CardSection extends View
     /**
      * Add Model fields to a card section.
      */
-    public function addFields(Model $model, array $fields, bool $useLabel = false, bool $useTable = false): void
+    public function addFields(Model $entity, array $fields, bool $useLabel = false, bool $useTable = false): void
     {
-        $model->assertIsLoaded();
+        $entity->assertIsLoaded();
 
         if ($useTable) {
-            $this->addTableSection($model, $fields);
+            $this->addTableSection($entity, $fields);
         } else {
-            $this->addSectionFields($model, $fields, $useLabel);
+            $this->addSectionFields($entity, $fields, $useLabel);
         }
     }
 
     /**
      * Add fields label and value to section.
      */
-    private function addSectionFields(Model $model, array $fields, bool $useLabel = false): void
+    private function addSectionFields(Model $entity, array $fields, bool $useLabel = false): void
     {
         foreach ($fields as $field) {
-            if ($model->titleField === $field) {
+            if ($entity->titleField === $field) {
                 continue;
             }
 
-            $value = $this->getApp()->uiPersistence->typecastSaveField($model->getField($field), $model->get($field));
+            $value = $this->getApp()->uiPersistence->typecastSaveField($entity->getField($field), $entity->get($field));
             if ($useLabel) {
-                $label = $model->getField($field)->getCaption();
+                $label = $entity->getField($field)->getCaption();
                 $value = $label . $this->glue . $value;
             }
 
@@ -87,9 +97,9 @@ class CardSection extends View
     /**
      * Add field into section using a CardTable View.
      */
-    private function addTableSection(Model $model, array $fields): void
+    private function addTableSection(Model $entity, array $fields): void
     {
         $cardTable = CardTable::addTo($this, ['class' => $this->tableClass]);
-        $cardTable->setModel($model, $fields);
+        $cardTable->setModel($entity, $fields);
     }
 }

--- a/src/CardTable.php
+++ b/src/CardTable.php
@@ -12,7 +12,7 @@ use Atk4\Data\Model;
  * IMPORTANT: Although the purpose of the "Card" component will remain the same, we do plan to
  * improve implementation of a card to to use https://fomantic-ui.com/views/card.html .
  *
- * @property false|null $model use $entity property instead TODO remove null once https://github.com/phpstan/phpstan/issues/10787 is fixed
+ * @property false $model use $entity property instead
  */
 class CardTable extends Table
 {

--- a/src/CardTable.php
+++ b/src/CardTable.php
@@ -11,6 +11,8 @@ use Atk4\Data\Model;
  *
  * IMPORTANT: Although the purpose of the "Card" component will remain the same, we do plan to
  * improve implementation of a card to to use https://fomantic-ui.com/views/card.html .
+ *
+ * @property false|null $model use $entity property instead TODO remove null once https://github.com/phpstan/phpstan/issues/10787 is fixed
  */
 class CardTable extends Table
 {

--- a/src/Crud.php
+++ b/src/Crud.php
@@ -98,8 +98,8 @@ class Crud extends Grid
 
         // grab model ID when using delete
         // must be set before delete action execute
-        $this->model->onHook(Model::HOOK_AFTER_DELETE, function (Model $model) {
-            $this->deletedId = $model->getId();
+        $this->model->onHook(Model::HOOK_AFTER_DELETE, function (Model $entity) {
+            $this->deletedId = $entity->getId();
         });
 
         if ($this->useMenuActions === null) {

--- a/src/Form.php
+++ b/src/Form.php
@@ -21,7 +21,7 @@ use Atk4\Ui\Js\JsExpression;
 use Atk4\Ui\Js\JsExpressionable;
 
 /**
- * @property false|null $model use $entity property instead TODO remove null once https://github.com/phpstan/phpstan/issues/10787 is fixed
+ * @property false $model use $entity property instead
  */
 class Form extends View
 {

--- a/src/Form.php
+++ b/src/Form.php
@@ -20,6 +20,9 @@ use Atk4\Ui\Js\JsConditionalForm;
 use Atk4\Ui\Js\JsExpression;
 use Atk4\Ui\Js\JsExpressionable;
 
+/**
+ * @property false $model use $entity property instead
+ */
 class Form extends View
 {
     use HookTrait;

--- a/src/Form.php
+++ b/src/Form.php
@@ -21,7 +21,7 @@ use Atk4\Ui\Js\JsExpression;
 use Atk4\Ui\Js\JsExpressionable;
 
 /**
- * @property false $model use $entity property instead
+ * @property false|null $model use $entity property instead TODO remove null once https://github.com/phpstan/phpstan/issues/10787 is fixed
  */
 class Form extends View
 {
@@ -362,7 +362,7 @@ class Form extends View
      */
     public function controlFactory(Field $field, $controlSeed = []): Control
     {
-        $this->model->assertIsEntity($field->getOwner());
+        $this->entity->assertIsEntity($field->getOwner());
 
         $fallbackSeed = [Control\Line::class];
 
@@ -397,7 +397,7 @@ class Form extends View
 
         $defaults = [
             'form' => $this,
-            'entityField' => new EntityFieldPair($this->model, $field->shortName),
+            'entityField' => new EntityFieldPair($this->entity, $field->shortName),
             'shortName' => $field->shortName,
         ];
 

--- a/src/Form/AbstractLayout.php
+++ b/src/Form/AbstractLayout.php
@@ -16,7 +16,7 @@ use Atk4\Ui\View;
 /**
  * Custom Layout for a form.
  *
- * @property false|null $model use $entity property instead TODO remove null once https://github.com/phpstan/phpstan/issues/10787 is fixed
+ * @property false $model use $entity property instead
  */
 abstract class AbstractLayout extends View
 {

--- a/src/Form/AbstractLayout.php
+++ b/src/Form/AbstractLayout.php
@@ -40,7 +40,7 @@ abstract class AbstractLayout extends View
     public function addControl(string $name, $control = [], array $fieldSeed = []): Control
     {
         if ($this->form->entity === null) {
-            $this->form->entity = (new ProxyModel())->createEntity();
+            $this->form->setModel((new ProxyModel())->createEntity());
         }
         $model = $this->form->entity->getModel();
 

--- a/src/Form/AbstractLayout.php
+++ b/src/Form/AbstractLayout.php
@@ -15,6 +15,8 @@ use Atk4\Ui\View;
 
 /**
  * Custom Layout for a form.
+ *
+ * @property false|null $model use $entity property instead TODO remove null once https://github.com/phpstan/phpstan/issues/10787 is fixed
  */
 abstract class AbstractLayout extends View
 {
@@ -37,10 +39,10 @@ abstract class AbstractLayout extends View
      */
     public function addControl(string $name, $control = [], array $fieldSeed = []): Control
     {
-        if ($this->form->model === null) {
-            $this->form->model = (new ProxyModel())->createEntity();
+        if ($this->form->entity === null) {
+            $this->form->entity = (new ProxyModel())->createEntity();
         }
-        $model = $this->form->model->getModel();
+        $model = $this->form->entity->getModel();
 
         // TODO this class should not refer to any specific form control
         $controlClass = is_object($control)

--- a/src/Form/Control/Lookup.php
+++ b/src/Form/Control/Lookup.php
@@ -270,7 +270,7 @@ class Lookup extends Input
             $form->setModel($entity, $this->plus['fields'] ?? null);
 
             $form->onSubmit(function (Form $form) {
-                $msg = $form->model->getUserAction('add')->execute();
+                $msg = $form->entity->getUserAction('add')->execute();
 
                 $res = new JsBlock();
                 if (is_string($msg)) {
@@ -278,7 +278,7 @@ class Lookup extends Input
                 }
                 $res->addStatement((new Jquery())->closest('.atk-modal')->modal('hide'));
 
-                $row = $this->renderRow($form->model);
+                $row = $this->renderRow($form->entity);
                 $chain = $this->jsDropdown();
                 $chain->dropdown('set value', $row['value'])->dropdown('set text', $row['title']);
                 $res->addStatement($chain);
@@ -341,7 +341,7 @@ class Lookup extends Input
         if ($this->getApp()->hasRequestQueryParam('form')) {
             parse_str($this->getApp()->getRequestQueryParam('form'), $data);
         } elseif ($this->form !== null) {
-            $data = $this->form->model->get();
+            $data = $this->form->entity->get();
         } else {
             return;
         }

--- a/src/Form/Control/Multiline.php
+++ b/src/Form/Control/Multiline.php
@@ -11,7 +11,6 @@ use Atk4\Data\Field\SqlExpressionField;
 use Atk4\Data\Model;
 use Atk4\Data\Persistence;
 use Atk4\Data\ValidationException;
-use Atk4\Ui\Exception;
 use Atk4\Ui\Form;
 use Atk4\Ui\HtmlTemplate;
 use Atk4\Ui\Js\JsExpressionable;
@@ -34,7 +33,7 @@ use Atk4\Ui\View;
  *
  * $form->onSubmit(function (Form $form) use ($ml) {
  *     // save Form model and then Multiline model
- *     $form->model->save(); // saving invoice record
+ *     $form->entity->save(); // saving invoice record
  *     $ml->saveRows(); // saving invoice items record related to invoice
  *     return new JsToast('Saved!');
  * });
@@ -219,7 +218,7 @@ class Multiline extends Form\Control
             }
 
             // remove __atml ID from array field
-            if ($this->form->model->getField($this->shortName)->type === 'json') {
+            if ($this->form->entity->getField($this->shortName)->type === 'json') {
                 $rows = [];
                 foreach ($this->rowData as $cols) {
                     unset($cols['__atkml']);
@@ -430,11 +429,7 @@ class Multiline extends Form\Control
     public function setReferenceModel(string $refModelName, ?Model $entity = null, array $fieldNames = []): void
     {
         if ($entity === null) {
-            if (!$this->form->model->isEntity()) {
-                throw new Exception('Model entity is not set');
-            }
-
-            $entity = $this->form->model;
+            $entity = $this->form->entity;
         }
 
         $this->setModel($entity->ref($refModelName), $fieldNames);

--- a/src/JsCallback.php
+++ b/src/JsCallback.php
@@ -26,7 +26,7 @@ class JsCallback extends Callback
     /**
      * Usually JsCallback should not allow to trigger during a reload.
      * Consider reloading a form, if triggering is allowed during the reload process
-     * then $form->model could be saved during that reload which can lead to unexpected result
+     * then $form->entity could be saved during that reload which can lead to unexpected result
      * if model ID is not properly handled.
      *
      * @var bool

--- a/src/Table.php
+++ b/src/Table.php
@@ -146,7 +146,7 @@ class Table extends Lister
         }
 
         if ($this->model === null) {
-            $this->model = new ProxyModel();
+            $this->setModel(new ProxyModel());
         }
         $this->model->assertIsModel();
 

--- a/src/Table/Column/FilterModel.php
+++ b/src/Table/Column/FilterModel.php
@@ -109,8 +109,8 @@ abstract class FilterModel extends Model
         }
 
         // add hook in order to persist data in session
-        $this->onHook(self::HOOK_AFTER_SAVE, function (Model $model) {
-            $this->memorize('data', $model->get());
+        $this->onHook(self::HOOK_AFTER_SAVE, function (Model $entity) {
+            $this->memorize('data', $entity->get());
         });
     }
 

--- a/src/Table/Column/FilterPopup.php
+++ b/src/Table/Column/FilterPopup.php
@@ -47,8 +47,8 @@ class FilterPopup extends Popup
         $this->setOption('delay', ['hide' => 1500]);
         $this->setHoverable();
 
-        $model = FilterModel::factoryType($this->getApp(), $this->field);
-        $model = $model->createEntity();
+        $entity = FilterModel::factoryType($this->getApp(), $this->field)
+            ->createEntity();
 
         $this->form = Form::addTo($this)->addClass('');
         $this->form->buttonSave->addClass('');
@@ -56,14 +56,14 @@ class FilterPopup extends Popup
 
         $this->form->buttonSave->set('Set');
 
-        $this->form->setControlsDisplayRules($model->getFormDisplayRules());
+        $this->form->setControlsDisplayRules($entity->getFormDisplayRules());
 
         // load data associated with this popup
-        $filter = $model->recallData();
+        $filter = $entity->recallData();
         if ($filter !== null) {
-            $model->setMulti($filter);
+            $entity->setMulti($filter);
         }
-        $this->form->setModel($model);
+        $this->form->setModel($entity);
 
         $this->form->onSubmit(function (Form $form) {
             $form->entity->save();
@@ -72,8 +72,8 @@ class FilterPopup extends Popup
         });
 
         Button::addTo($this->form, ['Clear', 'class.clear' => true])
-            ->on('click', function (Jquery $j) use ($model) {
-                $model->clearData();
+            ->on('click', function (Jquery $j) use ($entity) {
+                $entity->clearData();
 
                 return new JsBlock([
                     $this->form->js()->form('reset'),

--- a/src/Table/Column/FilterPopup.php
+++ b/src/Table/Column/FilterPopup.php
@@ -66,7 +66,7 @@ class FilterPopup extends Popup
         $this->form->setModel($model);
 
         $this->form->onSubmit(function (Form $form) {
-            $form->model->save();
+            $form->entity->save();
 
             return new JsReload($this->reload);
         });
@@ -90,7 +90,7 @@ class FilterPopup extends Popup
 
     public function recallData(): ?array
     {
-        return $this->form->model->recallData();
+        return $this->form->entity->recallData();
     }
 
     /**
@@ -98,6 +98,6 @@ class FilterPopup extends Popup
      */
     public function setFilterCondition(Model $tableModel): void
     {
-        $this->form->model->setConditionForModel($tableModel);
+        $this->form->entity->setConditionForModel($tableModel);
     }
 }

--- a/src/UserAction/ArgumentFormExecutor.php
+++ b/src/UserAction/ArgumentFormExecutor.php
@@ -40,7 +40,7 @@ class ArgumentFormExecutor extends BasicExecutor
 
         $this->form->onSubmit(function (Form $form) {
             // set arguments from the model
-            $this->setArguments($form->model->get());
+            $this->setArguments($form->entity->get());
 
             return $this->executeModelAction();
         });

--- a/src/UserAction/BasicExecutor.php
+++ b/src/UserAction/BasicExecutor.php
@@ -45,7 +45,7 @@ class BasicExecutor extends View implements ExecutorInterface
     /** @var array list of validated arguments */
     protected $validArguments = [];
 
-    /** @var JsExpressionable|\Closure JS expression to return if action was successful, e.g "new JsToast('Thank you')" */
+    /** @var JsExpressionable|\Closure<T of Model>($this, T): ?JsBlock JS expression to return if action was successful, e.g "new JsToast('Thank you')" */
     protected $jsSuccess;
 
     #[\Override]

--- a/src/UserAction/ConfirmationExecutor.php
+++ b/src/UserAction/ConfirmationExecutor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atk4\Ui\UserAction;
 
 use Atk4\Core\HookTrait;
+use Atk4\Data\Model;
 use Atk4\Data\Model\UserAction;
 use Atk4\Ui\Button;
 use Atk4\Ui\Exception;
@@ -29,7 +30,7 @@ class ConfirmationExecutor extends Modal implements JsExecutorInterface
     /** @var UserAction|null Action to execute */
     public $action;
 
-    /** @var JsExpressionable|\Closure JS expression to return if action was successful, e.g "new JsToast('Thank you')" */
+    /** @var JsExpressionable|\Closure<T of Model>($this, T, mixed, mixed): ?JsBlock JS expression to return if action was successful, e.g "new JsToast('Thank you')" */
     public $jsSuccess;
 
     /** @var string CSS class for modal size. */
@@ -180,7 +181,7 @@ class ConfirmationExecutor extends Modal implements JsExecutorInterface
     protected function jsGetExecute($obj, $id): JsBlock
     {
         $success = $this->jsSuccess instanceof \Closure
-            ? ($this->jsSuccess)($this, $this->action->getModel(), $id)
+            ? ($this->jsSuccess)($this, $this->action->getModel(), $id, $obj)
             : $this->jsSuccess;
 
         return new JsBlock([

--- a/src/UserAction/FormExecutor.php
+++ b/src/UserAction/FormExecutor.php
@@ -22,7 +22,7 @@ class FormExecutor extends BasicExecutor
         }
 
         // setup form model using action fields
-        if ($this->form->model === null) {
+        if ($this->form->entity === null) {
             if (!$this->action->fields) {
                 $this->action->fields = $this->getModelFields($this->action->getModel());
             }

--- a/src/UserAction/JsCallbackExecutor.php
+++ b/src/UserAction/JsCallbackExecutor.php
@@ -34,7 +34,7 @@ class JsCallbackExecutor extends JsCallback implements ExecutorInterface
     /** @var Model\UserAction The model user action */
     public $action;
 
-    /** @var JsExpressionable|\Closure JS expression to return if action was successful, e.g "new JsToast('Thank you')" */
+    /** @var JsExpressionable|\Closure<T of Model>($this, T, mixed, mixed): ?JsBlock JS expression to return if action was successful, e.g "new JsToast('Thank you')" */
     public $jsSuccess;
 
     #[\Override]

--- a/src/UserAction/JsCallbackExecutor.php
+++ b/src/UserAction/JsCallbackExecutor.php
@@ -47,9 +47,6 @@ class JsCallbackExecutor extends JsCallback implements ExecutorInterface
     public function setAction(Model\UserAction $action)
     {
         $this->action = $action;
-        if (!$this->action->enabled && $this->getOwner() instanceof View) { // @phpstan-ignore-line
-            $this->getOwner()->addClass('disabled');
-        }
 
         return $this;
     }

--- a/src/UserAction/ModalExecutor.php
+++ b/src/UserAction/ModalExecutor.php
@@ -115,34 +115,6 @@ class ModalExecutor extends Modal implements JsExecutorInterface
         ]);
     }
 
-    /**
-     * Assign a View that will fire action execution.
-     * If action require steps, it will automatically initialize
-     * proper step to execute first.
-     *
-     * @param array<string, string> $urlArgs
-     *
-     * @return $this
-     */
-    public function assignTrigger(View $view, array $urlArgs = [], string $when = 'click', ?string $selector = null): self
-    {
-        if (!$this->actionInitialized) {
-            throw new Exception('Action must be set prior to assign trigger');
-        }
-
-        if ($this->steps !== []) {
-            // use modal for stepping action
-            $urlArgs['step'] = $this->step;
-            if ($this->action->enabled) {
-                $view->on($when, $selector, $this->jsLoadAndShow($urlArgs));
-            } else {
-                $view->addClass('disabled');
-            }
-        }
-
-        return $this;
-    }
-
     #[\Override]
     public function jsExecute(array $urlArgs = []): JsBlock
     {

--- a/src/UserAction/StepExecutorTrait.php
+++ b/src/UserAction/StepExecutorTrait.php
@@ -147,7 +147,7 @@ trait StepExecutorTrait
 
         $form->onSubmit(function (Form $form) {
             // collect arguments
-            $this->setActionDataFromModel('args', $form->entity, array_keys($form->entity->getFields()));
+            $this->setActionDataFromEntity('args', $form->entity, array_keys($form->entity->getFields()));
 
             return $this->jsStepSubmit($this->step);
         });
@@ -168,7 +168,7 @@ trait StepExecutorTrait
 
         $form->onSubmit(function (Form $form) {
             // collect fields defined in Model\UserAction
-            $this->setActionDataFromModel('fields', $form->entity, $this->action->fields);
+            $this->setActionDataFromEntity('fields', $form->entity, $this->action->fields);
 
             return $this->jsStepSubmit($this->step);
         });
@@ -420,11 +420,11 @@ trait StepExecutorTrait
     /**
      * @param array<string> $fields
      */
-    private function setActionDataFromModel(string $step, Model $model, array $fields): void
+    private function setActionDataFromEntity(string $step, Model $entity, array $fields): void
     {
         $data = [];
         foreach ($fields as $k) {
-            $data[$k] = $model->get($k);
+            $data[$k] = $entity->get($k);
         }
         $this->actionData[$step] = $data;
     }

--- a/src/UserAction/StepExecutorTrait.php
+++ b/src/UserAction/StepExecutorTrait.php
@@ -44,7 +44,7 @@ trait StepExecutorTrait
     /** @var bool */
     protected $actionInitialized = false;
 
-    /** @var JsExpressionable|\Closure JS expression to return if action was successful, e.g "new JsToast('Thank you')" */
+    /** @var JsExpressionable|\Closure<T of Model>($this, T, mixed, mixed): ?JsBlock JS expression to return if action was successful, e.g "new JsToast('Thank you')" */
     public $jsSuccess;
 
     /** @var array A seed for creating form in order to edit arguments/fields user entry. */

--- a/src/UserAction/StepExecutorTrait.php
+++ b/src/UserAction/StepExecutorTrait.php
@@ -147,7 +147,7 @@ trait StepExecutorTrait
 
         $form->onSubmit(function (Form $form) {
             // collect arguments
-            $this->setActionDataFromModel('args', $form->model, array_keys($form->model->getFields()));
+            $this->setActionDataFromModel('args', $form->entity, array_keys($form->entity->getFields()));
 
             return $this->jsStepSubmit($this->step);
         });
@@ -168,7 +168,7 @@ trait StepExecutorTrait
 
         $form->onSubmit(function (Form $form) {
             // collect fields defined in Model\UserAction
-            $this->setActionDataFromModel('fields', $form->model, $this->action->fields);
+            $this->setActionDataFromModel('fields', $form->entity, $this->action->fields);
 
             return $this->jsStepSubmit($this->step);
         });

--- a/src/View.php
+++ b/src/View.php
@@ -111,7 +111,7 @@ class View extends AbstractView
      * Do not try to create your own "Model" implementation, instead you must be looking for
      * your own "Persistence" implementation.
      *
-     * @phpstan-assert !null $this->model
+     * @XXXphpstan-assert !null $this->model TODO enable once https://github.com/phpstan/phpstan/issues/10787 is fixed
      */
     public function setModel(Model $model): void
     {
@@ -137,7 +137,7 @@ class View extends AbstractView
      *
      * @param array $fields Limit model to particular fields
      *
-     * @phpstan-assert !null $this->model
+     * @phpstan-assert !null $this->model TODO enable once https://github.com/phpstan/phpstan/issues/10787 is fixed
      */
     public function setSource(array $data, $fields = null): Model
     {

--- a/src/View.php
+++ b/src/View.php
@@ -115,7 +115,11 @@ class View extends AbstractView
      */
     public function setModel(Model $model): void
     {
-        if ($this->model !== null && $this->model !== $model) {
+        if ($this->model !== null) {
+            if ($this->model === $model) {
+                return;
+            }
+
             throw new Exception('Different model is already set');
         }
 

--- a/src/View.php
+++ b/src/View.php
@@ -110,8 +110,6 @@ class View extends AbstractView
      *
      * Do not try to create your own "Model" implementation, instead you must be looking for
      * your own "Persistence" implementation.
-     *
-     * @XXXphpstan-assert !null $this->model TODO enable once https://github.com/phpstan/phpstan/issues/10787 is fixed
      */
     public function setModel(Model $model): void
     {
@@ -137,7 +135,7 @@ class View extends AbstractView
      *
      * @param array $fields Limit model to particular fields
      *
-     * @phpstan-assert !null $this->model TODO enable once https://github.com/phpstan/phpstan/issues/10787 is fixed
+     * @phpstan-assert !null $this->model
      */
     public function setSource(array $data, $fields = null): Model
     {

--- a/src/View.php
+++ b/src/View.php
@@ -33,6 +33,7 @@ class View extends AbstractView
     protected array $_jsActions = [];
 
     public ?Model $model = null;
+    public ?Model $entity = null;
 
     /**
      * Name of the region in the parent's template where this object will output itself.
@@ -118,7 +119,13 @@ class View extends AbstractView
             throw new Exception('Different model is already set');
         }
 
-        $this->model = $model;
+        if ($model->isEntity()) {
+            unset($this->{'model'});
+            $this->entity = $model;
+        } else {
+            unset($this->{'entity'});
+            $this->model = $model;
+        }
     }
 
     /**

--- a/src/View.php
+++ b/src/View.php
@@ -104,6 +104,17 @@ class View extends AbstractView
         $this->setDefaults($defaults);
     }
 
+    #[\Override]
+    public function &__get(string $name)
+    {
+        // TODO remove in atk4/ui 6.0
+        if ($name === 'model' && !(new \ReflectionProperty(self::class, 'model'))->isInitialized($this) && $this->entity !== null) {
+            throw new Exception('Use View::$entity property instead for entity access');
+        }
+
+        return parent::__get($name);
+    }
+
     /**
      * Associate this view with a model. Do not place any logic in this class, instead take it
      * to renderView().
@@ -113,8 +124,8 @@ class View extends AbstractView
      */
     public function setModel(Model $model): void
     {
-        if ($this->model !== null) {
-            if ($this->model === $model) {
+        if (((new \ReflectionProperty(self::class, 'model'))->isInitialized($this) ? $this->model : $this->entity) !== null) {
+            if (((new \ReflectionProperty(self::class, 'model'))->isInitialized($this) ? $this->model : $this->entity) === $model) {
                 return;
             }
 

--- a/src/VueComponent/InlineEdit.php
+++ b/src/VueComponent/InlineEdit.php
@@ -13,6 +13,8 @@ use Atk4\Ui\View;
 
 /**
  * A Simple inline editable text Vue component.
+ *
+ * @property false|null $model use $entity property instead TODO remove null once https://github.com/phpstan/phpstan/issues/10787 is fixed
  */
 class InlineEdit extends View
 {
@@ -80,7 +82,7 @@ class InlineEdit extends View
         // set default validation error handler
         if (!$this->formatErrorMsg) {
             $this->formatErrorMsg = function (ValidationException $e, string $value) {
-                $caption = $this->model->getField($this->fieldName)->getCaption();
+                $caption = $this->entity->getField($this->fieldName)->getCaption();
 
                 return $caption . ' - ' . $e->getMessage() . '. <br>Trying to set this value: "' . $value . '"';
             };
@@ -90,18 +92,20 @@ class InlineEdit extends View
     #[\Override]
     public function setModel(Model $entity): void
     {
+        $entity->assertIsEntity();
+
         parent::setModel($entity);
 
         if ($this->fieldName === null) {
-            $this->fieldName = $this->model->titleField;
+            $this->fieldName = $this->entity->titleField;
         }
 
-        if ($this->autoSave && $this->model->isLoaded()) {
+        if ($this->autoSave && $this->entity->isLoaded()) {
             $this->cb->set(function () {
                 $postValue = $this->getApp()->getRequestPostParam('value');
                 try {
-                    $this->model->set($this->fieldName, $this->getApp()->uiPersistence->typecastLoadField($this->model->getField($this->fieldName), $postValue));
-                    $this->model->save();
+                    $this->entity->set($this->fieldName, $this->getApp()->uiPersistence->typecastLoadField($this->entity->getField($this->fieldName), $postValue));
+                    $this->entity->save();
 
                     return $this->jsSuccess('Update saved');
                 } catch (ValidationException $e) {
@@ -126,7 +130,7 @@ class InlineEdit extends View
     {
         if (!$this->autoSave) {
             $value = $this->getApp()->uiPersistence->typecastLoadField(
-                $this->model->getField($this->fieldName),
+                $this->entity->getField($this->fieldName),
                 $this->getApp()->tryGetRequestPostParam('value')
             );
             $this->cb->set(static function () use ($fx, $value) {
@@ -163,8 +167,8 @@ class InlineEdit extends View
     {
         parent::renderView();
 
-        if ($this->model !== null && $this->model->isLoaded()) {
-            $initValue = $this->model->get($this->fieldName);
+        if ($this->entity !== null && $this->entity->isLoaded()) {
+            $initValue = $this->entity->get($this->fieldName);
         } else {
             $initValue = $this->initValue;
         }

--- a/src/VueComponent/InlineEdit.php
+++ b/src/VueComponent/InlineEdit.php
@@ -14,7 +14,7 @@ use Atk4\Ui\View;
 /**
  * A Simple inline editable text Vue component.
  *
- * @property false|null $model use $entity property instead TODO remove null once https://github.com/phpstan/phpstan/issues/10787 is fixed
+ * @property false $model use $entity property instead
  */
 class InlineEdit extends View
 {

--- a/tests-behat/useraction.feature
+++ b/tests-behat/useraction.feature
@@ -72,3 +72,10 @@ Feature: UserAction executor and UserConfirmation modal
     When I fill field using "//input[../div[text()='Greet']]" with "Laura"
     When I press button "Greet"
     Then Toast display should contain text "Hello Laura"
+
+  Scenario: testing JsCallbackExecutor in grid menu
+    Given I am on "data-action/jsactionsgrid.php"
+    When I click using selector "//tr[td[text()='Argentina']]//div.ui.dropdown[div[text()='Actions...']]"
+    Then No toast should be displayed
+    When I click using selector "//tr[td[text()='Argentina']]//div.ui.dropdown[div[text()='Actions...']]//div.menu/div[text()='Callback']"
+    Then Toast display should contain text "Success: callback execute using country Argentina"

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -117,14 +117,14 @@ class FormTest extends TestCase
             self::assertSame('John', $form->entity->get('name'));
 
             return $form;
-        }, ['email' => 'john@yahoo.com', 'is_admin' => '1'], static function (Model $m) {
+        }, ['email' => 'john@yahoo.com', 'is_admin' => '1'], static function (Model $entity) {
             // field has default, but form send back empty value
-            self::assertSame('', $m->get('name'));
+            self::assertSame('', $entity->get('name'));
 
-            self::assertSame('john@yahoo.com', $m->get('email'));
+            self::assertSame('john@yahoo.com', $entity->get('email'));
 
             // security check, unspecified field must not be changed
-            self::assertFalse($m->get('is_admin'));
+            self::assertFalse($entity->get('is_admin'));
         });
     }
 
@@ -135,8 +135,8 @@ class FormTest extends TestCase
             $form->addControl('foo');
 
             return $form;
-        }, ['foo' => '0'], static function (Model $m) {
-            self::assertSame('0', $m->get('foo'));
+        }, ['foo' => '0'], static function (Model $entity) {
+            self::assertSame('0', $entity->get('foo'));
         });
     }
 
@@ -222,9 +222,9 @@ class FormTest extends TestCase
                 $form->setModel($m->createEntity(), ['foo']);
 
                 return $form;
-            }, ['foo' => 'x'], static function (Model $model) use (&$submitReached) {
+            }, ['foo' => 'x'], static function (Model $entity) use (&$submitReached) {
                 $submitReached = true;
-                $model->set('bar', null);
+                $entity->set('bar', null);
             });
         } catch (UnhandledCallbackExceptionError $e) {
             $catchReached = true;

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -82,7 +82,7 @@ class FormTest extends TestCase
         $form->onSubmit(static function (Form $form) use (&$wasSubmitCalled, $submitFx): void {
             $wasSubmitCalled = true;
             if ($submitFx !== null) {
-                $submitFx($form->model);
+                $submitFx($form->entity);
             }
         });
 
@@ -114,7 +114,7 @@ class FormTest extends TestCase
 
             $form->setModel($m->createEntity(), ['name', 'email']);
 
-            self::assertSame('John', $form->model->get('name'));
+            self::assertSame('John', $form->entity->get('name'));
 
             return $form;
         }, ['email' => 'john@yahoo.com', 'is_admin' => '1'], static function (Model $m) {

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -151,4 +151,13 @@ class ViewTest extends TestCase
         yield [Popup::class];
         yield [VirtualPage::class];
     }
+
+    public function testJsCallbackGetUrlException(): void
+    {
+        $v = new JsCallback();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Do not use getUrl on JsCallback, use getJsUrl()');
+        $v->getUrl();
+    }
 }

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -10,6 +10,7 @@ use Atk4\Ui\AbstractView;
 use Atk4\Ui\Callback;
 use Atk4\Ui\Console;
 use Atk4\Ui\Exception;
+use Atk4\Ui\Form;
 use Atk4\Ui\JsCallback;
 use Atk4\Ui\JsSse;
 use Atk4\Ui\Loader;
@@ -101,6 +102,22 @@ class ViewTest extends TestCase
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Different model is already set');
         $v->setModel($m2);
+    }
+
+    public function testSetModelEntity(): void
+    {
+        $form = new Form();
+        $form->setApp($this->createApp());
+        $form->invokeInit();
+        $entity = (new Model())->createEntity();
+        $form->setModel($entity);
+
+        self::assertSame($entity, $form->entity);
+        self::assertFalse((new \ReflectionProperty(Form::class, 'model'))->isInitialized($form));
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Use View::$entity property instead for entity access');
+        $form->model; // @phpstan-ignore-line
     }
 
     public function testSetSourceZeroKeyException(): void


### PR DESCRIPTION
In 99% cases the impact is on `Form::$model` property usage. Seach `form->model` in your codebase and replace it with `form->entity`.

The motivation is to simplify model/entity orientation for the developer. When Model is guaranteed to be entity only, is should never be named model.