### PR TITLE
Allow disabling dropdown clearable

### DIFF
--- a/src/Form/Control/Dropdown.php
+++ b/src/Form/Control/Dropdown.php
@@ -159,10 +159,12 @@ class Dropdown extends Input
     protected function jsRenderDropdown(): JsExpressionable
     {
         $dropdownOptions = $this->dropdownOptions;
-        if ($this->entityField === null || ($this->entityField->getField()->nullable || !$this->entityField->getField()->required)) {
-            $dropdownOptions['clearable'] = true;
-        }
 
+        if (!array_key_exists('clearable', $dropdownOptions)) {
+            if ($this->entityField === null || ($this->entityField->getField()->nullable || !$this->entityField->getField()->required)) {
+                $dropdownOptions['clearable'] = true;
+            }
+        }
         return $this->jsDropdown(true)->dropdown($dropdownOptions);
     }
 

--- a/src/Form/Control/Dropdown.php
+++ b/src/Form/Control/Dropdown.php
@@ -165,6 +165,7 @@ class Dropdown extends Input
                 $dropdownOptions['clearable'] = true;
             }
         }
+
         return $this->jsDropdown(true)->dropdown($dropdownOptions);
     }
 

--- a/src/Form/Control/Dropdown.php
+++ b/src/Form/Control/Dropdown.php
@@ -160,7 +160,7 @@ class Dropdown extends Input
     {
         $dropdownOptions = $this->dropdownOptions;
 
-        if (!isset($dropdownOptions['clearable']) && ($this->entityField === null || ($this->entityField->getField()->nullable || !$this->entityField->getField()->required))) {
+        if (!isset($dropdownOptions['clearable']) && ($this->entityField === null || $this->entityField->getField()->nullable || !$this->entityField->getField()->required)) {
             $dropdownOptions['clearable'] = true;
         }
 

--- a/src/Form/Control/Dropdown.php
+++ b/src/Form/Control/Dropdown.php
@@ -160,10 +160,8 @@ class Dropdown extends Input
     {
         $dropdownOptions = $this->dropdownOptions;
 
-        if (!array_key_exists('clearable', $dropdownOptions)) {
-            if ($this->entityField === null || ($this->entityField->getField()->nullable || !$this->entityField->getField()->required)) {
-                $dropdownOptions['clearable'] = true;
-            }
+        if (!isset($dropdownOptions['clearable']) && $this->entityField === null || ($this->entityField->getField()->nullable || !$this->entityField->getField()->required)) {
+            $dropdownOptions['clearable'] = true;
         }
 
         return $this->jsDropdown(true)->dropdown($dropdownOptions);

--- a/src/Form/Control/Dropdown.php
+++ b/src/Form/Control/Dropdown.php
@@ -160,7 +160,7 @@ class Dropdown extends Input
     {
         $dropdownOptions = $this->dropdownOptions;
 
-        if (!isset($dropdownOptions['clearable']) && $this->entityField === null || ($this->entityField->getField()->nullable || !$this->entityField->getField()->required)) {
+        if (!isset($dropdownOptions['clearable']) && ($this->entityField === null || ($this->entityField->getField()->nullable || !$this->entityField->getField()->required))) {
             $dropdownOptions['clearable'] = true;
         }
 


### PR DESCRIPTION
I added a small if to check if the "clearable" option is set, if it is then override the default model-based behaviour for dropdowns.

The current implementation requires you to actually use a model to populate the dropdown otherwise clearable is always set. In cases where you aren't using any models at all for DB/data related handling this will make it possible to delete the value which might not be the expected result. 

This PR will make the the Dropdown honour setDropdownOption('clearable', false).