### PR TITLE
Change "isDisabled" to "isEnabled" for actions everywhere

### DIFF
--- a/demos/collection/table.php
+++ b/demos/collection/table.php
@@ -15,7 +15,7 @@ use Atk4\Ui\View;
 /** @var App $app */
 require_once __DIR__ . '/../init-app.php';
 
-if ($app->tryGetRequestQueryParam('id')) {
+if ($app->tryGetRequestQueryParam('person_id') || $app->tryGetRequestQueryParam('person_surname')) {
     $app->layout->js(true, new JsToast('Details link is in simulation mode.'));
 }
 
@@ -78,7 +78,7 @@ $table = Table::addTo($app);
 $table->setSource($myArray, ['name']);
 
 // $table->addColumn('name');
-$table->addColumn('surname', [Table\Column\Link::class, 'url' => 'table.php?id={$surname}']);
+$table->addColumn('surname', [Table\Column\Link::class, 'url' => 'table.php?person_surname={$surname}']);
 $table->addColumn('birthdate', [], ['type' => 'date']);
 $table->addColumn('cv', [Table\Column\Html::class]);
 

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -346,15 +346,15 @@ class Grid extends View
      * Adds a new button into the action column on the right. For Crud this
      * column will already contain "delete" and "edit" buttons.
      *
-     * @param string|array<mixed>|View                       $button     Label text, object or seed for the Button
+     * @param string|array<mixed>|View                       $button    Label text, object or seed for the Button
      * @param JsExpressionable|JsCallbackSetWithRowIdClosure $action
-     * @param bool|\Closure<T of Model>(T): bool             $isDisabled
+     * @param bool|\Closure<T of Model>(T): bool             $isEnabled
      *
      * @return View
      */
-    public function addActionButton($button, $action = null, string $confirmMsg = '', $isDisabled = false)
+    public function addActionButton($button, $action = null, string $confirmMsg = '', $isEnabled = true)
     {
-        return $this->getActionButtons()->addButton($button, $action, $confirmMsg, $isDisabled);
+        return $this->getActionButtons()->addButton($button, $action, $confirmMsg, $isEnabled);
     }
 
     /**
@@ -396,13 +396,13 @@ class Grid extends View
      *
      * @param View|string                                    $view
      * @param JsExpressionable|JsCallbackSetWithRowIdClosure $action
-     * @param bool|\Closure<T of Model>(T): bool             $isDisabled
+     * @param bool|\Closure<T of Model>(T): bool             $isEnabled
      *
      * @return View
      */
-    public function addActionMenuItem($view, $action = null, string $confirmMsg = '', $isDisabled = false)
+    public function addActionMenuItem($view, $action = null, string $confirmMsg = '', $isEnabled = true)
     {
-        return $this->getActionMenu()->addActionMenuItem($view, $action, $confirmMsg, $isDisabled);
+        return $this->getActionMenu()->addActionMenuItem($view, $action, $confirmMsg, $isEnabled);
     }
 
     /**
@@ -500,14 +500,14 @@ class Grid extends View
      * @param string|array<mixed>|View           $button
      * @param string                             $title
      * @param \Closure(View, mixed): void        $callback
-     * @param array<string, string>              $args       extra URL argument for callback
-     * @param bool|\Closure<T of Model>(T): bool $isDisabled
+     * @param array<string, string>              $args      extra URL argument for callback
+     * @param bool|\Closure<T of Model>(T): bool $isEnabled
      *
      * @return View
      */
-    public function addModalAction($button, $title, \Closure $callback, $args = [], $isDisabled = false)
+    public function addModalAction($button, $title, \Closure $callback, $args = [], $isEnabled = true)
     {
-        return $this->getActionButtons()->addModal($button, $title, $callback, $this, $args, $isDisabled);
+        return $this->getActionButtons()->addModal($button, $title, $callback, $this, $args, $isEnabled);
     }
 
     /**

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -374,11 +374,8 @@ class Grid extends View
         if (!$confirmation) {
             $confirmation = '';
         }
-        $disabled = is_bool($executor->getAction()->enabled)
-            ? !$executor->getAction()->enabled
-            : $executor->getAction()->enabled;
 
-        return $this->getActionButtons()->addButton($button, $executor, $confirmation, $disabled);
+        return $this->getActionButtons()->addButton($button, $executor, $confirmation, $executor->getAction()->enabled);
     }
 
     private function getActionButtons(): Table\Column\ActionButtons
@@ -417,11 +414,8 @@ class Grid extends View
         if (!$confirmation) {
             $confirmation = '';
         }
-        $disabled = is_bool($executor->getAction()->enabled)
-            ? !$executor->getAction()->enabled
-            : $executor->getAction()->enabled;
 
-        return $this->getActionMenu()->addActionMenuItem($item, $executor, $confirmation, $disabled);
+        return $this->getActionMenu()->addActionMenuItem($item, $executor, $confirmation, $executor->getAction()->enabled);
     }
 
     /**

--- a/src/Table/Column/ActionButtons.php
+++ b/src/Table/Column/ActionButtons.php
@@ -42,11 +42,11 @@ class ActionButtons extends Table\Column
      *
      * @param string|array<mixed>|View                                         $button
      * @param JsExpressionable|JsCallbackSetWithRowIdClosure|ExecutorInterface $action
-     * @param bool|\Closure<T of Model>(T): bool                               $isDisabled
+     * @param bool|\Closure<T of Model>(T): bool                               $isEnabled
      *
      * @return View
      */
-    public function addButton($button, $action = null, string $confirmMsg = '', $isDisabled = false)
+    public function addButton($button, $action = null, string $confirmMsg = '', $isEnabled = true)
     {
         $name = $this->name . '_button_' . (count($this->buttons) + 1);
 
@@ -60,10 +60,10 @@ class ActionButtons extends Table\Column
 
         $this->assertColumnViewNotInitialized($button);
 
-        if ($isDisabled === true) {
+        if ($isEnabled === false) {
             $button->addClass('disabled');
-        } elseif ($isDisabled !== false) {
-            $this->isEnabledFxs[$name] = $isDisabled;
+        } elseif ($isEnabled !== true) {
+            $this->isEnabledFxs[$name] = $isEnabled;
         }
 
         $button->setApp($this->table->getApp());
@@ -88,15 +88,15 @@ class ActionButtons extends Table\Column
      * load contents through $callback. Will pass a virtual page.
      *
      * @param string|array<mixed>|View           $button
-     * @param string|array<mixed>                $defaults   modal title or modal defaults array
+     * @param string|array<mixed>                $defaults  modal title or modal defaults array
      * @param \Closure(View, mixed): void        $callback
      * @param View                               $owner
      * @param array<string, string>              $args
-     * @param bool|\Closure<T of Model>(T): bool $isDisabled
+     * @param bool|\Closure<T of Model>(T): bool $isEnabled
      *
      * @return View
      */
-    public function addModal($button, $defaults, \Closure $callback, $owner = null, $args = [], $isDisabled = false)
+    public function addModal($button, $defaults, \Closure $callback, $owner = null, $args = [], $isEnabled = true)
     {
         if ($owner === null) { // TODO explicit owner should not be needed
             $owner = $this->getOwner()->getOwner();
@@ -113,7 +113,7 @@ class ActionButtons extends Table\Column
             $callback($t, $id);
         });
 
-        return $this->addButton($button, $modal->jsShow(array_merge([$this->name => $this->getOwner()->jsRow()->data('id')], $args)), '', $isDisabled);
+        return $this->addButton($button, $modal->jsShow(array_merge([$this->name => $this->getOwner()->jsRow()->data('id')], $args)), '', $isEnabled);
     }
 
     #[\Override]

--- a/src/Table/Column/ActionMenu.php
+++ b/src/Table/Column/ActionMenu.php
@@ -56,11 +56,11 @@ class ActionMenu extends Table\Column
      *
      * @param View|string                                                      $item
      * @param JsExpressionable|JsCallbackSetWithRowIdClosure|ExecutorInterface $action
-     * @param bool|\Closure<T of Model>(T): bool                               $isDisabled
+     * @param bool|\Closure<T of Model>(T): bool                               $isEnabled
      *
      * @return View
      */
-    public function addActionMenuItem($item, $action = null, string $confirmMsg = '', $isDisabled = false)
+    public function addActionMenuItem($item, $action = null, string $confirmMsg = '', $isEnabled = true)
     {
         $name = $this->name . '_action_' . (count($this->items) + 1);
 
@@ -75,10 +75,10 @@ class ActionMenu extends Table\Column
 
         $item->addClass('{$_' . $name . '_disabled} i_' . $name);
 
-        if ($isDisabled === true) {
+        if ($isEnabled === false) {
             $item->addClass('disabled');
-        } elseif ($isDisabled !== false) {
-            $this->isEnabledFxs[$name] = $isDisabled;
+        } elseif ($isEnabled !== true) {
+            $this->isEnabledFxs[$name] = $isEnabled;
         }
 
         if ($action !== null) {

--- a/src/Table/Column/Checkbox.php
+++ b/src/Table/Column/Checkbox.php
@@ -20,16 +20,6 @@ class Checkbox extends Table\Column
     /** @var string */
     public $class;
 
-    /**
-     * Return action which will calculate and return array of all checkbox IDs, e.g. [3, 5, 20].
-     */
-    public function jsChecked(): JsExpressionable
-    {
-        return (new Jquery($this->table))->find('.checked.' . $this->class)->closest('tr')
-            ->map(new JsFunction([], [new JsExpression('return $(this).data(\'id\')')]))
-            ->get()->join(',');
-    }
-
     #[\Override]
     protected function init(): void
     {
@@ -57,5 +47,15 @@ class Checkbox extends Table\Column
     public function getDataCellTemplate(?Field $field = null): string
     {
         return $this->getApp()->getTag('div', ['class' => 'ui child fitted checkbox ' . $this->class], [['input/', ['type' => 'checkbox']]]);
+    }
+
+    /**
+     * Return action which will calculate and return array of all checkbox IDs, e.g. [3, 5, 20].
+     */
+    public function jsChecked(): JsExpressionable
+    {
+        return (new Jquery($this->table))->find('.checked.' . $this->class)->closest('tr')
+            ->map(new JsFunction([], [new JsExpression('return $(this).data(\'id\')')]))
+            ->get()->join(',');
     }
 }


### PR DESCRIPTION
fix #2212

Thanks @mkrecek234, I agree accepting "isEnabled" fx into "isDisabled" params was highly confusing.

BC break: If you are passing `bool` in your code, the logic is inverted newly! PHPStan cannot detect this!