### PR TITLE
Upgrade behat/mink-extension dev package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,9 +68,9 @@
     },
     "require-dev": {
         "atk4/behat-mink-selenium2-driver": "^1.6.2",
-        "behat/mink-extension": "^2.3.1",
         "ergebnis/composer-normalize": "^2.13",
         "ergebnis/phpunit-slow-test-detector": "^2.9",
+        "friends-of-behat/mink-extension": "^2.3.1",
         "friendsofphp/php-cs-fixer": "^3.0",
         "fzaninotto/faker": "^1.6",
         "guzzlehttp/guzzle": "^7.3",

--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,6 @@
     },
     "conflict": {
         "behat/behat": "<3.9",
-        "behat/gherkin": ">=4.13.0",
         "behat/mink": "<1.9",
         "guzzlehttp/psr7": "<2.4",
         "symfony/console": "<4.4.30 || >=5 <5.3.7",


### PR DESCRIPTION
The behat/mink-extension dev dependency was formally abandoned in 2020 (but the final 2.3.1 release was in Feb 2018). That package requires `symfony/config: ^2.7|^3.0|^4.0`. That was forcing symfony/config to 4.4.4 (which is also no longer supported) and therefore blocking several other packages including some that are unsupported or on security-only support.

The `friends-of-behat/mink-extension` fork is a drop-in replacement with updated dependency constraints, which will allow composer to install the newer versions.

On PHP 8.3 this results in:

  - Removing symfony/polyfill-php73 (v1.32.0)
  - Removing behat/transliterator (v1.5.0)
  - Removing behat/mink-extension (2.3.1)
  - Upgrading symfony/yaml (v6.4.21 => v7.2.6)
  - Upgrading psr/log (2.0.0 => 3.0.2)
  - Upgrading symfony/filesystem (v5.4.45 => v6.4.13)
  - Upgrading symfony/config (v4.4.44 => v7.0.8)
  - Upgrading symfony/translation-contracts (v2.5.4 => v3.5.1)
  - Upgrading symfony/translation (v4.4.47 => v7.2.6)
  - Upgrading symfony/event-dispatcher (v5.4.45 => v7.2.0)
  - Installing symfony/var-exporter (v7.2.6)
  - Upgrading psr/container (1.1.2 => 2.0.2)
  - Upgrading symfony/service-contracts (v2.5.4 => v3.5.1)
  - Upgrading symfony/dependency-injection (v4.4.49 => v7.2.6)
  - Upgrading symfony/string (v6.4.21 => v7.2.6)
  - Upgrading symfony/console (v5.4.47 => v7.2.6)
  - Upgrading behat/behat (v3.15.0 => v3.22.0)
  - Installing friends-of-behat/mink-extension (v2.7.5)