### PR TITLE
Strip "ID" suffix from reference form control label

### DIFF
--- a/demos/collection/crud.php
+++ b/demos/collection/crud.php
@@ -68,7 +68,7 @@ $crud->setModel($model);
 // because Crud inherits Grid, you can also define custom actions
 $crud->addModalAction(['icon' => 'cogs'], 'Details', static function (View $p, $id) use ($crud) {
     $model = Country::assertInstanceOf($crud->model);
-    Message::addTo($p, ['Details for: ' . $model->load($id)->name . ' (id: ' . $p->getApp()->uiPersistence->typecastSaveField($crud->model->getIdField(), $id) . ')']);
+    Message::addTo($p, ['Details for: ' . $model->load($id)->name . ' (ID: ' . $p->getApp()->uiPersistence->typecastSaveField($crud->model->getIdField(), $id) . ')']);
 });
 
 $column = $columns->addColumn();

--- a/demos/collection/crud.php
+++ b/demos/collection/crud.php
@@ -86,7 +86,7 @@ $myExecutorClass = AnonymousClassNameCache::get_class(fn () => new class extends
 
         if (File::assertInstanceOf($this->action->getEntity())->is_folder) {
             Grid::addTo($right, ['menu' => false, 'ipp' => 5])
-                ->setModel(File::assertInstanceOf($this->getAction()->getModel())->subFolder);
+                ->setModel(File::assertInstanceOf($this->getAction()->getEntity())->subFolder);
         } else {
             Message::addTo($right, ['Not a folder', 'type' => 'warning']);
         }

--- a/demos/form/form2.php
+++ b/demos/form/form2.php
@@ -96,8 +96,8 @@ $personClass = AnonymousClassNameCache::get_class(fn () => new class extends Mod
         $this->addField('name', ['required' => true]);
         $this->addField('surname', ['ui' => ['placeholder' => 'e.g. Smith']]);
         $this->addField('gender', ['enum' => ['M', 'F']]);
-        $this->hasOne('country_lookup_id', ['model' => [Country::class]]); // this works fast
-        $this->hasOne('country_dropdown_id', ['model' => [Country::class], 'ui' => ['form' => new Form\Control\Dropdown()]]); // this works slow
+        $this->hasOne('country_lookup_id', ['model' => [Country::class]]); // this renders faster
+        $this->hasOne('country_dropdown_id', ['model' => [Country::class], 'ui' => ['form' => new Form\Control\Dropdown()]]); // this renders slower
     }
 
     #[\Override]

--- a/demos/init-db.php
+++ b/demos/init-db.php
@@ -196,7 +196,7 @@ trait ModelPreventModificationTrait
 }
 
 /**
- * Improve testing by using prefixed real field and SQL names.
+ * Improve testing by using non-scalar ID and prefixed field/SQL names.
  *
  * @property WrappedId $id @Atk4\Field()
  *

--- a/demos/init-db.php
+++ b/demos/init-db.php
@@ -198,6 +198,9 @@ trait ModelPreventModificationTrait
 /**
  * Improve testing by using prefixed real field and SQL names.
  *
+ * @property WrappedId $id @Atk4\Field()
+ *
+ * @method WrappedId|null                  getId()
  * @method static|null                     tryLoad(WrappedId $id = null)
  * @method static                          load(WrappedId $id)
  * @method \Traversable<WrappedId, static> getIterator()

--- a/demos/init-db.php
+++ b/demos/init-db.php
@@ -248,8 +248,8 @@ class ModelWithPrefixedFields extends Model
             return $name;
         }
 
-        if (isset(self::$prefixedFieldNames[$name . '_id'])) {
-            return self::$prefixedFieldNames[$name . '_id'];
+        if (str_ends_with(self::$prefixedFieldNames[$name . '_id'] ?? '', '_id')) {
+            return substr(self::$prefixedFieldNames[$name . '_id'], 0, -3);
         }
 
         return self::$prefixedFieldNames[$name];

--- a/demos/init-db.php
+++ b/demos/init-db.php
@@ -441,6 +441,10 @@ class Stat extends ModelWithPrefixedFields
         $this->onHook(Model::HOOK_AFTER_LOAD, static function (self $entity) {
             $map = ['EUR' => '€', 'USD' => '$', 'GBP' => '£'];
             $entity->currency_symbol = $map[$entity->currency] ?? '?';
+
+            // fix too dirty field for user action
+            $dirtyRef = &$entity->getDirtyRef();
+            unset($dirtyRef[$entity->fieldName()->currency_symbol]);
         });
 
         $this->addField($this->fieldName()->project_budget, ['type' => 'atk4_money']);

--- a/demos/tutorial/actions.php
+++ b/demos/tutorial/actions.php
@@ -165,7 +165,7 @@ $wizard->addStep('Crud integration', static function (Wizard $page) {
         $country = new Country($owner->getApp()->db);
         $country->getUserAction('add')->enabled = false;
         $country->getUserAction('delete')->enabled = static function (Country $entity) {
-            return $entity->id % 2 === 0;
+            return $entity->id->getId() % 2 === 0;
         };
         $country->addUserAction('mail', [
             'appliesTo' => Model\UserAction::APPLIES_TO_SINGLE_RECORD,

--- a/src/Form.php
+++ b/src/Form.php
@@ -383,7 +383,7 @@ class Form extends View
         if ($field->type === 'json' && $field->hasReference()) {
             $limit = ($field->getReference() instanceof ContainsMany) ? 0 : 1;
             $model = $field->getReference()->createTheirModel();
-            $fallbackSeed = [Control\Multiline::class, 'model' => $model, 'rowLimit' => $limit, 'caption' => $model->getModelCaption()];
+            $fallbackSeed = [Control\Multiline::class, 'model' => $model, 'rowLimit' => $limit];
         } elseif ($field->type !== 'boolean') {
             if ($field->enum !== null) {
                 $fallbackSeed = [Control\Dropdown::class, 'values' => array_combine($field->enum, $field->enum)];

--- a/src/Form/Layout.php
+++ b/src/Form/Layout.php
@@ -173,7 +173,7 @@ class Layout extends AbstractLayout
             if ($label === null) {
                 $label = $element->entityField->getField()->getCaption();
                 if (property_exists($element, 'model')) {
-                    $label = preg_replace('~^(?:.*\K ID$|ID )~s', '', $label);
+                    $label = preg_replace('~ ID$~i', '', $label);
                 }
             }
 

--- a/src/Form/Layout.php
+++ b/src/Form/Layout.php
@@ -6,6 +6,7 @@ namespace Atk4\Ui\Form;
 
 use Atk4\Core\Factory;
 use Atk4\Data\Field;
+use Atk4\Data\Reference\HasOneSql;
 use Atk4\Ui\Button;
 use Atk4\Ui\Header;
 use Atk4\Ui\HtmlTemplate;
@@ -121,6 +122,23 @@ class Layout extends AbstractLayout
         return $v;
     }
 
+    private function getEntityFieldCaptionWithoutReferenceSuffix(Control $control): string
+    {
+        $field = $control->entityField->getField();
+        $caption = $field->getCaption();
+
+        if ($field->hasReference()) {
+            $ref = $field->getReference();
+            if ($ref instanceof HasOneSql) {
+                $analysingTheirModel = $ref->createAnalysingTheirModel();
+
+                return \Closure::bind(static fn () => $ref->getOurFieldCaptionWithoutReferenceSuffix($analysingTheirModel), null, HasOneSql::class)();
+            }
+        }
+
+        return preg_replace('~ ID$~i', '', $caption);
+    }
+
     #[\Override]
     protected function recursiveRender(): void
     {
@@ -171,10 +189,9 @@ class Layout extends AbstractLayout
             $template = $element->renderLabel ? $labeledControl : $noLabelControl;
             $label = $element->caption;
             if ($label === null) {
-                $label = $element->entityField->getField()->getCaption();
-                if (property_exists($element, 'model')) {
-                    $label = preg_replace('~ ID$~i', '', $label);
-                }
+                $label = property_exists($element, 'model')
+                    ? $this->getEntityFieldCaptionWithoutReferenceSuffix($element)
+                    : $element->entityField->getField()->getCaption();
             }
 
             // anything but form controls gets inserted directly

--- a/src/Form/Layout.php
+++ b/src/Form/Layout.php
@@ -169,7 +169,13 @@ class Layout extends AbstractLayout
             }
 
             $template = $element->renderLabel ? $labeledControl : $noLabelControl;
-            $label = $element->caption ?? $element->entityField->getField()->getCaption();
+            $label = $element->caption;
+            if ($label === null) {
+                $label = $element->entityField->getField()->getCaption();
+                if (property_exists($element, 'model')) {
+                    $label = preg_replace('~^ID | ID$~', '', $label);
+                }
+            }
 
             // anything but form controls gets inserted directly
             if ($element instanceof Control\Checkbox) {

--- a/src/Form/Layout.php
+++ b/src/Form/Layout.php
@@ -6,7 +6,6 @@ namespace Atk4\Ui\Form;
 
 use Atk4\Core\Factory;
 use Atk4\Data\Field;
-use Atk4\Data\Reference\HasOneSql;
 use Atk4\Ui\Button;
 use Atk4\Ui\Header;
 use Atk4\Ui\HtmlTemplate;
@@ -122,21 +121,11 @@ class Layout extends AbstractLayout
         return $v;
     }
 
-    private function getEntityFieldCaptionWithoutReferenceSuffix(Control $control): string
+    private function getEntityFieldCaptionWithoutIdSuffix(Control $control): string
     {
         $field = $control->entityField->getField();
-        $caption = $field->getCaption();
 
-        if ($field->hasReference()) {
-            $ref = $field->getReference();
-            if ($ref instanceof HasOneSql) {
-                $analysingTheirModel = $ref->createAnalysingTheirModel();
-
-                return \Closure::bind(static fn () => $ref->getOurFieldCaptionWithoutReferenceSuffix($analysingTheirModel), null, HasOneSql::class)();
-            }
-        }
-
-        return preg_replace('~ ID$~i', '', $caption);
+        return preg_replace('~ (' . preg_quote($field->getOwner()->getIdField()->getCaption(), '~') . '|ID)$~i', '', $field->getCaption());
     }
 
     #[\Override]
@@ -190,7 +179,7 @@ class Layout extends AbstractLayout
             $label = $element->caption;
             if ($label === null) {
                 $label = property_exists($element, 'model')
-                    ? $this->getEntityFieldCaptionWithoutReferenceSuffix($element)
+                    ? $this->getEntityFieldCaptionWithoutIdSuffix($element)
                     : $element->entityField->getField()->getCaption();
             }
 

--- a/src/Form/Layout.php
+++ b/src/Form/Layout.php
@@ -121,13 +121,6 @@ class Layout extends AbstractLayout
         return $v;
     }
 
-    private function getEntityFieldCaptionWithoutIdSuffix(Control $control): string
-    {
-        $field = $control->entityField->getField();
-
-        return preg_replace('~ ID$~i', '', $field->getCaption());
-    }
-
     #[\Override]
     protected function recursiveRender(): void
     {
@@ -178,9 +171,10 @@ class Layout extends AbstractLayout
             $template = $element->renderLabel ? $labeledControl : $noLabelControl;
             $label = $element->caption;
             if ($label === null) {
-                $label = property_exists($element, 'model')
-                    ? $this->getEntityFieldCaptionWithoutIdSuffix($element)
-                    : $element->entityField->getField()->getCaption();
+                $label = $element->entityField->getField()->getCaption();
+                if (property_exists($element, 'model')) {
+                    $label = preg_replace('~ ID$~i', '', $label);
+                }
             }
 
             // anything but form controls gets inserted directly

--- a/src/Form/Layout.php
+++ b/src/Form/Layout.php
@@ -125,7 +125,12 @@ class Layout extends AbstractLayout
     {
         $field = $control->entityField->getField();
 
-        return preg_replace('~ (' . preg_quote($field->getOwner()->getIdField()->getCaption(), '~') . '|ID)$~i', '', $field->getCaption());
+        $idSuffixes = ['ID'];
+        if ($field->getOwner()->idField && $field->getOwner()->hasField($field->getOwner()->idField)) {
+            $idSuffixes = $field->getOwner()->getIdField()->getCaption();
+        }
+
+        return preg_replace('~ (' . implode('|', array_map(fn ($v) => preg_quote($v, '~'), $idSuffixes)) . ')$~i', '', $field->getCaption());
     }
 
     #[\Override]

--- a/src/Form/Layout.php
+++ b/src/Form/Layout.php
@@ -173,7 +173,7 @@ class Layout extends AbstractLayout
             if ($label === null) {
                 $label = $element->entityField->getField()->getCaption();
                 if (property_exists($element, 'model')) {
-                    $label = preg_replace('~^ID | ID$~', '', $label);
+                    $label = preg_replace('~^(?:.*\K ID$|ID )~s', '', $label);
                 }
             }
 

--- a/src/Form/Layout.php
+++ b/src/Form/Layout.php
@@ -125,12 +125,7 @@ class Layout extends AbstractLayout
     {
         $field = $control->entityField->getField();
 
-        $idSuffixes = ['ID'];
-        if ($field->getOwner()->idField && $field->getOwner()->hasField($field->getOwner()->idField)) {
-            $idSuffixes = $field->getOwner()->getIdField()->getCaption();
-        }
-
-        return preg_replace('~ (' . implode('|', array_map(fn ($v) => preg_quote($v, '~'), $idSuffixes)) . ')$~i', '', $field->getCaption());
+        return preg_replace('~ ID$~i', '', $field->getCaption());
     }
 
     #[\Override]

--- a/src/Table/Column/KeyValue.php
+++ b/src/Table/Column/KeyValue.php
@@ -33,7 +33,7 @@ use Atk4\Ui\Table;
  *    ],
  *    'ui' => [
  *        'form' => [Form\Control\Dropdown::class],
- *        'table' => ['KeyValue'],
+ *        'table' => [Table\Column\KeyValue::class],
  *    ],
  * ]);
  */

--- a/tests-behat/dropdown.feature
+++ b/tests-behat/dropdown.feature
@@ -13,7 +13,7 @@ Feature: Dropdown
     Then I should not see "Soda"
     Then I should not see "Cola"
     Then I should not see "No results found."
-    When I click using selector "//div.field[label[text()='Product ID']]//div.ui.dropdown"
+    When I click using selector "//div.field[label[text()='Product']]//div.ui.dropdown"
     Then I should see "No results found."
 
   Scenario: dropdown multiple


### PR DESCRIPTION
close #1759

related with https://github.com/atk4/data/pull/1239 - this improves https://github.com/atk4/ui/blob/5.2.0/src/Table/Column.php#L361 and https://github.com/atk4/ui/blob/5.2.0/src/CardTable.php#L44