### PR TITLE
Fixes to IPP in Grid.php and Grid-demo.

### DIFF
--- a/demos/collection/grid.php
+++ b/demos/collection/grid.php
@@ -105,4 +105,4 @@ $grid->addModalBulkAction(['Delete selected', 'icon' => 'trash'], '', static fun
 });
 
 // setting ipp with an array will add an ItemPerPageSelector to paginator
-$grid->setIpp([10, 100, 1000]);
+$grid->setIpp([10, 50, 100, 1000]);

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -214,13 +214,18 @@ class Grid extends View
      *
      * @return $this
      */
-    public function addItemsPerPageSelector(array $items = [10, 100, 1000], $label = 'Items per page:')
+    public function addItemsPerPageSelector(array $items = [10, 50, 100, 1000], $label = 'Items per page:')
     {
         $ipp = (int) $this->container->stickyGet('ipp');
-        if ($ipp) {
+
+        /*
+         * If $ipp is 0 don't set $this->ipp to the first item as that always sets the viewed selection
+         * to the first item in the list. If we actually track the ipp in the app we want it to set and
+         * show the correct value, as it was before reload or other events, before this change it only set the selected ipp value but showed the first item.
+         * Default ipp in this class is 50, that will be showed when nothing is selected.
+         */
+        if ($ipp > 0) {
             $this->ipp = $ipp;
-        } else {
-            $this->ipp = $items[0];
         }
 
         $pageLength = ItemsPerPageSelector::addTo($this->paginator, ['pageLengthItems' => $items, 'label' => $label, 'currentIpp' => $this->ipp], ['afterPaginator']);

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -48,7 +48,7 @@ class Grid extends View
     public $paginator;
 
     /** @var int Number of items per page to display. */
-    public $ipp = 50;
+    public $ipp = 10;
 
     /**
      * Calling addActionButton will add a new column inside $table, and will be re-used


### PR DESCRIPTION
Added 50 to items list both in the Grid-demo as well as in Grid. 
Fixed so Grid ipp will show selected value if set, otherwise fallback to 50 as it is default.

If $ipp is 0 don't set $this->ipp to the first item as that always sets the viewed selection
to the first item in the list. If we actually track the ipp in the app we want it to set and
show the correct value, as it was before reload or other events, before this change it only set the selected ipp value but showed the first item.
Default ipp in this class is 50, that will be showed when nothing is selected.

If we want to have 10 as default, $ipp should be set to 10 instead of 50.