### PR TITLE
Remove unneeded VirtualPage "__atk_tab" code

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ _All components can be view using the [demos](https://ui.atk4.org/demos/) applic
 
 | Component       | Description                                                           | Introduced |
 | --------------- | --------------------------------------------------------------------- | ---------- |
-| View            | Template, Render Tree and various patterns                            | 0.1        |
+| View            | Template, render tree and various patterns                            | 0.1        |
 | Button          | Button in various variations including icons, labels, styles and tags | 0.1        |
 | Input           | Decoration of input fields, integration with buttons.                 | 0.2        |
 | JS              | Assign JS events and abstraction of PHP callbacks.                    | 0.2        |

--- a/docs/app.md
+++ b/docs/app.md
@@ -306,7 +306,7 @@ callback is triggered and need to respond with some JSON.
 :::{php:attr} isRendering
 :::
 
-Will be true if the application is currently rendering recursively through the Render Tree.
+Will be true if the application is currently rendering recursively through the render tree.
 
 ## Links
 

--- a/docs/core.md
+++ b/docs/core.md
@@ -77,7 +77,7 @@ render
 
 ## Sticky GET
 
-Agile UI implements advanced approach allowing any View object that you add into Render Tree to
+Agile UI implements advanced approach allowing any View object that you add into render tree to
 declare "sticky GET arguments". Here is example:
 
 ```

--- a/docs/js.md
+++ b/docs/js.md
@@ -497,7 +497,7 @@ or `contentClass` or use the method `addContentClass()`. See the Fomantic-UI mod
 
 This alternative implementation to {php:class}`Modal` is convenient for situations
 when the need to open a dialog box is not known in advance. This class is not
-a component, but rather an Action so you **must not** add it to the Render Tree.
+a component, but rather an Action so you **must not** add it to the render tree.
 To accomplish that, use a {ref}`virtualpage`:
 
 ```
@@ -552,7 +552,7 @@ In this example, filling out and submitting the form will result in table conten
 
 Care needs to be taken when attempting to combine the above with a {php:class}`Js\JsModal` which requires a {ref}`virtualpage` to
 store its contents. In that case, the order in which declarations are made matters because of the way the
-Render Tree is processed.
+render tree is processed.
 
 For example, in order to open a modal dialog containing a form and reload a table located on the main page
 with the updated data on form submission (thus without having to reload the entire page), the following elements are

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -288,7 +288,7 @@ will automatically populate a user-menu with the name of the user and log-out bu
 
 ## Advanced techniques
 
-By design we make sure that adding a component into a Render Tree (See {ref}`view`)
+By design we make sure that adding a component into a render tree (See {ref}`view`)
 is enough, so App provides a mechanism for components to:
 
 - Depend on JS, CSS, and other assets

--- a/docs/render.md
+++ b/docs/render.md
@@ -3,7 +3,7 @@
 
 # Introduction
 
-Agile UI allows you to create and combine various objects into a single Render Tree for unified rendering. Tree represents
+Agile UI allows you to create and combine various objects into a single render tree for unified rendering. Tree represents
 all the UI components that will contribute to the HTML generation. Render tree is automatically created and maintained:
 
 ```

--- a/docs/sticky.md
+++ b/docs/sticky.md
@@ -45,7 +45,7 @@ multiple requests to get there.
 In earlier example, we have called `$app->stickyGet` which creates a global stickyGet. After
 executing, all the invocations to App::url() or View::url() will contain "client_id".
 
-In some cases, Sticky GET only make sense within a certain branch of a Render Tree. For instance,
+In some cases, Sticky GET only make sense within a certain branch of a render tree. For instance,
 when Loader wishes to load content dynamically, it must pass extra _GET parameter to trigger a
 {php:class}`Callback`. Next, when Console needs to establish live SSE stream, it should include
 the SAME get argument to trigger a callback for the Loader, otherwise Console wouldn't be

--- a/docs/view.md
+++ b/docs/view.md
@@ -6,10 +6,10 @@
 # Views
 
 Agile UI is a component framework, which follows a software patterns known as
-`Render Tree` and `Two pass HTML rendering`.
+"render tree" and "two pass HTML rendering".
 
 :::{php:class} View
-A View is a most fundamental object that can take part in the Render tree. All
+A View is a most fundamental object that can take part in the render tree. All
 of the other components descend from the `View` class.
 :::
 
@@ -28,8 +28,8 @@ The above code will produce the following HTML block:
 </div>
 ```
 
-All of the views combined form a `Render Tree`. In order to get the HTML output
-from all the `Views` in `Render Tree` you need to execute `render()` for the top-most
+All of the views combined form a "render tree". In order to get the HTML output
+from all the render tree `View`s you need to execute `render()` for the top-most
 leaf:
 
 ```
@@ -460,7 +460,7 @@ Outputs:
 <div class="ui button" id="my-button3">Button</div>
 ```
 
-If ID is not specified it will be set automatically. The top-most element of a Render Tree will
+If ID is not specified it will be set automatically. The top-most element of a render tree will
 use `id=atk` and all of the child elements will create a derived ID based on it's UI role.
 
 ```yaml

--- a/src/VirtualPage.php
+++ b/src/VirtualPage.php
@@ -111,13 +111,6 @@ class VirtualPage extends View
                 $this->getApp()->terminateJson($this);
             }
 
-            if ($this->getApp()->hasRequestQueryParam('__atk_tab')) {
-                $outputArr = $this->renderToJsonArr();
-                $output = $this->getApp()->getTag('script', [], '$(function () {' . $outputArr['atkjs'] . '});')
-                    . $outputArr['html'];
-                $this->getApp()->terminateHtml($output);
-            }
-
             // do not terminate if callback supplied (no cutting)
             if ($mode !== 'callback') {
                 $this->getApp()->terminateHtml($this);


### PR DESCRIPTION
The `$this->getApp()->terminateHtml($this)` code below is strictly equivalent - see https://github.com/atk4/ui/blob/accdc771da/src/App.php#L549 and https://github.com/atk4/ui/blob/accdc771da/src/View.php#L671 - as long as the VP mode is non-`callback` - https://github.com/atk4/ui/blob/accdc771da/src/Tabs.php#L31.