### PR TITLE
Fix Behat Firefox CI

### DIFF
--- a/src/HtmlTemplate/Value.php
+++ b/src/HtmlTemplate/Value.php
@@ -26,7 +26,7 @@ class Value
     public function set(string $value): self
     {
         if (\PHP_VERSION_ID < 8_02_00
-                ? preg_match('~~u', $value) === false // much faster in PHP 8.1 and lower
+                ? preg_match('~~u', $value) === false // much faster in PHP 8.1 or lower
                 : !mb_check_encoding($value, 'UTF-8')
         ) {
             throw new Exception('Value is not valid UTF-8');

--- a/tests-behat/dropdown.feature
+++ b/tests-behat/dropdown.feature
@@ -86,13 +86,13 @@ Feature: Dropdown
     Given I am on "basic/menu.php"
     When I click using selector "//div.ui.dropdown[div[text()='With Callback']]"
     # https://github.com/fomantic/Fomantic-UI/blob/2.9.4/src/definitions/modules/dropdown.js#L3804
-    When I wait "150" ms
+    When I wait "100" ms
     When I click using selector "//div.ui.dropdown[div[text()='With Callback']]//div.item[text()='c']"
     Then Toast display should contain text "New selected item: c"
 
   Scenario: dropdown menu from model
     When I click using selector "//div.ui.dropdown[div[text()='From Model']]"
     # https://github.com/fomantic/Fomantic-UI/blob/2.9.4/src/definitions/modules/dropdown.js#L3804
-    When I wait "150" ms
+    When I wait "100" ms
     When I click using selector "//div.ui.dropdown[div[text()='From Model']]//div.item[text()='Beverages']"
     Then Toast display should contain text "New selected item: Beverages"

--- a/tests-behat/dropdown.feature
+++ b/tests-behat/dropdown.feature
@@ -85,10 +85,14 @@ Feature: Dropdown
   Scenario: dropdown menu
     Given I am on "basic/menu.php"
     When I click using selector "//div.ui.dropdown[div[text()='With Callback']]"
+    # click twice, fix Firefox CI since 2025-09-01 (v142.0.1)
+    When I click using selector "//div.ui.dropdown[div[text()='With Callback']]"
     When I click using selector "//div.ui.dropdown[div[text()='With Callback']]//div.item[text()='c']"
     Then Toast display should contain text "New selected item: c"
 
   Scenario: dropdown menu from model
+    When I click using selector "//div.ui.dropdown[div[text()='From Model']]"
+    # click twice, fix Firefox CI since 2025-09-01 (v142.0.1)
     When I click using selector "//div.ui.dropdown[div[text()='From Model']]"
     When I click using selector "//div.ui.dropdown[div[text()='From Model']]//div.item[text()='Beverages']"
     Then Toast display should contain text "New selected item: Beverages"

--- a/tests-behat/dropdown.feature
+++ b/tests-behat/dropdown.feature
@@ -85,14 +85,10 @@ Feature: Dropdown
   Scenario: dropdown menu
     Given I am on "basic/menu.php"
     When I click using selector "//div.ui.dropdown[div[text()='With Callback']]"
-    # click twice, fix Firefox CI since 2025-09-01 (v142.0.1)
-    When I click using selector "//div.ui.dropdown[div[text()='With Callback']]"
     When I click using selector "//div.ui.dropdown[div[text()='With Callback']]//div.item[text()='c']"
     Then Toast display should contain text "New selected item: c"
 
   Scenario: dropdown menu from model
-    When I click using selector "//div.ui.dropdown[div[text()='From Model']]"
-    # click twice, fix Firefox CI since 2025-09-01 (v142.0.1)
     When I click using selector "//div.ui.dropdown[div[text()='From Model']]"
     When I click using selector "//div.ui.dropdown[div[text()='From Model']]//div.item[text()='Beverages']"
     Then Toast display should contain text "New selected item: Beverages"

--- a/tests-behat/dropdown.feature
+++ b/tests-behat/dropdown.feature
@@ -85,10 +85,14 @@ Feature: Dropdown
   Scenario: dropdown menu
     Given I am on "basic/menu.php"
     When I click using selector "//div.ui.dropdown[div[text()='With Callback']]"
+    # https://github.com/fomantic/Fomantic-UI/blob/2.9.4/src/definitions/modules/dropdown.js#L3804
+    When I wait "150" ms
     When I click using selector "//div.ui.dropdown[div[text()='With Callback']]//div.item[text()='c']"
     Then Toast display should contain text "New selected item: c"
 
   Scenario: dropdown menu from model
     When I click using selector "//div.ui.dropdown[div[text()='From Model']]"
+    # https://github.com/fomantic/Fomantic-UI/blob/2.9.4/src/definitions/modules/dropdown.js#L3804
+    When I wait "150" ms
     When I click using selector "//div.ui.dropdown[div[text()='From Model']]//div.item[text()='Beverages']"
     Then Toast display should contain text "New selected item: Beverages"


### PR DESCRIPTION
CI log:

```
  Scenario: dropdown menu                                                                              # tests-behat/dropdown.feature:85
    Given I am on "basic/menu.php"                                                                     # Behat\MinkExtension\Context\MinkContext::visit()
    When I click using selector "//div.ui.dropdown[div[text()='With Callback']]"                       # Atk4\Ui\Behat\Context::iClickUsingSelector()
    When I click using selector "//div.ui.dropdown[div[text()='With Callback']]//div.item[text()='c']" # Atk4\Ui\Behat\Context::iClickUsingSelector()
      WebDriver\Exception\MoveTargetOutOfBounds: Origin element [object Object] {"element-6066-11e4-a52e-4f735466cecf":"f391ed3c-f912-4a17-8d69-1243e05a58bb"} is not displayed
      Build info: version: '3.141.59', revision: 'e82be7d358', time: '2018-11-14T08:25:53'
      System info: host: 'bbcfaf4f68a3', ip: '172.18.0.2', os.name: 'Linux', os.arch: 'amd64', os.version: '6.11.0-1018-azure', java.version: '17.0.16'
      Driver info: driver.version: unknown in vendor/instaclick/php-webdriver/lib/WebDriver/Exception.php:198
      Stack trace:
      #0 vendor/instaclick/php-webdriver/lib/WebDriver/AbstractWebDriver.php(168): WebDriver\Exception::factory()
      #1 vendor/instaclick/php-webdriver/lib/WebDriver/Session.php(306): WebDriver\AbstractWebDriver->curl()
      #2 src/Behat/MinkSeleniumDriver.php(58): WebDriver\Session->moveto()
      #3 vendor/atk4/behat-mink-selenium2-driver/src/Selenium2Driver.php(916): Atk4\Ui\Behat\MinkSeleniumDriver->mouseOverElement()
      #4 vendor/atk4/behat-mink-selenium2-driver/src/Selenium2Driver.php(911): Behat\Mink\Driver\Selenium2Driver->clickOnElement()
      #5 vendor/behat/mink/src/Element/NodeElement.php(176): Behat\Mink\Driver\Selenium2Driver->click()
      #6 src/Behat/Context.php(391): Behat\Mink\Element\NodeElement->click()
```

since 2025-09-01 (Alpine Firefox v142.0.1) the CI was always failing