### PR TITLE
Remove bool defaults support from Form\Control::onChange()

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -444,7 +444,7 @@ class Form extends View
         $errors = [];
         foreach ($this->controls as $k => $control) {
             // save field value only if field was editable in form at all
-            if (!$control->readOnly && !$control->disabled) {
+            if (!$control->disabled && !$control->readOnly) {
                 $postRawValue = $postRawData[$k] ?? null;
                 if ($postRawValue === null) {
                     throw (new Exception('Form POST param does not exist'))

--- a/src/Form/Control.php
+++ b/src/Form/Control.php
@@ -130,14 +130,10 @@ class Control extends View
      * $control->onChange(new JsExpression('$(this).parents(\'.form\').form(\'submit\')'));
      *
      * @param JsExpressionable|JsCallbackSetWithValueClosure|array{JsCallbackSetWithValueClosure} $expr
-     * @param array<int|string, mixed>|bool                                                       $defaults
+     * @param array<int|string, mixed>                                                            $defaults
      */
-    public function onChange($expr, $defaults = []): void
+    public function onChange($expr, array $defaults = []): void
     {
-        if (is_bool($defaults)) {
-            $defaults = $defaults ? [] : ['preventDefault' => false, 'stopPropagation' => false];
-        }
-
         $this->on('change', '#' . $this->name . '_input', $expr, $defaults);
     }
 

--- a/src/Form/Control/Dropdown.php
+++ b/src/Form/Control/Dropdown.php
@@ -204,7 +204,7 @@ class Dropdown extends Input
             $this->template->dangerouslySetHtml('multipleClass', 'multiple');
         }
 
-        if ($this->readOnly || $this->disabled) {
+        if ($this->disabled || $this->readOnly) {
             if ($this->multiple) {
                 $this->jsDropdown(true)->find('a i.delete.icon')->attr('class', 'disabled');
             }

--- a/src/Form/Control/Dropdown.php
+++ b/src/Form/Control/Dropdown.php
@@ -7,9 +7,7 @@ namespace Atk4\Ui\Form\Control;
 use Atk4\Data\Model;
 use Atk4\Ui\HtmlTemplate;
 use Atk4\Ui\Js\Jquery;
-use Atk4\Ui\Js\JsExpression;
 use Atk4\Ui\Js\JsExpressionable;
-use Atk4\Ui\Js\JsFunction;
 use Atk4\Ui\View\ModelTrait;
 
 class Dropdown extends Input
@@ -216,8 +214,6 @@ class Dropdown extends Input
         } elseif ($this->readOnly) {
             $this->template->set('disabledClass', 'read-only');
             $this->template->dangerouslySetHtml('disabled', 'readonly="readonly"');
-
-            $this->setDropdownOption('onShow', new JsFunction([], [new JsExpression('return false')]));
         }
 
         $this->template->set('DefaultText', $this->empty);

--- a/src/Form/Control/Lookup.php
+++ b/src/Form/Control/Lookup.php
@@ -381,7 +381,6 @@ class Lookup extends Input
             $this->template->dangerouslySetHtml('disabled', 'readonly="readonly"');
 
             $this->settings['apiSettings'] = null;
-            $this->settings['onShow'] = new JsFunction([], [new JsExpression('return false')]);
         }
 
         if ($this->dependency) {

--- a/src/Form/Control/Lookup.php
+++ b/src/Form/Control/Lookup.php
@@ -379,7 +379,9 @@ class Lookup extends Input
         } elseif ($this->readOnly) {
             $this->template->set('disabledClass', 'read-only');
             $this->template->dangerouslySetHtml('disabled', 'readonly="readonly"');
+        }
 
+        if ($this->disabled || $this->readOnly) {
             $this->settings['apiSettings'] = null;
         }
 

--- a/src/Form/Control/Radio.php
+++ b/src/Form/Control/Radio.php
@@ -84,14 +84,8 @@ class Radio extends Form\Control
     }
 
     #[\Override]
-    public function onChange($expr, $defaults = []): void
+    public function onChange($expr, array $defaults = []): void
     {
-        if (is_bool($defaults)) {
-            $defaults = $defaults
-                ? []
-                : ['preventDefault' => false, 'stopPropagation' => false];
-        }
-
         $this->on('change', 'input', $expr, $defaults);
     }
 }

--- a/src/Form/Control/Radio.php
+++ b/src/Form/Control/Radio.php
@@ -51,7 +51,9 @@ class Radio extends Form\Control
             $this->model->idField = 'k';
         }
 
-        $value = $this->entityField ? $this->entityField->get() : $this->content;
+        $value = $this->entityField !== null
+            ? $this->entityField->get()
+            : $this->content;
 
         $this->lister->setModel($this->model);
 
@@ -66,11 +68,16 @@ class Radio extends Form\Control
 
             $lister->tRow->set('value', $this->getApp()->uiPersistence->typecastAttributeSaveField($this->entityField->getField(), $lister->currentRow->getId()));
 
-            $lister->tRow->dangerouslySetHtml('checked', $lister->currentRow->compare($lister->model->idField, $value) ? 'checked="checked"' : '');
+            $lister->tRow->dangerouslySetHtml(
+                'checked',
+                $lister->currentRow->compare($lister->model->idField, $value)
+                    ? 'checked="checked"'
+                    : ''
+            );
         });
 
         $this->js(true, null, '.ui.checkbox.radio')->checkbox([
-            'uncheckable' => !$this->entityField || ($this->entityField->getField()->nullable || !$this->entityField->getField()->required),
+            'uncheckable' => $this->entityField === null || ($this->entityField->getField()->nullable || !$this->entityField->getField()->required),
         ]);
 
         parent::renderView();
@@ -80,7 +87,9 @@ class Radio extends Form\Control
     public function onChange($expr, $defaults = []): void
     {
         if (is_bool($defaults)) {
-            $defaults = $defaults ? [] : ['preventDefault' => false, 'stopPropagation' => false];
+            $defaults = $defaults
+                ? []
+                : ['preventDefault' => false, 'stopPropagation' => false];
         }
 
         $this->on('change', 'input', $expr, $defaults);


### PR DESCRIPTION
improve coverage

If someone uses this frequently, let's discuss alternatives and add tests.